### PR TITLE
Remove unused things from build script.

### DIFF
--- a/builders/org.python.pydev.build/build.xml
+++ b/builders/org.python.pydev.build/build.xml
@@ -183,53 +183,6 @@
         </delete>
         <!-- Copy the features and plugins over into a dropins folder. Installing makes it so that non-linux plugins/features won't be there! -->
         <mkdir dir="${baseLocation}/dropins/eclipse" />
-        <copy todir="${baseLocation}/dropins/eclipse">
-            <fileset dir="${studio3.p2.repo}" defaultexcludes="true">
-                <include name="features/*" />
-                <include name="plugins/*" />
-            </fileset>
-        </copy>
-
-        <!-- Unjar the features -->
-        <for param="file">
-            <path>
-                <fileset dir="${baseLocation}/dropins/eclipse/features" defaultexcludes="true">
-                    <include name="*.jar" />
-                </fileset>
-            </path>
-            <sequential>
-                <echo message="Unzipping JAR @{file}" />
-                <basename file="@{file}" property="@{file}.name" suffix="jar" />
-                <mkdir dir="${baseLocation}/dropins/eclipse/features/${@{file}.name}" />
-                <unjar dest="${baseLocation}/dropins/eclipse/features/${@{file}.name}" src="@{file}" />
-                <delete file="@{file}" />
-                <echo message="Replacing the update site domain names." />
-                <!-- The following will replace update.aptana.org update/... sites with download.aptana.com/... update sites -->
-                <replaceregexp file="${baseLocation}/dropins/eclipse/features/${@{file}.name}/feature.xml" match="http://update.aptana.com/update/" replace="http://download.aptana.com/tools/studio/plugin/" byline="true" />
-                <!-- The following will replace aptana.org update sites with aptana.com update sites -->
-                <replaceregexp file="${baseLocation}/dropins/eclipse/features/${@{file}.name}/feature.xml" match="http://download.aptana.org/tools/studio/plugin/" replace="http://download.aptana.com/tools/studio/plugin/" byline="true" />
-            </sequential>
-        </for>
-        <!-- UnJAR the handful of plugins that we need to... -->
-        <for param="file">
-            <path>
-                <fileset dir="${baseLocation}/dropins/eclipse/plugins" defaultexcludes="true">
-                    <include name="com.aptana.terminal_*.jar" />
-                    <include name="com.aptana.libraries_*.jar" />
-                    <include name="org.jruby_*.jar" />
-                    <include name="com.aptana.branding_*.jar" />
-                    <include name="com.aptana.parsing_*.jar" />
-                    <include name="com.aptana.portablegit.win32_*.jar" />
-                </fileset>
-            </path>
-            <sequential>
-                <echo message="Unzipping JAR @{file}" />
-                <basename file="@{file}" property="@{file}.name" suffix="jar" />
-                <mkdir dir="${baseLocation}/dropins/eclipse/plugins/${@{file}.name}" />
-                <unjar dest="${baseLocation}/dropins/eclipse/plugins/${@{file}.name}" src="@{file}" />
-                <delete file="@{file}" />
-            </sequential>
-        </for>
     </target>
 
 	<!-- - - - - - - - - - - - - - - - - - 


### PR DESCRIPTION
Needing aptana studio, jruby and etc. seems to be left over from old
things and just make it harder to build.
