### PR TITLE
Allow project Resource Path Variables to be used in PythonPath string substitutions

### DIFF
--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
@@ -6,6 +6,7 @@
  */
 package org.python.pydev.core.docutils;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -13,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 
+import org.eclipse.core.resources.IPathVariableManager;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
@@ -33,7 +35,22 @@ public class StringSubstitution {
         if (nature != null) {
             try {
                 IPythonPathNature pythonPathNature = nature.getPythonPathNature();
+                IPathVariableManager projectPathVarManager = nature.getProject().getPathVariableManager();
                 variableSubstitution = pythonPathNature.getVariableSubstitution();
+                String[] pathVarNames = projectPathVarManager.getPathVariableNames();
+                URI uri = null;
+                String var = null;
+                String path = null;
+                for (int i = 0; i < pathVarNames.length; i++) {
+                    var = pathVarNames[i];
+                    uri = projectPathVarManager.getURIValue(var);
+                    if (uri != null && uri.getScheme().equalsIgnoreCase("file")) {
+                        path = uri.getPath();
+                        if (path != null && !variableSubstitution.containsKey(var)) {
+                            variableSubstitution.put(var, path);
+                        }
+                    }
+                }
             } catch (Exception e) {
                 Log.log(e);
             }

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
@@ -7,6 +7,7 @@
 package org.python.pydev.core.docutils;
 
 import java.io.File;
+import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,9 +15,32 @@ import java.util.Set;
 
 import junit.framework.TestCase;
 
+import org.eclipse.core.resources.FileInfoMatcherDescription;
+import org.eclipse.core.resources.IBuildConfiguration;
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IFolder;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IPathVariableChangeListener;
+import org.eclipse.core.resources.IPathVariableManager;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IProjectDescription;
+import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.resources.IResourceFilterDescription;
+import org.eclipse.core.resources.IResourceProxy;
+import org.eclipse.core.resources.IResourceProxyVisitor;
+import org.eclipse.core.resources.IResourceVisitor;
+import org.eclipse.core.resources.IWorkspace;
+import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
+import org.eclipse.core.runtime.IPluginDescriptor;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.eclipse.core.runtime.QualifiedName;
+import org.eclipse.core.runtime.content.IContentTypeMatcher;
+import org.eclipse.core.runtime.jobs.ISchedulingRule;
 import org.python.pydev.core.ICodeCompletionASTManager;
 import org.python.pydev.core.IInterpreterInfo;
 import org.python.pydev.core.IInterpreterManager;
@@ -31,21 +55,30 @@ public class StringSubstitutionTest extends TestCase {
 
     public void testStringSubstitution() throws Exception {
         final Map<String, String> variableSubstitution = new HashMap<String, String>();
+        final Map<String, String> pathSubstitution = new HashMap<String, String>();
         variableSubstitution.put("AA", "XX");
-        assertEquals("aaXXbb",
-                createStringSubstitution(variableSubstitution).performPythonpathStringSubstitution("aa${AA}bb"));
+        assertEquals("aaXXbb${BB}",
+                createStringSubstitution(variableSubstitution, pathSubstitution).performPythonpathStringSubstitution("aa${AA}bb${BB}"));
+
+        pathSubstitution.put("BB", "/ZZ");
+        assertEquals("aaXXbb/ZZ",
+                createStringSubstitution(variableSubstitution, pathSubstitution).performPythonpathStringSubstitution("aa${AA}bb${BB}"));
+
+        variableSubstitution.put("BB", "WW");
+        assertEquals("aaWWbb",
+                createStringSubstitution(variableSubstitution, pathSubstitution).performPythonpathStringSubstitution("aa${BB}bb"));
 
         variableSubstitution.put("AA", "${XX}");
         variableSubstitution.put("XX", "YY");
         assertEquals("aaYYbb",
-                createStringSubstitution(variableSubstitution).performPythonpathStringSubstitution("aa${AA}bb"));
+                createStringSubstitution(variableSubstitution, pathSubstitution).performPythonpathStringSubstitution("aa${AA}bb"));
 
-        assertEquals("aa${unknown}bb", createStringSubstitution(variableSubstitution)
+        assertEquals("aa${unknown}bb", createStringSubstitution(variableSubstitution, pathSubstitution)
                 .performPythonpathStringSubstitution("aa${unknown}bb"));
     }
 
     //Just creating stub...
-    private StringSubstitution createStringSubstitution(final Map<String, String> variableSubstitution) {
+    private StringSubstitution createStringSubstitution(final Map<String, String> variableSubstitution, final Map<String, String> pathSubstitution) {
         StringSubstitution s = new StringSubstitution(new IPythonNature() {
 
             public void endRequests() {
@@ -228,7 +261,598 @@ public class StringSubstitutionTest extends TestCase {
             }
 
             public IProject getProject() {
-                throw new RuntimeException("Not implemented");
+                return new IProject () {
+
+                    public boolean exists(IPath path) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource findMember(String path) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource findMember(String path, boolean includePhantoms) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource findMember(IPath path) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource findMember(IPath path, boolean includePhantoms) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public String getDefaultCharset() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public String getDefaultCharset(boolean checkImplicit) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IFile getFile(IPath path) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IFolder getFolder(IPath path) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource[] members() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource[] members(boolean includePhantoms) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResource[] members(int memberFlags) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IFile[] findDeletedMembersWithHistory(int depth, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDefaultCharset(String charset) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDefaultCharset(String charset, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResourceFilterDescription createFilter(int type,
+                            FileInfoMatcherDescription matcherDescription, int updateFlags, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResourceFilterDescription[] getFilters() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void accept(IResourceProxyVisitor visitor, int memberFlags) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void accept(IResourceProxyVisitor visitor, int depth, int memberFlags) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void accept(IResourceVisitor visitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void accept(IResourceVisitor visitor, int depth, boolean includePhantoms)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void accept(IResourceVisitor visitor, int depth, int memberFlags) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void clearHistory(IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void copy(IPath destination, boolean force, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void copy(IPath destination, int updateFlags, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void copy(IProjectDescription description, boolean force, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void copy(IProjectDescription description, int updateFlags, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IMarker createMarker(String type) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IResourceProxy createProxy() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void delete(boolean force, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void delete(int updateFlags, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void deleteMarkers(String type, boolean includeSubtypes, int depth) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean exists() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IMarker findMarker(long id) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IMarker[] findMarkers(String type, boolean includeSubtypes, int depth) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public int findMaxProblemSeverity(String type, boolean includeSubtypes, int depth)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public String getFileExtension() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getFullPath() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public long getLocalTimeStamp() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getLocation() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public URI getLocationURI() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IMarker getMarker(long id) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public long getModificationStamp() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public String getName() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPathVariableManager getPathVariableManager() {
+                        return new IPathVariableManager() {
+
+                            public URI convertToRelative(URI path, boolean force, String variableHint)
+                                    throws CoreException {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public void setValue(String name, IPath value) throws CoreException {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public void setURIValue(String name, URI value) throws CoreException {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public IPath getValue(String name) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public URI getURIValue(String name) {
+                                try {
+                                    return new URI("file://".concat(pathSubstitution.get(name)));
+                                } catch (Exception e) {
+                                    ;
+                                }
+                                return null;
+                            }
+
+                            public String[] getPathVariableNames() {
+                                return pathSubstitution.keySet().toArray(new String[]{});
+                            }
+
+                            public void addChangeListener(IPathVariableChangeListener listener) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public void removeChangeListener(IPathVariableChangeListener listener) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public URI resolveURI(URI uri) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public IPath resolvePath(IPath path) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public boolean isDefined(String name) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public boolean isUserDefined(String name) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public IStatus validateName(String name) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public IStatus validateValue(IPath path) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public IStatus validateValue(URI path) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public URI getVariableRelativePathLocation(URI location) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public String convertToUserEditableFormat(String value, boolean locationFormat) {
+                                throw new RuntimeException("Not implemented");
+                            }
+
+                            public String convertFromUserEditableFormat(String value, boolean locationFormat) {
+                                throw new RuntimeException("Not implemented");
+                            }
+                        };
+                    }
+
+                    public IContainer getParent() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public Map<QualifiedName, String> getPersistentProperties() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public String getPersistentProperty(QualifiedName key) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IProject getProject() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getProjectRelativePath() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getRawLocation() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public URI getRawLocationURI() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public ResourceAttributes getResourceAttributes() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public Map<QualifiedName, Object> getSessionProperties() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public Object getSessionProperty(QualifiedName key) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public int getType() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IWorkspace getWorkspace() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isAccessible() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isDerived() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isDerived(int options) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isHidden() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isHidden(int options) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isLinked() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isVirtual() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isLinked(int options) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isLocal(int depth) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isPhantom() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isReadOnly() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isSynchronized(int depth) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isTeamPrivateMember() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isTeamPrivateMember(int options) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void move(IPath destination, boolean force, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void move(IPath destination, int updateFlags, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void move(IProjectDescription description, boolean force, boolean keepHistory,
+                            IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void move(IProjectDescription description, int updateFlags, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void refreshLocal(int depth, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void revertModificationStamp(long value) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDerived(boolean isDerived) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDerived(boolean isDerived, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setHidden(boolean isHidden) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setLocal(boolean flag, int depth, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public long setLocalTimeStamp(long value) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setPersistentProperty(QualifiedName key, String value) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setReadOnly(boolean readOnly) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setResourceAttributes(ResourceAttributes attributes) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setSessionProperty(QualifiedName key, Object value) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setTeamPrivateMember(boolean isTeamPrivate) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void touch(IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public Object getAdapter(Class adapter) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean contains(ISchedulingRule rule) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isConflicting(ISchedulingRule rule) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void build(int kind, String builderName, Map<String, String> args, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void build(int kind, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void build(IBuildConfiguration config, int kind, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void close(IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void create(IProjectDescription description, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void create(IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void create(IProjectDescription description, int updateFlags, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void delete(boolean deleteContent, boolean force, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IBuildConfiguration getActiveBuildConfig() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IBuildConfiguration getBuildConfig(String configName) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IBuildConfiguration[] getBuildConfigs() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IContentTypeMatcher getContentTypeMatcher() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IProjectDescription getDescription() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IFile getFile(String name) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IFolder getFolder(String name) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IProjectNature getNature(String natureId) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getPluginWorkingLocation(IPluginDescriptor plugin) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IPath getWorkingLocation(String id) {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IProject[] getReferencedProjects() throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IProject[] getReferencingProjects() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public IBuildConfiguration[] getReferencedBuildConfigs(String configName, boolean includeMissing)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean hasBuildConfig(String configName) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean hasNature(String natureId) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isNatureEnabled(String natureId) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public boolean isOpen() {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void loadSnapshot(int options, URI snapshotLocation, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void move(IProjectDescription description, boolean force, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void open(int updateFlags, IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void open(IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void saveSnapshot(int options, URI snapshotLocation, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDescription(IProjectDescription description, IProgressMonitor monitor)
+                            throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+
+                    public void setDescription(IProjectDescription description, int updateFlags,
+                            IProgressMonitor monitor) throws CoreException {
+                        throw new RuntimeException("Not implemented");
+                    }
+                };
             }
 
             public void setProject(IProject project) {


### PR DESCRIPTION
For example, `PROJECT_LOC`, etc.

This allows paths relative to project and workspace locations to be more easily added. For example, this is desirable when developing a project using buildout in a virtualenv, particularly one with a complex `PYTHONPATH` such as Plone.

Also requested as a feature in [this earlier forum post](http://sourceforge.net/projects/pydev/forums/forum/293649/topic/3822328).

It's been a while since I wrote Java, so code and style criticism is most welcome.

Originally submitted as aptana/Pydev@44.
