### PR TITLE
Fix warnings: add parameters to raw types.

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/MarkerStub.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/MarkerStub.java
@@ -19,9 +19,9 @@ public class MarkerStub implements IMarker {
 
     private static final Object TYPE = "TYPE_STUB";
 
-    private Map attrs;
+    private Map<String, Object> attrs;
 
-    public MarkerStub(Map attrs) {
+    public MarkerStub(Map<String, Object> attrs) {
         this.attrs = attrs;
     }
 
@@ -60,7 +60,7 @@ public class MarkerStub implements IMarker {
         return i;
     }
 
-    public Map getAttributes() throws CoreException {
+    public Map<String, Object> getAttributes() throws CoreException {
         return attrs;
     }
 

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalDependencyInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalDependencyInfo.java
@@ -490,7 +490,6 @@ public abstract class AbstractAdditionalDependencyInfo extends AbstractAdditiona
      * actually does the load
      * @return true if it was successfully loaded and false otherwise
      */
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     protected boolean load() {
 
         Throwable errorFound = null;
@@ -535,8 +534,10 @@ public abstract class AbstractAdditionalDependencyInfo extends AbstractAdditiona
             FastStringBuffer string = bufferedReader.readLine();
             ObjectsPoolMap objectsPoolMap = new ObjectsPool.ObjectsPoolMap();
             if (string != null && string.startsWith("-- VERSION_")) {
-                Tuple tupWithResults = new Tuple(new Tuple3(null, null, null), null);
-                Tuple3 superTupWithResults = (Tuple3) tupWithResults.o1;
+                Tuple<Tuple3<Object, Object, Object>, Object> tupWithResults = new Tuple<Tuple3<Object, Object, Object>, Object>(
+                        new Tuple3<Object, Object, Object>(
+                                null, null, null), null);
+                Tuple3<Object, Object, Object> superTupWithResults = tupWithResults.o1;
                 //tupWithResults.o2 = DiskCache
                 if (string.toString().equals(expected)) {
                     //OK, proceed with new I/O format!

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalInfoWithBuild.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalInfoWithBuild.java
@@ -119,8 +119,8 @@ public abstract class AbstractAdditionalInfoWithBuild extends AbstractAdditional
                     String modName = new String(tup.substring(0, i));
                     File file = new File(tup.substring(i + 1, j));
 
-                    return new Tuple<ModulesKey, List>(new ModulesKey(modName, file), InfoStrFactory.strToInfo(tup
-                            .substring(j + 1)));
+                    return new Tuple<ModulesKey, List<IInfo>>(new ModulesKey(modName, file), InfoStrFactory.strToInfo(tup
+                                    .substring(j + 1)));
                 }
                 if (arg.startsWith("LST")) {
                     //Backward compatibility

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalTokensInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalTokensInfo.java
@@ -753,12 +753,12 @@ public abstract class AbstractAdditionalTokensInfo {
     @SuppressWarnings("unchecked")
     protected void restoreSavedInfo(Object o) throws MisconfigurationException {
         synchronized (lock) {
-            Tuple3 readFromFile = (Tuple3) o;
-            SortedMap o1 = (SortedMap) readFromFile.o1;
-            SortedMap o2 = (SortedMap) readFromFile.o2;
+            Tuple3<Object, Object, Object> readFromFile = (Tuple3<Object, Object, Object>) o;
+            SortedMap<String, Set<IInfo>> o1 = (SortedMap<String, Set<IInfo>>) readFromFile.o1;
+            SortedMap<String, Set<IInfo>> o2 = (SortedMap<String, Set<IInfo>>) readFromFile.o2;
 
-            this.topLevelInitialsToInfo = (SortedMap<String, Set<IInfo>>) o1;
-            this.innerInitialsToInfo = (SortedMap<String, Set<IInfo>>) o2;
+            this.topLevelInitialsToInfo = o1;
+            this.innerInitialsToInfo = o2;
             if (readFromFile.o3 != null) {
                 //may be null in new format (where that's checked during load time).
                 if (AbstractAdditionalTokensInfo.version != (Integer) readFromFile.o3) {

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityChecker.java
@@ -61,6 +61,7 @@ public class AdditionalInfoIntegrityChecker implements IPyEditListener {
         public List<SourceModule> moduleNotInAdditionalInfo = new ArrayList<SourceModule>();
         public List<String> additionalModulesNotInDisk = new ArrayList<String>();
 
+        @Override
         public String toString() {
             return desc.toString();
         }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitor.java
@@ -156,9 +156,9 @@ public class ScopeAnalyzerVisitor extends ScopeAnalyzerVisitorWithoutImports {
             ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>> ret) {
 
         //other matches for the imports that we had already found.
-        Tuple matchingImportEntries = getImportEntries(found, f);
-        List<Tuple4<IToken, Integer, ASTEntry, Found>> fromModule = (List<Tuple4<IToken, Integer, ASTEntry, Found>>) matchingImportEntries.o1;
-        List<Tuple4<IToken, Integer, ASTEntry, Found>> fromImports = (List<Tuple4<IToken, Integer, ASTEntry, Found>>) matchingImportEntries.o2;
+        Tuple<List<Tuple4<IToken, Integer, ASTEntry, Found>>, List<Tuple4<IToken, Integer, ASTEntry, Found>>> matchingImportEntries = getImportEntries(found, f);
+        List<Tuple4<IToken, Integer, ASTEntry, Found>> fromModule = matchingImportEntries.o1;
+        List<Tuple4<IToken, Integer, ASTEntry, Found>> fromImports = matchingImportEntries.o2;
 
         ret.addAll(fromModule);
         ret.addAll(fromImports);
@@ -217,7 +217,8 @@ public class ScopeAnalyzerVisitor extends ScopeAnalyzerVisitorWithoutImports {
      * because they are either in some other scope or are in the module part of an ImportFrom
      */
     @SuppressWarnings("unchecked")
-    private Tuple getImportEntries(Tuple3<Found, Integer, ASTEntry> found, Set<IToken> f) {
+    private Tuple<List<Tuple4<IToken, Integer, ASTEntry, Found>>, List<Tuple4<IToken, Integer, ASTEntry, Found>>> getImportEntries(
+            Tuple3<Found, Integer, ASTEntry> found, Set<IToken> f) {
         List<Tuple4<IToken, Integer, ASTEntry, Found>> fromModuleRet = new ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>>();
         List<Tuple4<IToken, Integer, ASTEntry, Found>> fromImportsRet = new ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>>();
         if (found.o1.isImport()) {
@@ -233,7 +234,8 @@ public class ScopeAnalyzerVisitor extends ScopeAnalyzerVisitorWithoutImports {
             checkImportEntries(fromImportsRet, f, fromImports, found.o2);
 
         }
-        return new Tuple(fromModuleRet, fromImportsRet);
+        return new Tuple<List<Tuple4<IToken, Integer, ASTEntry, Found>>, List<Tuple4<IToken, Integer, ASTEntry, Found>>>(
+                fromModuleRet, fromImportsRet);
     }
 
     /**
@@ -247,7 +249,7 @@ public class ScopeAnalyzerVisitor extends ScopeAnalyzerVisitorWithoutImports {
             for (Tuple3<Found, Integer, ASTEntry> foundInFromModule : importEntries) {
                 IToken generator = foundInFromModule.o1.getSingle().generator;
 
-                Tuple4<IToken, Integer, ASTEntry, Found> tup3 = new Tuple4(generator,
+                Tuple4<IToken, Integer, ASTEntry, Found> tup3 = new Tuple4<IToken, Integer, ASTEntry, Found>(generator,
                         colDelta > foundInFromModule.o2 ? colDelta : foundInFromModule.o2, foundInFromModule.o3,
                         foundInFromModule.o1);
 

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorForImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorForImports.java
@@ -85,7 +85,7 @@ public final class ScopeAnalyzerVisitorForImports extends ScopeAnalyzerVisitor {
             for (Tuple3<Found, Integer, ASTEntry> foundInFromModule : fList) {
                 IToken generator = foundInFromModule.o1.getSingle().generator;
 
-                Tuple4<IToken, Integer, ASTEntry, Found> tup3 = new Tuple4(generator, 0, foundInFromModule.o3,
+                Tuple4<IToken, Integer, ASTEntry, Found> tup3 = new Tuple4<IToken, Integer, ASTEntry, Found>(generator, 0, foundInFromModule.o3,
                         foundInFromModule.o1);
                 ret.add(tup3);
             }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
@@ -469,14 +469,14 @@ public class ScopeAnalyzerVisitorWithoutImports extends AbstractScopeAnalyzerVis
     protected ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>> getCompleteTokenOccurrences() {
         //that's because we don't want duplicates
         Set<IToken> f = new HashSet<IToken>();
-        ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>> ret = new ArrayList();
+        ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>> ret = new ArrayList<Tuple4<IToken, Integer, ASTEntry, Found>>();
 
         for (Tuple3<Found, Integer, ASTEntry> found : foundOccurrences) {
             List<GenAndTok> all = found.o1.getAll();
 
             for (GenAndTok tok : all) {
 
-                Tuple4<IToken, Integer, ASTEntry, Found> tup4 = new Tuple4(tok.generator, found.o2, found.o3, found.o1);
+                Tuple4<IToken, Integer, ASTEntry, Found> tup4 = new Tuple4<IToken, Integer, ASTEntry, Found>(tok.generator, found.o2, found.o3, found.o1);
 
                 if (!f.contains(tok.generator)) {
                     f.add(tok.generator);
@@ -484,7 +484,7 @@ public class ScopeAnalyzerVisitorWithoutImports extends AbstractScopeAnalyzerVis
                 }
 
                 for (IToken t : tok.references) {
-                    tup4 = new Tuple4(t, found.o2, found.o3, found.o1);
+                    tup4 = new Tuple4<IToken, Integer, ASTEntry, Found>(t, found.o2, found.o3, found.o1);
                     if (!f.contains(t)) {
                         f.add(t);
                         ret.add(tup4);

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoTestsBase.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoTestsBase.java
@@ -88,9 +88,8 @@ public class AdditionalInfoTestsBase extends AnalysisTestsBase {
      * @param type the marker type
      * @return the created stub
      */
-    @SuppressWarnings("unchecked")
     protected MarkerAnnotationAndPosition createMarkerStub(int start, int end, int type) {
-        HashMap attrs = new HashMap();
+        HashMap<String, Object> attrs = new HashMap<String, Object>();
 
         attrs.put(AnalysisRunner.PYDEV_ANALYSIS_TYPE, type);
         attrs.put(IMarker.CHAR_START, start);

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
@@ -244,7 +244,7 @@ public class CtxParticipant implements IPyDevCompletionParticipant, IPyDevComple
         return importedNames;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection getGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
         return getThem(request, state, AutoImportsPreferencesPage.doAutoImport());
@@ -253,8 +253,7 @@ public class CtxParticipant implements IPyDevCompletionParticipant, IPyDevComple
     /**
      * IPyDevCompletionParticipant
      */
-    @SuppressWarnings("unchecked")
-    public Collection getCompletionsForMethodParameter(ICompletionState state, ILocalScope localScope,
+    public Collection<IToken> getCompletionsForMethodParameter(ICompletionState state, ILocalScope localScope,
             Collection<IToken> interfaceForLocal) {
         ArrayList<IToken> ret = new ArrayList<IToken>();
         String qual = state.getQualifier();
@@ -280,7 +279,7 @@ public class CtxParticipant implements IPyDevCompletionParticipant, IPyDevComple
      * IPyDevCompletionParticipant
      * @throws MisconfigurationException 
      */
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection getStringGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
         return getThem(request, state, false);
@@ -291,7 +290,6 @@ public class CtxParticipant implements IPyDevCompletionParticipant, IPyDevComple
         throw new RuntimeException("Deprecated");
     }
 
-    @SuppressWarnings("unchecked")
     public Collection<IToken> getCompletionsForTokenWithUndefinedType(ICompletionState state, ILocalScope localScope,
             Collection<IToken> interfaceForLocal) {
         return getCompletionsForMethodParameter(state, localScope, interfaceForLocal);

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
@@ -250,19 +250,19 @@ public class ImportsCompletionParticipant implements IPyDevCompletionParticipant
         return importedNames;
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection getGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
         return getThem(request, state, AutoImportsPreferencesPage.doAutoImport());
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection getCompletionsForMethodParameter(ICompletionState state, ILocalScope localScope,
             Collection<IToken> interfaceForLocal) {
         return Collections.emptyList();
     }
 
-    @SuppressWarnings("unchecked")
+    @SuppressWarnings({ "unchecked", "rawtypes" })
     public Collection getStringGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
         return getThem(request, state, false);

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchConfigurationDelegate.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchConfigurationDelegate.java
@@ -41,7 +41,7 @@ public class PydevdServerLaunchConfigurationDelegate extends AbstractLaunchConfi
 
         ProcessServer p = new ProcessServer();
         String label = "Debug Server";
-        HashMap processAttributes = new HashMap();
+        HashMap<String, String> processAttributes = new HashMap<String, String>();
         processAttributes.put(IProcess.ATTR_PROCESS_TYPE, Constants.PROCESS_TYPE);
         processAttributes.put(IProcess.ATTR_PROCESS_LABEL, label);
         processAttributes.put(DebugPlugin.ATTR_CAPTURE_OUTPUT, "true");

--- a/plugins/com.python.pydev.fastparser/tests/com/python/pydev/fastparser/MemoVisitor.java
+++ b/plugins/com.python.pydev.fastparser/tests/com/python/pydev/fastparser/MemoVisitor.java
@@ -25,7 +25,7 @@ import org.python.pydev.parser.visitors.NodeUtils;
 
 public class MemoVisitor extends VisitorBase {
 
-    List visited = new ArrayList();
+    List<SimpleNode> visited = new ArrayList<SimpleNode>();
 
     protected Object unhandled_node(SimpleNode node) throws Exception {
         if (node instanceof Pass) {
@@ -65,9 +65,9 @@ public class MemoVisitor extends VisitorBase {
     public boolean equals(Object obj) {
 
         MemoVisitor other = (MemoVisitor) obj;
-        Iterator iter1 = other.visited.iterator();
+        Iterator<SimpleNode> iter1 = other.visited.iterator();
 
-        for (Iterator iter = visited.iterator(); iter.hasNext();) {
+        for (Iterator<SimpleNode> iter = visited.iterator(); iter.hasNext();) {
             SimpleNode n = (SimpleNode) iter.next();
             SimpleNode n1 = null;
             try {
@@ -117,7 +117,7 @@ public class MemoVisitor extends VisitorBase {
 
     public String toString() {
         StringBuffer buffer = new StringBuffer();
-        for (Iterator iter = visited.iterator(); iter.hasNext();) {
+        for (Iterator<SimpleNode> iter = visited.iterator(); iter.hasNext();) {
             buffer.append(iter.next().toString());
             buffer.append("\n");
         }

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesJob.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesJob.java
@@ -378,7 +378,7 @@ public class MarkOccurrencesJob extends Job {
                 if (annotationModel instanceof IAnnotationModelExtension) {
                     //replace those 
                     ((IAnnotationModelExtension) annotationModel).replaceAnnotations(
-                            annotationsToRemove.toArray(new Annotation[annotationsToRemove.size()]), new HashMap());
+                            annotationsToRemove.toArray(new Annotation[annotationsToRemove.size()]), new HashMap<Annotation, Position>());
                 } else {
                     Iterator<Annotation> annotationIterator = annotationsToRemove.iterator();
 

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/AbstractPythonSearchQuery.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/AbstractPythonSearchQuery.java
@@ -57,7 +57,7 @@ public abstract class AbstractPythonSearchQuery implements ISearchQuery {
         private final AbstractTextSearchResult fResult;
         private final boolean fIsFileSearchOnly;
         private final boolean fSearchInBinaries;
-        private ArrayList fCachedMatches;
+        private ArrayList<FileMatch> fCachedMatches;
 
         private TextSearchResultCollector(AbstractTextSearchResult result, boolean isFileSearchOnly,
                 boolean searchInBinaries) {
@@ -149,7 +149,7 @@ public abstract class AbstractPythonSearchQuery implements ISearchQuery {
         }
 
         public void beginReporting() {
-            fCachedMatches = new ArrayList();
+            fCachedMatches = new ArrayList<FileMatch>();
         }
 
         public void endReporting() {

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTreeContentProvider.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTreeContentProvider.java
@@ -31,7 +31,7 @@ public class FileTreeContentProvider implements ITreeContentProvider, IFileSearc
     private AbstractTextSearchResult fResult;
     private FileSearchPage fPage;
     private AbstractTreeViewer fTreeViewer;
-    private Map fChildrenMap;
+    private Map<Object, Set> fChildrenMap;
 
     FileTreeContentProvider(FileSearchPage page, AbstractTreeViewer viewer) {
         fPage = page;
@@ -70,7 +70,7 @@ public class FileTreeContentProvider implements ITreeContentProvider, IFileSearc
 
     private synchronized void initialize(AbstractTextSearchResult result) {
         fResult = result;
-        fChildrenMap = new HashMap();
+        fChildrenMap = new HashMap<Object, Set>();
         boolean showLineMatches = !((AbstractPythonSearchQuery) fResult.getQuery()).isFileNameSearch();
 
         if (result != null) {

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceConfigurationPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceConfigurationPage.java
@@ -208,7 +208,7 @@ public class ReplaceConfigurationPage extends UserInputWizardPage {
 
     private void storeSettings() {
         String[] items = fTextField.getItems();
-        ArrayList history = new ArrayList();
+        ArrayList<String> history = new ArrayList<String>();
         history.add(fTextField.getText());
         int historySize = Math.min(items.length, 6);
         for (int i = 0; i < historySize; i++) {

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceRefactoring.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceRefactoring.java
@@ -105,10 +105,9 @@ public class ReplaceRefactoring extends Refactoring {
             return new RefactoringStatus();
         }
 
-        @SuppressWarnings("unchecked")
         private Match[] getMatches() {
             if (fMatches == null) {
-                ArrayList matches = new ArrayList();
+                ArrayList<FileMatch> matches = new ArrayList<FileMatch>();
                 for (int i = 0; i < fMatchGroups.length; i++) {
                     MatchGroup curr = fMatchGroups[i];
                     if (curr.group.isEnabled()) {
@@ -214,7 +213,7 @@ public class ReplaceRefactoring extends Refactoring {
         } else if (object instanceof IFile) {
             Match[] matches = fResult.getMatches(object);
             if (matches.length > 0) {
-                Collection bucket = null;
+                Collection<FileMatch> bucket = null;
                 for (int i = 0; i < matches.length; i++) {
                     FileMatch fileMatch = (FileMatch) matches[i];
                     if (!isSkipped(fileMatch)) {
@@ -276,7 +275,7 @@ public class ReplaceRefactoring extends Refactoring {
 
         RefactoringStatus resultingStatus = new RefactoringStatus();
 
-        Collection allFiles = fMatches.keySet();
+        Collection<IFile> allFiles = fMatches.keySet();
         checkFilesToBeChanged((IFile[]) allFiles.toArray(new IFile[allFiles.size()]), resultingStatus);
         if (resultingStatus.hasFatalError()) {
             return resultingStatus;
@@ -325,7 +324,7 @@ public class ReplaceRefactoring extends Refactoring {
     @SuppressWarnings("unchecked")
     private void checkFilesToBeChanged(IFile[] filesToBeChanged, RefactoringStatus resultingStatus)
             throws CoreException {
-        ArrayList readOnly = new ArrayList();
+        ArrayList<IFile> readOnly = new ArrayList<IFile>();
         for (int i = 0; i < filesToBeChanged.length; i++) {
             IFile file = filesToBeChanged[i];
             if (file.isReadOnly())

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateClassOrMethodOrField.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateClassOrMethodOrField.java
@@ -44,6 +44,7 @@ public abstract class AbstractPyCreateClassOrMethodOrField extends AbstractPyCre
 
     public abstract String getCreationStr();
 
+    @Override
     public void execute(RefactoringInfo refactoringInfo, int locationStrategy) {
         try {
             String creationStr = this.getCreationStr();
@@ -221,7 +222,7 @@ public abstract class AbstractPyCreateClassOrMethodOrField extends AbstractPyCre
                         int iLineStartingScope = scopeStart.iLineStartingScope;
                         String line = pySelection.getLine(iLineStartingScope);
 
-                        if (pySelection.matchesFunctionLine(line) || pySelection.matchesClassLine(line)) {
+                        if (pySelection.matchesFunctionLine(line) || PySelection.matchesClassLine(line)) {
                             //check for decorators...
                             if (iLineStartingScope > 0) {
                                 int i = iLineStartingScope - 1;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
@@ -60,7 +60,6 @@ public class TddCodeGenerationQuickFixParticipant extends AbstractAnalysisMarker
         participants.add(tddQuickFixParticipant);
     }
 
-    @SuppressWarnings({ "unchecked", "rawtypes" })
     public List<ICompletionProposal> getProps(PySelection ps, ImageCache imageCache, File f, IPythonNature nature,
             PyEdit edit, int offset) throws BadLocationException {
         List<ICompletionProposal> ret = super.getProps(ps, imageCache, f, nature, edit, offset);
@@ -81,7 +80,7 @@ public class TddCodeGenerationQuickFixParticipant extends AbstractAnalysisMarker
         List<TddPossibleMatches> callsAtLine = ps.getTddPossibleMatchesAtLine();
         if (callsAtLine.size() > 0) {
             //Make sure we don't check the same thing twice.
-            Map<String, TddPossibleMatches> callsToCheck = new HashMap();
+            Map<String, TddPossibleMatches> callsToCheck = new HashMap<String, TddPossibleMatches>();
             for (TddPossibleMatches call : callsAtLine) {
                 String callString = call.initialPart + call.secondPart;
                 callsToCheck.put(callString, call);

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringLocalToken.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringLocalToken.java
@@ -32,7 +32,7 @@ public class RefactoringLocalToken extends RefactoringRenameTestBase {
         }
     }
 
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameClassProcess> getProcessUnderTest() {
         return PyRenameClassProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameAttributeRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameAttributeRefactoringTest.java
@@ -30,7 +30,7 @@ public class RenameAttributeRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameAttributeProcess> getProcessUnderTest() {
         return PyRenameAttributeProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameClassRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameClassRefactoringTest.java
@@ -42,7 +42,7 @@ public class RenameClassRefactoringTest extends RefactoringRenameTestBase {
         }
     }
 
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameClassProcess> getProcessUnderTest() {
         return PyRenameClassProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest.java
@@ -40,7 +40,7 @@ public class RenameFunctionRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameFunctionProcess> getProcessUnderTest() {
         return PyRenameFunctionProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameGlobalRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameGlobalRefactoringTest.java
@@ -28,7 +28,7 @@ public class RenameGlobalRefactoringTest extends RefactoringRenameTestBase {
         }
     }
 
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameGlobalProcess> getProcessUnderTest() {
         return PyRenameGlobalProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameLocalRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameLocalRefactoringTest.java
@@ -30,7 +30,7 @@ public class RenameLocalRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameLocalProcess> getProcessUnderTest() {
         return PyRenameLocalProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameModuleRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameModuleRefactoringTest.java
@@ -31,7 +31,7 @@ public class RenameModuleRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameImportProcess> getProcessUnderTest() {
         return PyRenameImportProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameParamRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameParamRefactoringTest.java
@@ -30,7 +30,7 @@ public class RenameParamRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameParameterProcess> getProcessUnderTest() {
         return PyRenameParameterProcess.class;
     }
 

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameSelfRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameSelfRefactoringTest.java
@@ -30,7 +30,7 @@ public class RenameSelfRefactoringTest extends RefactoringRenameTestBase {
     }
 
     @Override
-    protected Class getProcessUnderTest() {
+    protected Class<PyRenameSelfAttributeProcess> getProcessUnderTest() {
         return PyRenameSelfAttributeProcess.class;
     }
 

--- a/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllTests.java
+++ b/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllTests.java
@@ -27,7 +27,7 @@ public class AllTests {
     public static final String SUFFIX = "Test";
 
     private static void addTestsToSuite(TestCollector collector, TestSuite suite) {
-        Enumeration e = collector.collectTests();
+        Enumeration<String> e = collector.collectTests();
         while (e.hasMoreElements()) {
             String name = (String) e.nextElement();
             try {

--- a/plugins/com.python.pydev.runalltests/src/junit3/runner/ClassPathTestCollector.java
+++ b/plugins/com.python.pydev.runalltests/src/junit3/runner/ClassPathTestCollector.java
@@ -21,26 +21,26 @@ public abstract class ClassPathTestCollector implements TestCollector {
 	public ClassPathTestCollector() {
 	}
 	
-	public Enumeration collectTests() {
+	public Enumeration<String> collectTests() {
 		String classPath= System.getProperty("java.class.path");
-		Hashtable result = collectFilesInPath(classPath);
+		Hashtable<String, String> result = collectFilesInPath(classPath);
 		return result.elements();
 	}
 
-	public Hashtable collectFilesInPath(String classPath) {
-		Hashtable result= collectFilesInRoots(splitClassPath(classPath));
+	public Hashtable<String, String> collectFilesInPath(String classPath) {
+		Hashtable<String, String> result= collectFilesInRoots(splitClassPath(classPath));
 		return result;
 	}
 	
-	Hashtable collectFilesInRoots(Vector roots) {
-		Hashtable result= new Hashtable(100);
-		Enumeration e= roots.elements();
+	Hashtable<String, String> collectFilesInRoots(Vector roots) {
+		Hashtable<String, String> result= new Hashtable(100);
+		Enumeration<String> e= roots.elements();
 		while (e.hasMoreElements()) 
 			gatherFiles(new File((String)e.nextElement()), "", result);
 		return result;
 	}
 
-	void gatherFiles(File classRoot, String classFileName, Hashtable result) {
+	void gatherFiles(File classRoot, String classFileName, Hashtable<String, String> result) {
 		File thisRoot= new File(classRoot, classFileName);
 		if (thisRoot.isFile()) {
 			if (isTestClass(classFileName)) {
@@ -56,8 +56,8 @@ public abstract class ClassPathTestCollector implements TestCollector {
 		}
 	}
 	
-	Vector splitClassPath(String classPath) {
-		Vector result= new Vector();
+	Vector<String> splitClassPath(String classPath) {
+		Vector<String> result= new Vector<String>();
 		String separator= System.getProperty("path.separator");
 		StringTokenizer tokenizer= new StringTokenizer(classPath, separator);
 		while (tokenizer.hasMoreTokens()) 

--- a/plugins/com.python.pydev.runalltests/src/junit3/runner/TestCollector.java
+++ b/plugins/com.python.pydev.runalltests/src/junit3/runner/TestCollector.java
@@ -11,5 +11,5 @@ public interface TestCollector {
     /**
      * Returns an enumeration of Strings with qualified class names
      */
-    public Enumeration collectTests();
+    public Enumeration<String> collectTests();
 }

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/LineElement.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/LineElement.java
@@ -57,7 +57,7 @@ public class LineElement {
     }
 
     public FileMatch[] getMatches(AbstractTextSearchResult result) {
-        ArrayList res = new ArrayList();
+        ArrayList<FileMatch> res = new ArrayList<FileMatch>();
         Match[] matches = result.getMatches(fParent);
         for (int i = 0; i < matches.length; i++) {
             FileMatch curr = (FileMatch) matches[i];

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/PySearchPage.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/PySearchPage.java
@@ -336,7 +336,7 @@ public class PySearchPage extends DialogPage implements ISearchPage {
     }
 
     private SearchPatternData findInPrevious(String pattern) {
-        for (Iterator iter = fPreviousSearchPatterns.iterator(); iter.hasNext();) {
+        for (Iterator<SearchPatternData> iter = fPreviousSearchPatterns.iterator(); iter.hasNext();) {
             SearchPatternData element = (SearchPatternData) iter.next();
             if (pattern.equals(element.textPattern)) {
                 return element;

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceAction2.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceAction2.java
@@ -122,7 +122,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
     }
 
     private IFile[] collectFiles(Iterator resources) {
-        final Set files = new HashSet();
+        final Set<IResource> files = new HashSet<IResource>();
         final AbstractTextSearchResult result = fPage.getInput();
         if (result == null)
             return new IFile[0];
@@ -176,7 +176,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
             return false;
         }
 
-        final List outOfDateEntries = new ArrayList();
+        final List<IFile> outOfDateEntries = new ArrayList<IFile>();
         for (int j = 0; j < fElements.length; j++) {
             IFile entry = fElements[j];
             Match[] markers = fPage.getDisplayedMatches(entry);
@@ -188,7 +188,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
             }
         }
 
-        final List outOfSyncEntries = new ArrayList();
+        final List<IFile> outOfSyncEntries = new ArrayList<IFile>();
         for (int i = 0; i < fElements.length; i++) {
             IFile entry = fElements[i];
             if (isOutOfSync(entry)) {
@@ -219,7 +219,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
     }
 
     private IFile[] getReadOnlyFiles() {
-        Set readOnly = new HashSet();
+        Set<IFile> readOnly = new HashSet<IFile>();
         for (int i = 0; i < fElements.length; i++) {
             if (fElements[i].isReadOnly())
                 readOnly.add(fElements[i]);
@@ -228,7 +228,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
         return (IFile[]) readOnly.toArray(readOnlyArray);
     }
 
-    private void research(IProgressMonitor monitor, List outOfDateEntries, FileSearchQuery operation)
+    private void research(IProgressMonitor monitor, List<IFile> outOfDateEntries, FileSearchQuery operation)
             throws CoreException {
         String message = SearchMessages.ReplaceAction2_statusMessage;
         MultiStatus multiStatus = new MultiStatus(NewSearchUI.PLUGIN_ID, IStatus.OK, message, null);
@@ -244,7 +244,7 @@ import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
         }
     }
 
-    private boolean askForResearch(List outOfDateEntries, List outOfSyncEntries) {
+    private boolean askForResearch(List<IFile> outOfDateEntries, List<IFile> outOfSyncEntries) {
         SearchAgainConfirmationDialog dialog = new SearchAgainConfirmationDialog(fSite.getShell(),
                 (ILabelProvider) fPage.getViewer().getLabelProvider(), outOfSyncEntries, outOfDateEntries);
         return dialog.open() == IDialogConstants.OK_ID;

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceDialog2.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceDialog2.java
@@ -115,7 +115,7 @@ class ReplaceDialog2 extends ExtendedDialogWindow {
     private Button fSkipButton;
     private Button fSkipFileButton;
 
-    private List fMarkers;
+    private List<Match> fMarkers;
     private boolean fSkipReadonly = false;
 
     // reuse editors stuff
@@ -130,7 +130,7 @@ class ReplaceDialog2 extends ExtendedDialogWindow {
         Assert.isNotNull(entries);
         Assert.isNotNull(page.getInput());
         fPage = page;
-        fMarkers = new ArrayList();
+        fMarkers = new ArrayList<Match>();
         initializeMarkers(entries);
     }
 
@@ -691,7 +691,7 @@ class ReplaceDialog2 extends ExtendedDialogWindow {
     private int countResources() {
         IResource r = null;
         int count = 0;
-        for (Iterator elements = fMarkers.iterator(); elements.hasNext();) {
+        for (Iterator<Match> elements = fMarkers.iterator(); elements.hasNext();) {
             Match element = (Match) elements.next();
             if (!element.getElement().equals(r)) {
                 count++;
@@ -702,7 +702,7 @@ class ReplaceDialog2 extends ExtendedDialogWindow {
     }
 
     private Match[] collectMarkers(IFile resource) {
-        List matching = new ArrayList();
+        List<Match> matching = new ArrayList<Match>();
         for (int i = 0; i < fMarkers.size(); i++) {
             Match marker = (Match) fMarkers.get(i);
             if (!resource.equals(marker.getElement()))
@@ -750,7 +750,7 @@ class ReplaceDialog2 extends ExtendedDialogWindow {
      */
     public boolean close() {
         String[] items = fTextField.getItems();
-        ArrayList history = new ArrayList();
+        ArrayList<String> history = new ArrayList<String>();
         history.add(fTextField.getText());
         int historySize = Math.min(items.length, 6);
         for (int i = 0; i < historySize; i++) {

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
@@ -117,7 +117,7 @@ public class StringSubstitution {
         /**
          * Stack of variables to resolve
          */
-        private Stack fStack;
+        private Stack<VariableReference> fStack;
 
         class VariableReference {
 
@@ -191,13 +191,13 @@ public class StringSubstitution {
          * @param resolveVariables whether to resolve the value of any variables
          * @exception CoreException if unable to resolve a variable
          */
-        private HashSet substitute(String expression, boolean resolveVariables, Map<String, String> variableSubstitution)
+        private HashSet<String> substitute(String expression, boolean resolveVariables, Map<String, String> variableSubstitution)
                 throws CoreException {
             fResult = new StringBuffer(expression.length());
-            fStack = new Stack();
+            fStack = new Stack<VariableReference>();
             fSubs = false;
 
-            HashSet resolvedVariables = new HashSet();
+            HashSet<String> resolvedVariables = new HashSet<String>();
 
             int pos = 0;
             int state = SCAN_FOR_START;
@@ -227,7 +227,7 @@ public class StringSubstitution {
                         int end = expression.indexOf(VARIABLE_END, pos);
                         if (end < 0) {
                             // variables are not completed
-                            VariableReference tos = (VariableReference) fStack.peek();
+                            VariableReference tos = fStack.peek();
                             tos.append(expression.substring(pos));
                             pos = expression.length();
                         } else {
@@ -235,14 +235,14 @@ public class StringSubstitution {
                                 // start of a nested variable
                                 int length = start - pos;
                                 if (length > 0) {
-                                    VariableReference tos = (VariableReference) fStack.peek();
+                                    VariableReference tos = fStack.peek();
                                     tos.append(expression.substring(pos, start));
                                 }
                                 pos = start + 2;
                                 fStack.push(new VariableReference());
                             } else {
                                 // end of variable reference
-                                VariableReference tos = (VariableReference) fStack.pop();
+                                VariableReference tos = fStack.pop();
                                 String substring = expression.substring(pos, end);
                                 tos.append(substring);
                                 resolvedVariables.add(substring);
@@ -258,7 +258,7 @@ public class StringSubstitution {
                                     state = SCAN_FOR_START;
                                 } else {
                                     // append to previous variable
-                                    tos = (VariableReference) fStack.peek();
+                                    tos = fStack.peek();
                                     tos.append(value);
                                 }
                             }
@@ -268,12 +268,12 @@ public class StringSubstitution {
             }
             // process incomplete variable references
             while (!fStack.isEmpty()) {
-                VariableReference tos = (VariableReference) fStack.pop();
+                VariableReference tos = fStack.pop();
                 if (fStack.isEmpty()) {
                     fResult.append(VARIABLE_START);
                     fResult.append(tos.getText());
                 } else {
-                    VariableReference var = (VariableReference) fStack.peek();
+                    VariableReference var = fStack.peek();
                     var.append(VARIABLE_START);
                     var.append(tos.getText());
                 }

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIResourceStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIResourceStub.java
@@ -147,7 +147,7 @@ public class AbstractIResourceStub implements IResource {
         throw new RuntimeException("Not implemented");
     }
 
-    public Map getPersistentProperties() throws CoreException {
+    public Map<QualifiedName, String> getPersistentProperties() throws CoreException {
         throw new RuntimeException("Not implemented");
     }
 
@@ -175,7 +175,7 @@ public class AbstractIResourceStub implements IResource {
         throw new RuntimeException("Not implemented");
     }
 
-    public Map getSessionProperties() throws CoreException {
+    public Map<QualifiedName, Object> getSessionProperties() throws CoreException {
         throw new RuntimeException("Not implemented");
     }
 

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
@@ -94,7 +94,7 @@ public class PyDebugModelPresentation implements IDebugModelPresentation {
             PyBreakpoint pyBreakpoint = (PyBreakpoint) element;
             IMarker marker = ((PyBreakpoint) element).getMarker();
             try {
-                Map attrs = marker.getAttributes();
+                Map<String, Object> attrs = marker.getAttributes();
 
                 //get the filename
                 String ioFile = pyBreakpoint.getFile();

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RetargetSetNextAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RetargetSetNextAction.java
@@ -59,7 +59,7 @@ public class RetargetSetNextAction extends RetargetAction {
     }
 
     @Override
-    protected Class getAdapterClass() {
+    protected Class<ISetNextTarget> getAdapterClass() {
         return ISetNextTarget.class;
     }
 

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
@@ -62,7 +62,7 @@ public class PythonBreakpointPage extends PropertyPage {
     protected Button fSuspendVMButton;
     protected Text fHitCountText;
 
-    protected List fErrorMessages = new ArrayList();
+    protected List<String> fErrorMessages = new ArrayList<String>();
 
     /**
      * Attribute used to indicate that a breakpoint should be deleted
@@ -178,7 +178,7 @@ public class PythonBreakpointPage extends PropertyPage {
      */
     protected void createTypeSpecificLabels(Composite parent) {
         //         Line number
-        PyBreakpoint breakpoint = (PyBreakpoint) getBreakpoint();
+        PyBreakpoint breakpoint = getBreakpoint();
         StringBuffer lineNumber = new StringBuffer(4);
         try {
             int lNumber = breakpoint.getLineNumber();
@@ -219,7 +219,7 @@ public class PythonBreakpointPage extends PropertyPage {
     * @param parent
     */
     protected void createTypeSpecificEditors(Composite parent) throws CoreException {
-        PyBreakpoint breakpoint = (PyBreakpoint) getBreakpoint();
+        PyBreakpoint breakpoint = getBreakpoint();
         if (breakpoint.supportsCondition()) {
             createConditionEditor(parent);
         }
@@ -353,7 +353,7 @@ public class PythonBreakpointPage extends PropertyPage {
      * @throws CoreException if an exception occurs accessing the breakpoint
      */
     private void createConditionEditor(Composite parent) throws CoreException {
-        PyBreakpoint breakpoint = (PyBreakpoint) getBreakpoint();
+        PyBreakpoint breakpoint = getBreakpoint();
 
         String label = null;
         ICommandManager commandManager = PlatformUI.getWorkbench().getCommandSupport().getCommandManager();

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
@@ -64,7 +64,7 @@ public class PydevConsoleDebugCommsTest extends TestCase {
         String[] cmdarray = new String[] { TestDependent.PYTHON_EXE, consoleFile, String.valueOf(port),
                 String.valueOf(clientPort) };
 
-        Map env = new TreeMap();
+        Map<String, String> env = new TreeMap<String, String>();
         env.put("HOME", homeDir.toString());
         env.put("PYTHONPATH", pydevdDir);
         String sysRoot = System.getenv("SystemRoot");

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/ScopesParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/ScopesParser.java
@@ -123,7 +123,7 @@ public class ScopesParser {
             List<ScopeEntry> list = getAtOffset(offset);
             ScopeEntry startEntry = new ScopeEntry(scopeId, type, true, offset);
             list.add(startEntry);
-            idToStartEnd.put(scopeId, new Tuple(startEntry, null));
+            idToStartEnd.put(scopeId, new Tuple<ScopeEntry, ScopeEntry>(startEntry, null));
             return scopeId;
         }
 

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyAstIteratorBase.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyAstIteratorBase.java
@@ -203,7 +203,7 @@ public abstract class EasyAstIteratorBase extends VisitorBase {
     protected boolean isInGlobal() {
         Iterator<SimpleNode> iterator = stack.iterator();
         while (iterator.hasNext()) {
-            SimpleNode node = (SimpleNode) iterator.next();
+            SimpleNode node = iterator.next();
             if (node instanceof ClassDef || node instanceof FunctionDef) {
                 return false;
             }
@@ -218,13 +218,13 @@ public abstract class EasyAstIteratorBase extends VisitorBase {
     protected boolean isInClassMethodDecl() {
         Iterator<SimpleNode> iterator = stack.iterator();
         while (iterator.hasNext()) {
-            SimpleNode node = (SimpleNode) iterator.next();
+            SimpleNode node = iterator.next();
             if (node instanceof ClassDef) {
                 break;
             }
         }
         while (iterator.hasNext()) {
-            SimpleNode node = (SimpleNode) iterator.next();
+            SimpleNode node = iterator.next();
             if (node instanceof FunctionDef) {
                 return true;
             }
@@ -240,7 +240,7 @@ public abstract class EasyAstIteratorBase extends VisitorBase {
             return false;
         }
 
-        SimpleNode last = (SimpleNode) stack.peek();
+        SimpleNode last = stack.peek();
         if (last instanceof ClassDef) {
             return true;
         }
@@ -337,7 +337,7 @@ public abstract class EasyAstIteratorBase extends VisitorBase {
     public List<ASTEntry> getAsList(Class... classes) {
         List<ASTEntry> newList = new ArrayList<ASTEntry>();
         for (Iterator<ASTEntry> iter = nodes.iterator(); iter.hasNext();) {
-            ASTEntry entry = (ASTEntry) iter.next();
+            ASTEntry entry = iter.next();
             if (isFromClass(entry.node, classes)) {
                 newList.add(entry);
             }

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ImageCache.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ImageCache.java
@@ -82,7 +82,7 @@ public class ImageCache {
 
     public void dispose() {
         synchronized (lock) {
-            Iterator e = imageHash.values().iterator();
+            Iterator<Image> e = imageHash.values().iterator();
             while (e.hasNext())
                 ((Image) e.next()).dispose();
             if (missing != null) {

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineSortByNameAction.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineSortByNameAction.java
@@ -52,7 +52,7 @@ public class OutlineSortByNameAction extends Action {
                 sortByNameSorter = new ViewerSorter() {
                     @SuppressWarnings("unchecked")
                     public int compare(Viewer viewer, Object e1, Object e2) {
-                        return ((Comparable) e1).compareTo(e2);
+                        return ((Comparable<Object>) e1).compareTo(e2);
                     }
                 };
             }

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilder.java
@@ -73,7 +73,7 @@ public class PyDevBuilder extends IncrementalProjectBuilder {
      * 
      * @see org.eclipse.core.internal.events InternalBuilder#build(int, java.util.Map, org.eclipse.core.runtime.IProgressMonitor)
      */
-    protected IProject[] build(int kind, Map args, IProgressMonitor monitor) throws CoreException {
+    protected IProject[] build(int kind, Map<String, String> args, IProgressMonitor monitor) throws CoreException {
 
         if (PyDevBuilderPrefPage.usePydevBuilders() == false)
             return null;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
@@ -1516,7 +1516,7 @@ public class PyEdit extends PyEditProjection implements IPyEdit, IGrammarVersion
         RunInUiThread.async(runnable);
     }
 
-    public Class getActionClass() {
+    public Class<Action> getActionClass() {
         return Action.class;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
@@ -81,8 +81,8 @@ public class PyEditConfiguration extends PyEditConfigurationWithoutEditor {
      */
     @Override
     @SuppressWarnings("unchecked")
-    protected Map getHyperlinkDetectorTargets(ISourceViewer sourceViewer) {
-        Map targets = super.getHyperlinkDetectorTargets(sourceViewer);
+    protected Map<String, IPySyntaxHighlightingAndCodeCompletionEditor> getHyperlinkDetectorTargets(ISourceViewer sourceViewer) {
+        Map<String, IPySyntaxHighlightingAndCodeCompletionEditor> targets = super.getHyperlinkDetectorTargets(sourceViewer);
         targets.put("org.python.pydev.editor.PythonEditor", edit); //$NON-NLS-1$
         return targets;
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
@@ -57,7 +57,7 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
         private IAnnotationModel fAnnotationModel;
 
         /** Annotations to add. */
-        private Map fAddAnnotations;
+        private Map<SpellingAnnotation, Position> fAddAnnotations;
 
         /**
          * Initializes this collector with the given annotation model.
@@ -82,13 +82,12 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
          * @see org.eclipse.ui.texteditor.spelling.ISpellingProblemCollector#beginCollecting()
          */
         public void beginCollecting() {
-            fAddAnnotations = new HashMap();
+            fAddAnnotations = new HashMap<SpellingAnnotation, Position>();
         }
 
         /*
          * @see org.eclipse.ui.texteditor.spelling.ISpellingProblemCollector#endCollecting()
          */
-        @SuppressWarnings("unchecked")
         public void endCollecting() {
 
             List toRemove = new ArrayList();
@@ -110,7 +109,7 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
                 //retain that object locked (the annotation model is used on lots of places, so, retaining the lock
                 //on it on a minimum priority thread is not a good thing.
                 thread.setPriority(Thread.NORM_PRIORITY);
-                Iterator iter;
+                Iterator<SpellingAnnotation> iter;
 
                 synchronized (fLockObject) {
                     iter = fAnnotationModel.getAnnotationIterator();

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
@@ -43,7 +43,7 @@ public class PyWordRule implements IRule {
     /** The column constraint */
     protected int fColumn = UNDEFINED;
     /** The table of predefined words and token for this rule */
-    protected Map fWords = new HashMap();
+    protected Map<String, IToken> fWords = new HashMap<String, IToken>();
     /** Buffer used for pattern detection */
     private FastStringBuffer fBuffer = new FastStringBuffer();
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOrganizeImports.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOrganizeImports.java
@@ -476,7 +476,7 @@ public class PyOrganizeImports extends PyAction {
 
             Collections.sort(list);
             StringBuffer all = new StringBuffer();
-            for (Iterator iter = list.iterator(); iter.hasNext();) {
+            for (Iterator<String> iter = list.iterator(); iter.hasNext();) {
                 String element = (String) iter.next();
                 all.append(element);
                 if (iter.hasNext())

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapseAll.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapseAll.java
@@ -39,7 +39,7 @@ public class PyCollapseAll extends PyFoldingAction {
             if (iter != null) {
                 //we just want to collapse the leafs, and we are working only with the not collapsed sorted by offset.
 
-                List elements = new ArrayList(); //used to know the context
+                List<PyProjectionAnnotation> elements = new ArrayList<PyProjectionAnnotation>(); //used to know the context
                 while (iter.hasNext()) {
                     PyProjectionAnnotation element = (PyProjectionAnnotation) iter.next();
 
@@ -53,14 +53,14 @@ public class PyCollapseAll extends PyFoldingAction {
 
                         } else {
                             //ok, the one in the top has to be collapsed ( and this one added )
-                            PyProjectionAnnotation top = (PyProjectionAnnotation) elements.remove(elements.size() - 1);
+                            PyProjectionAnnotation top = elements.remove(elements.size() - 1);
                             model.collapse(top);
                             elements.add(element);
                         }
                     }
                 }
                 if (elements.size() > 0) {
-                    PyProjectionAnnotation top = (PyProjectionAnnotation) elements.remove(elements.size() - 1);
+                    PyProjectionAnnotation top = elements.remove(elements.size() - 1);
                     model.collapse(top);
                 }
             }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
@@ -29,13 +29,13 @@ public abstract class PyFoldingAction extends PyAction {
      * @param model
      * @return
      */
-    protected Iterator getAnnotationsIterator(final ProjectionAnnotationModel model, boolean useExpanded) {
+    protected Iterator<PyProjectionAnnotation> getAnnotationsIterator(final ProjectionAnnotationModel model, boolean useExpanded) {
         //put annotations in array list.
-        Iterator iter = model.getAnnotationIterator();
+        Iterator<PyProjectionAnnotation> iter = model.getAnnotationIterator();
         if (iter != null) {
 
             //get the not collapsed (expanded) and sort them
-            ArrayList expanded = new ArrayList();
+            ArrayList<PyProjectionAnnotation> expanded = new ArrayList<PyProjectionAnnotation>();
             while (iter.hasNext()) {
                 PyProjectionAnnotation element = (PyProjectionAnnotation) iter.next();
                 if (element.isCollapsed() == useExpanded) {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
@@ -32,12 +32,12 @@ public class PyUnCollapseAll extends PyFoldingAction {
 
         if (model != null) {
 
-            Iterator iter = getAnnotationsIterator(model, true);
+            Iterator<PyProjectionAnnotation> iter = getAnnotationsIterator(model, true);
 
             if (iter != null) {
                 //we just want to expand the roots, and we are working only with the collapsed sorted by offset.
 
-                List elements = new ArrayList(); //used to know the context
+                List<PyProjectionAnnotation> elements = new ArrayList<PyProjectionAnnotation>(); //used to know the context
                 while (iter.hasNext()) {
                     PyProjectionAnnotation element = (PyProjectionAnnotation) iter.next();
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
@@ -190,7 +190,7 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
 
     protected void initializeFields() {
 
-        Iterator e = fCheckBoxes.keySet().iterator();
+        Iterator<Button> e = fCheckBoxes.keySet().iterator();
         while (e.hasNext()) {
             Button b = (Button) e.next();
             String key = (String) fCheckBoxes.get(b);
@@ -208,7 +208,7 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
         //        updateStatus(validatePositiveNumber("0")); 
 
         // Update slaves
-        Iterator iter = fMasterSlaveListeners.iterator();
+        Iterator<SelectionListener> iter = fMasterSlaveListeners.iterator();
         while (iter.hasNext()) {
             SelectionListener listener = (SelectionListener) iter.next();
             listener.widgetSelected(null);

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
@@ -244,7 +244,7 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
 
         public void widgetSelected(SelectionEvent e) {
             Button button = (Button) e.widget;
-            fOverlayStore.setValue((String) fCheckBoxes.get(button), button.getSelection());
+            fOverlayStore.setValue(fCheckBoxes.get(button), button.getSelection());
         }
     };
 
@@ -252,7 +252,7 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
     protected ModifyListener fTextFieldListener = new ModifyListener() {
         public void modifyText(ModifyEvent e) {
             Text text = (Text) e.widget;
-            fOverlayStore.setValue((String) fTextFields.get(text), text.getText());
+            fOverlayStore.setValue(fTextFields.get(text), text.getText());
         }
     };
 
@@ -432,14 +432,14 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
         Iterator e = fCheckBoxes.keySet().iterator();
         while (e.hasNext()) {
             Button b = (Button) e.next();
-            String key = (String) fCheckBoxes.get(b);
+            String key = fCheckBoxes.get(b);
             b.setSelection(fOverlayStore.getBoolean(key));
         }
 
         e = fTextFields.keySet().iterator();
         while (e.hasNext()) {
             Text t = (Text) e.next();
-            String key = (String) fTextFields.get(t);
+            String key = fTextFields.get(t);
             t.setText(fOverlayStore.getString(key));
         }
 
@@ -447,9 +447,9 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
         updateStatus(validatePositiveNumber("0"));
 
         // Update slaves
-        Iterator iter = fMasterSlaveListeners.iterator();
+        Iterator<SelectionListener> iter = fMasterSlaveListeners.iterator();
         while (iter.hasNext()) {
-            SelectionListener listener = (SelectionListener) iter.next();
+            SelectionListener listener = iter.next();
             listener.widgetSelected(null);
         }
     }
@@ -599,7 +599,7 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
         String number = textControl.getText();
         IStatus status = validatePositiveNumber(number);
         if (!status.matches(IStatus.ERROR))
-            fOverlayStore.setValue((String) fTextFields.get(textControl), number);
+            fOverlayStore.setValue(fTextFields.get(textControl), number);
         updateStatus(status);
     }
 
@@ -625,7 +625,7 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
 
         if (!status.matches(IStatus.ERROR)) {
             for (int i = 0; i < fNumberFields.size(); i++) {
-                Text text = (Text) fNumberFields.get(i);
+                Text text = fNumberFields.get(i);
                 IStatus s = validatePositiveNumber(text.getText());
                 status = s.getSeverity() > status.getSeverity() ? s : status;
             }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/MenuManagerCopiedToAddCreateMenuWithMenuParent.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/MenuManagerCopiedToAddCreateMenuWithMenuParent.java
@@ -762,7 +762,7 @@ public class MenuManagerCopiedToAddCreateMenuWithMenuParent extends Contribution
             if (menuExist()) {
                 // clean contains all active items without double separators
                 IContributionItem[] items = getItems();
-                List clean = new ArrayList(items.length);
+                List<IContributionItem> clean = new ArrayList<IContributionItem>(items.length);
                 IContributionItem separator = null;
                 for (int i = 0; i < items.length; ++i) {
                     IContributionItem ci = items[i];
@@ -803,7 +803,7 @@ public class MenuManagerCopiedToAddCreateMenuWithMenuParent extends Contribution
                 int srcIx = 0;
                 int destIx = 0;
 
-                for (Iterator e = clean.iterator(); e.hasNext();) {
+                for (Iterator<IContributionItem> e = clean.iterator(); e.hasNext();) {
                     IContributionItem src = (IContributionItem) e.next();
                     IContributionItem dest;
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectFolderSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectFolderSelectionDialog.java
@@ -133,7 +133,7 @@ public class ProjectFolderSelectionDialog extends SelectionDialog {
      */
     protected void okPressed() {
 
-        List chosenContainerPathList = new ArrayList();
+        List<IPath> chosenContainerPathList = new ArrayList<IPath>();
         IPath returnValue = group.getContainerFullPath();
         if (returnValue != null)
             chosenContainerPathList.add(returnValue);

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectFolderSelectionGroup.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectFolderSelectionGroup.java
@@ -81,7 +81,7 @@ public class ProjectFolderSelectionGroup extends Composite {
                 if (showClosedProjects)
                     return allProjects;
 
-                ArrayList accessibleProjects = new ArrayList();
+                ArrayList<IProject> accessibleProjects = new ArrayList<IProject>();
                 for (int i = 0; i < allProjects.length; i++) {
                     if (allProjects[i].isOpen()) {
                         accessibleProjects.add(allProjects[i]);
@@ -92,7 +92,7 @@ public class ProjectFolderSelectionGroup extends Composite {
                 IContainer container = (IContainer) element;
                 if (container.isAccessible()) {
                     try {
-                        List children = new ArrayList();
+                        List<IResource> children = new ArrayList<IResource>();
                         IResource[] members = container.members();
                         for (int i = 0; i < members.length; i++) {
                             if (members[i].getType() != IResource.FILE) {
@@ -298,7 +298,7 @@ public class ProjectFolderSelectionGroup extends Composite {
                     IContainer container = (IContainer) element;
                     if (container.isAccessible()) {
                         try {
-                            List children = new ArrayList();
+                            List<IResource> children = new ArrayList<IResource>();
                             IResource[] members = container.members();
                             for (int i = 0; i < members.length; i++) {
                                 if (members[i].getType() != IResource.FILE) {
@@ -379,7 +379,7 @@ public class ProjectFolderSelectionGroup extends Composite {
         selectedContainer = container;
 
         //expand to and select the specified container
-        List itemsToExpand = new ArrayList();
+        List<IContainer> itemsToExpand = new ArrayList<IContainer>();
         IContainer parent = container.getParent();
         while (parent != null) {
             itemsToExpand.add(0, parent);

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
@@ -1004,6 +1004,7 @@ public abstract class AbstractInterpreterEditor extends PythonListEditor {
                                                     hashSet.remove("traceback");
                                                 }
                                             }
+                                            zipFile.close();
                                         } catch (Exception e) {
                                             //ignore (not zip file)
                                         }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
@@ -55,7 +55,7 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
             return;
         }
 
-        Map existing = (Map) this.attributes.get(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES);
+        Map<String, String> existing = (Map<String, String>) this.attributes.get(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES);
         HashMap<String, String> map = null;
         if (existing != null) {
             map = new HashMap<String, String>(existing);
@@ -127,7 +127,7 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
 
     }
 
-    public void setAttribute(String attributeName, List value) {
+    public void setAttribute(String attributeName, @SuppressWarnings("rawtypes") List value) {
         this.attributes.put(attributeName, value);
         if (attributeName.equals(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES)) {
             updateInfo();
@@ -135,7 +135,7 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
 
     }
 
-    public void setAttribute(String attributeName, Map value) {
+    public void setAttribute(String attributeName, @SuppressWarnings("rawtypes") Map value) {
         this.attributes.put(attributeName, value);
         if (attributeName.equals(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES)) {
             updateInfo();
@@ -143,7 +143,7 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
 
     }
 
-    public void setAttribute(String attributeName, Set value) {
+    public void setAttribute(String attributeName, @SuppressWarnings("rawtypes") Set value) {
         this.attributes.put(attributeName, value);
         if (attributeName.equals(ILaunchManager.ATTR_ENVIRONMENT_VARIABLES)) {
             updateInfo();
@@ -261,7 +261,7 @@ public class MyEnvWorkingCopy implements ILaunchConfigurationWorkingCopy {
         return defaultValue;
     }
 
-    public Map getAttributes() throws CoreException {
+    public Map<String, Object> getAttributes() throws CoreException {
         return this.attributes;
 
     }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyStringCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyStringCodeCompletion.java
@@ -261,8 +261,7 @@ public class PyStringCodeCompletion extends AbstractTemplateCodeCompletion {
      * @return completions added from contributors
      * @throws MisconfigurationException 
      */
-    @SuppressWarnings("unchecked")
-    private Collection<Object> getStringGlobalsFromParticipants(CompletionRequest request, ICompletionState state)
+    private Collection getStringGlobalsFromParticipants(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
         ArrayList ret = new ArrayList();
 

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonCompletionProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonCompletionProcessor.java
@@ -176,7 +176,7 @@ public class PythonCompletionProcessor extends AbstractCompletionProcessorWithCy
 
                 //THIRD: Get template proposals (if asked for)
                 if (request.showTemplates && (activationToken == null || activationToken.trim().length() == 0)) {
-                    List templateProposals = getTemplateProposals(viewer, documentOffset, activationToken, qualifier);
+                    List<ICompletionProposal> templateProposals = getTemplateProposals(viewer, documentOffset, activationToken, qualifier);
                     pythonAndTemplateProposals.addAll(templateProposals);
                 }
 
@@ -227,7 +227,7 @@ public class PythonCompletionProcessor extends AbstractCompletionProcessorWithCy
     /**
      * Returns the template proposals as a list.
      */
-    private List getTemplateProposals(ITextViewer viewer, int documentOffset, String activationToken,
+    private List<ICompletionProposal> getTemplateProposals(ITextViewer viewer, int documentOffset, String activationToken,
             java.lang.String qualifier) {
         List<ICompletionProposal> propList = new ArrayList<ICompletionProposal>();
         this.templatesCompletion.addTemplateProposals(viewer, documentOffset, propList);

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionParticipantsHelper.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionParticipantsHelper.java
@@ -26,7 +26,6 @@ public class CompletionParticipantsHelper {
      * @param state this is the state used for the completion
      * @param localScope this is the scope we're currently on (may be null)
      */
-    @SuppressWarnings("unchecked")
     public static Collection<IToken> getCompletionsForTokenWithUndefinedType(ICompletionState state,
             ILocalScope localScope) {
         IToken[] localTokens = localScope.getLocalTokens(-1, -1, false); //only to get the args
@@ -35,7 +34,7 @@ public class CompletionParticipantsHelper {
         for (IToken token : localTokens) {
             if (token.getRepresentation().equals(firstPart)) {
                 Collection<IToken> interfaceForLocal = localScope.getInterfaceForLocal(state.getActivationToken());
-                Collection argsCompletionFromParticipants = getCompletionsForTokenWithUndefinedTypeFromParticipants(
+                Collection<IToken> argsCompletionFromParticipants = getCompletionsForTokenWithUndefinedTypeFromParticipants(
                         state, localScope, interfaceForLocal);
                 return argsCompletionFromParticipants;
             }
@@ -46,13 +45,12 @@ public class CompletionParticipantsHelper {
     /**
      * If we were unable to find its type, pass that over to other completion participants.
      */
-    @SuppressWarnings("unchecked")
     public static Collection<IToken> getCompletionsForTokenWithUndefinedTypeFromParticipants(ICompletionState state,
             ILocalScope localScope, Collection<IToken> interfaceForLocal) {
-        ArrayList ret = new ArrayList();
+        ArrayList<IToken> ret = new ArrayList<IToken>();
 
-        List participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_COMPLETION);
-        for (Iterator iter = participants.iterator(); iter.hasNext();) {
+        List<?> participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_COMPLETION);
+        for (Iterator<?> iter = participants.iterator(); iter.hasNext();) {
             IPyDevCompletionParticipant participant = (IPyDevCompletionParticipant) iter.next();
             ret.addAll(participant.getCompletionsForTokenWithUndefinedType(state, localScope, interfaceForLocal));
         }
@@ -65,7 +63,6 @@ public class CompletionParticipantsHelper {
      * @param state this is the state used for the completion
      * @param localScope this is the scope we're currently on (may be null)
      */
-    @SuppressWarnings("unchecked")
     public static Collection<IToken> getCompletionsForMethodParameter(ICompletionState state, ILocalScope localScope) {
         IToken[] args = localScope.getLocalTokens(-1, -1, true); //only to get the args
         String activationToken = state.getActivationToken();
@@ -73,7 +70,8 @@ public class CompletionParticipantsHelper {
         for (IToken token : args) {
             if (token.getRepresentation().equals(firstPart)) {
                 Collection<IToken> interfaceForLocal = localScope.getInterfaceForLocal(state.getActivationToken());
-                Collection argsCompletionFromParticipants = getCompletionsForMethodParameterFromParticipants(state,
+                Collection<IToken> argsCompletionFromParticipants = getCompletionsForMethodParameterFromParticipants(
+                        state,
                         localScope, interfaceForLocal);
                 for (IToken t : interfaceForLocal) {
                     if (!t.getRepresentation().equals(state.getQualifier())) {
@@ -89,13 +87,12 @@ public class CompletionParticipantsHelper {
     /**
      * If we were able to find it as a method parameter, this method is called so that clients can extend those completions.
      */
-    @SuppressWarnings("unchecked")
     public static Collection<IToken> getCompletionsForMethodParameterFromParticipants(ICompletionState state,
             ILocalScope localScope, Collection<IToken> interfaceForLocal) {
-        ArrayList ret = new ArrayList();
+        ArrayList<IToken> ret = new ArrayList<IToken>();
 
-        List participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_COMPLETION);
-        for (Iterator iter = participants.iterator(); iter.hasNext();) {
+        List<?> participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_COMPLETION);
+        for (Iterator<?> iter = participants.iterator(); iter.hasNext();) {
             IPyDevCompletionParticipant participant = (IPyDevCompletionParticipant) iter.next();
             ret.addAll(participant.getCompletionsForMethodParameter(state, localScope, interfaceForLocal));
         }

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyPublicTreeMap.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyPublicTreeMap.java
@@ -179,7 +179,7 @@ public final class PyPublicTreeMap<K, V> extends AbstractMap<K, V> implements So
         return (root == null ? false : (value == null ? valueSearchNull(root) : valueSearchNonNull(root, value)));
     }
 
-    private boolean valueSearchNull(Entry n) {
+    private boolean valueSearchNull(Entry<K, V> n) {
         if (n.value == null)
             return true;
 
@@ -187,7 +187,7 @@ public final class PyPublicTreeMap<K, V> extends AbstractMap<K, V> implements So
         return (n.left != null && valueSearchNull(n.left)) || (n.right != null && valueSearchNull(n.right));
     }
 
-    private boolean valueSearchNonNull(Entry n, Object value) {
+    private boolean valueSearchNonNull(Entry<K, V> n, Object value) {
         // Check this node for the value
         if (value.equals(n.value))
             return true;
@@ -890,7 +890,7 @@ public final class PyPublicTreeMap<K, V> extends AbstractMap<K, V> implements So
                 K key = entry.getKey();
                 if (!inRange(key))
                     return false;
-                PyPublicTreeMap.Entry node = getEntry(key);
+                PyPublicTreeMap.Entry<K, V> node = getEntry(key);
                 return node != null && valEquals(node.getValue(), entry.getValue());
             }
 

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
@@ -318,7 +318,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
                 } else {
                     //the new references (later in the module) are always added to the head of the position...
                     if (current instanceof List) {
-                        ((List) current).add(0, newSourceToken);
+                        ((List<SourceToken>) current).add(0, newSourceToken);
 
                     } else if (current instanceof SourceToken) {
                         ArrayList<SourceToken> lst = new ArrayList<SourceToken>();
@@ -358,7 +358,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
             if (o instanceof SourceToken) {
                 ret.add((SourceToken) o);
             } else if (o instanceof List) {
-                ret.addAll((List) o);
+                ret.addAll((List<SourceToken>) o);
             } else {
                 throw new RuntimeException("Unexpected class in cache:" + o);
             }
@@ -611,7 +611,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
      */
     @SuppressWarnings("unchecked")
     private FindScopeVisitor getScopeVisitor(int line, int col) throws Exception {
-        Tuple key = new Tuple(line, col);
+        Tuple<Integer, Integer> key = new Tuple<Integer, Integer>(line, col);
         FindScopeVisitor scopeVisitor = this.scopeVisitorCache.getObj(key);
         if (scopeVisitor == null) {
             scopeVisitor = new FindScopeVisitor(line, col);
@@ -628,7 +628,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
      */
     @SuppressWarnings("unchecked")
     private FindDefinitionModelVisitor getFindDefinitionsScopeVisitor(String rep, int line, int col) throws Exception {
-        Tuple3 key = new Tuple3(rep, line, col);
+        Tuple3<String, Integer, Integer> key = new Tuple3<String, Integer, Integer>(rep, line, col);
         FindDefinitionModelVisitor visitor = this.findDefinitionVisitorCache.getObj(key);
         if (visitor == null) {
             visitor = new FindDefinitionModelVisitor(rep, line, col, this);

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/InnerModelVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/InnerModelVisitor.java
@@ -35,7 +35,7 @@ public class InnerModelVisitor extends AbstractVisitor {
     /**
      * List that contains heuristics to find attributes.
      */
-    private final List attrsHeuristics = new ArrayList();
+    private final List<HeuristicFindAttrs> attrsHeuristics = new ArrayList<HeuristicFindAttrs>();
 
     private final Map<String, SourceToken> repToTokenWithArgs = new HashMap<String, SourceToken>();
 
@@ -103,7 +103,7 @@ public class InnerModelVisitor extends AbstractVisitor {
             addToken(node);
 
             //iterate heuristics to find attributes
-            for (Iterator iter = attrsHeuristics.iterator(); iter.hasNext();) {
+            for (Iterator<HeuristicFindAttrs> iter = attrsHeuristics.iterator(); iter.hasNext();) {
                 HeuristicFindAttrs element = (HeuristicFindAttrs) iter.next();
                 element.visitFunctionDef(node);
                 addElementTokens(element);
@@ -120,7 +120,7 @@ public class InnerModelVisitor extends AbstractVisitor {
         if (visiting == VISITING_CLASS) {
 
             //iterate heuristics to find attributes
-            for (Iterator iter = attrsHeuristics.iterator(); iter.hasNext();) {
+            for (Iterator<HeuristicFindAttrs> iter = attrsHeuristics.iterator(); iter.hasNext();) {
                 HeuristicFindAttrs element = (HeuristicFindAttrs) iter.next();
                 element.visitAssign(node);
                 addElementTokens(element);
@@ -136,7 +136,7 @@ public class InnerModelVisitor extends AbstractVisitor {
         if (visiting == VISITING_CLASS) {
 
             //iterate heuristics to find attributes
-            for (Iterator iter = attrsHeuristics.iterator(); iter.hasNext();) {
+            for (Iterator<HeuristicFindAttrs> iter = attrsHeuristics.iterator(); iter.hasNext();) {
                 HeuristicFindAttrs element = (HeuristicFindAttrs) iter.next();
                 element.visitCall(node);
                 addElementTokens(element);

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContext.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContext.java
@@ -57,23 +57,23 @@ public final class PyDocumentTemplateContext extends DocumentTemplateContextWith
         return new PySelection(getDocument(), getStart());
     }
 
-    public Class getFastParserClass() {
+    public Class<FastParser> getFastParserClass() {
         return FastParser.class;
     }
 
-    public Class getNodeUtilsClass() {
+    public Class<NodeUtils> getNodeUtilsClass() {
         return NodeUtils.class;
     }
 
-    public Class getFunctionDefClass() {
+    public Class<FunctionDef> getFunctionDefClass() {
         return FunctionDef.class;
     }
 
-    public Class getClassDefClass() {
+    public Class<ClassDef> getClassDefClass() {
         return ClassDef.class;
     }
 
-    public Class getBadLocationExceptionClass() {
+    public Class<BadLocationException> getBadLocationExceptionClass() {
         return BadLocationException.class;
     }
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ProjectInfoForPackageExplorer.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ProjectInfoForPackageExplorer.java
@@ -170,14 +170,13 @@ public class ProjectInfoForPackageExplorer {
      * 
      * This method should only be called through recreateInfo.
      */
-    @SuppressWarnings("unchecked")
     private Tuple<List<ProjectConfigError>, IInterpreterInfo> getConfigErrorsAndInfo(IProject project) {
         if (project == null || !project.isOpen()) {
-            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList(), null);
+            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList<ProjectConfigError>(), null);
         }
         PythonNature nature = PythonNature.getPythonNature(project);
         if (nature == null) {
-            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList(), null);
+            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList<ProjectConfigError>(), null);
         }
 
         //If the info is not readily available, we try to get some more times... after that, if still not available,
@@ -199,7 +198,7 @@ public class ProjectInfoForPackageExplorer {
             }
         }
         if (configErrorsAndInfo == null) {
-            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList(), null);
+            return new Tuple<List<ProjectConfigError>, IInterpreterInfo>(new ArrayList<ProjectConfigError>(), null);
         }
 
         if (nature != null) {

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyCopyResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyCopyResourceAction.java
@@ -69,7 +69,7 @@ public class PyCopyResourceAction extends CopyAction {
     }
 
     @Override
-    protected List getSelectedResources() {
+    protected List<IResource> getSelectedResources() {
         return selected;
     }
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyDeleteResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyDeleteResourceAction.java
@@ -78,7 +78,7 @@ public class PyDeleteResourceAction extends DeleteResourceAction {
     }
 
     @Override
-    protected List getSelectedResources() {
+    protected List<IResource> getSelectedResources() {
         return selected;
     }
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyMoveResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyMoveResourceAction.java
@@ -68,7 +68,7 @@ public class PyMoveResourceAction extends MoveResourceAction {
     }
 
     @Override
-    protected List getSelectedResources() {
+    protected List<IResource> getSelectedResources() {
         return selected;
     }
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyPasteAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyPasteAction.java
@@ -71,7 +71,7 @@ public class PyPasteAction extends PasteAction {
     }
 
     @Override
-    protected List getSelectedResources() {
+    protected List<IResource> getSelectedResources() {
         return selected;
     }
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
@@ -114,7 +114,7 @@ public class PyRenameResourceAction extends RenameResourceAction {
     }
 
     @Override
-    protected List getSelectedResources() {
+    protected List<IResource> getSelectedResources() {
         return selected;
     }
 
@@ -131,7 +131,7 @@ public class PyRenameResourceAction extends RenameResourceAction {
             return;
         }
         IEditorPart[] dirtyEditors = Helpers.checkValidateState();
-        List resources = getSelectedResources();
+        List<IResource> resources = getSelectedResources();
         if (resources.size() == 1) {
             IResource r = (IResource) resources.get(0);
             if (r instanceof IFile) {

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyFilesAndFoldersOperation.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyFilesAndFoldersOperation.java
@@ -297,8 +297,7 @@ public class CopyFilesAndFoldersOperation {
      * @param existing
      *            holds the collected existing files
      */
-    @SuppressWarnings("unchecked")
-    private void collectExistingReadonlyFiles(IPath destinationPath, IResource[] copyResources, ArrayList existing) {
+    private void collectExistingReadonlyFiles(IPath destinationPath, IResource[] copyResources, ArrayList<IFile> existing) {
         IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
 
         for (int i = 0; i < copyResources.length; i++) {
@@ -1326,9 +1325,8 @@ public class CopyFilesAndFoldersOperation {
      *         files to validate. <code>false</code> one or more files did not
      *         pass validation.
      */
-    @SuppressWarnings("unchecked")
     private boolean validateEdit(IContainer destination, IResource[] sourceResources) {
-        ArrayList copyFiles = new ArrayList();
+        ArrayList<IFile> copyFiles = new ArrayList<IFile>();
 
         collectExistingReadonlyFiles(destination.getFullPath(), sourceResources, copyFiles);
         if (copyFiles.size() > 0) {
@@ -1473,9 +1471,8 @@ public class CopyFilesAndFoldersOperation {
      * @return <code>true</code> if there would be no name collisions, and
      *         <code>false</code> if there would
      */
-    @SuppressWarnings("unchecked")
     private IResource[] validateNoNameCollisions(IContainer destination, IResource[] sourceResources) {
-        List copyItems = new ArrayList();
+        List<IResource> copyItems = new ArrayList<IResource>();
         IWorkspaceRoot workspaceRoot = destination.getWorkspace().getRoot();
         int overwrite = IDialogConstants.NO_ID;
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/WorkspaceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/WorkspaceAction.java
@@ -111,7 +111,7 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
      * @param monitor a progress monitor
      * @return The result of the execution
      */
-    final IStatus execute(List resources, IProgressMonitor monitor) {
+    final IStatus execute(List<IResource> resources, IProgressMonitor monitor) {
         MultiStatus errors = null;
         //1FTIMQN: ITPCORE:WIN - clients required to do too much iteration work
         if (shouldPerformResourcePruning()) {
@@ -124,10 +124,10 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
         // call setTaskName as its the only was to assure the task name is
         // set in the monitor (see bug 31824)
         monitor.setTaskName(getOperationMessage());
-        Iterator resourcesEnum = resources.iterator();
+        Iterator<IResource> resourcesEnum = resources.iterator();
         try {
             while (resourcesEnum.hasNext()) {
-                IResource resource = (IResource) resourcesEnum.next();
+                IResource resource = resourcesEnum.next();
                 try {
                     // 1FV0B3Y: ITPUI:ALL - sub progress monitors granularity issues
                     invokeOperation(resource, new SubProgressMonitor(monitor, 1000));
@@ -229,7 +229,7 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
      * @return <code>true</code> if <code>child</code> is a descendent of any of the
      *   elements of <code>resources</code>
      */
-    boolean isDescendent(List resources, IResource child) {
+    boolean isDescendent(List<IResource> resources, IResource child) {
         IResource parent = child.getParent();
         return parent != null && (resources.contains(parent) || isDescendent(resources, parent));
     }
@@ -244,12 +244,11 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
      *      after pruning. 
      * @see #shouldPerformResourcePruning
      */
-    @SuppressWarnings("unchecked")
-    List pruneResources(List resourceCollection) {
-        List prunedList = new ArrayList(resourceCollection);
-        Iterator elementsEnum = prunedList.iterator();
+    List<IResource> pruneResources(List<IResource> resourceCollection) {
+        List<IResource> prunedList = new ArrayList<IResource>(resourceCollection);
+        Iterator<IResource> elementsEnum = prunedList.iterator();
         while (elementsEnum.hasNext()) {
-            IResource currentResource = (IResource) elementsEnum.next();
+            IResource currentResource = elementsEnum.next();
             if (isDescendent(prunedList, currentResource)) {
                 elementsEnum.remove(); //Removes currentResource
             }
@@ -338,8 +337,8 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
         if (!super.updateSelection(selection) || selection.isEmpty()) {
             return false;
         }
-        for (Iterator i = getSelectedResources().iterator(); i.hasNext();) {
-            IResource r = (IResource) i.next();
+        for (Iterator<IResource> i = getSelectedResources().iterator(); i.hasNext();) {
+            IResource r = i.next();
             if (!r.isAccessible()) {
                 return false;
             }
@@ -355,8 +354,8 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
      *
      * @return list of resource elements (element type: <code>IResource</code>)
      */
-    protected List getActionResources() {
-        return getSelectedResources();
+    protected List<IResource> getActionResources() {
+        return (List<IResource>) getSelectedResources();
     }
 
     /**
@@ -397,10 +396,9 @@ public abstract class WorkspaceAction extends SelectionListenerAction {
      * 
      * @since 3.1
      */
-    @SuppressWarnings("unchecked")
     public void runInBackground(ISchedulingRule rule, final Object[] jobFamilies) {
         //obtain a copy of the selected resources before the job is forked
-        final List resources = new ArrayList(getActionResources());
+        final List<IResource> resources = new ArrayList<IResource>(getActionResources());
         Job job = new WorkspaceJob(removeMnemonics(getText())) {
 
             /* (non-Javadoc)

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/properties/StringMatcherSimple.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/properties/StringMatcherSimple.java
@@ -151,7 +151,7 @@ public class StringMatcherSimple {
             }
         }
 
-        ArrayList temp = new ArrayList();
+        ArrayList<String> temp = new ArrayList<String>();
 
         int pos = 0;
         StringBuffer buf = new StringBuffer();
@@ -195,7 +195,7 @@ public class StringMatcherSimple {
             temp.add(buf.toString());
             bound += buf.length();
         }
-        segments = (String[]) temp.toArray(new String[temp.size()]);
+        segments = temp.toArray(new String[temp.size()]);
     }
 
     /**

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
@@ -110,7 +110,7 @@ public class InterpreterInfoTest extends TestCase {
         forced.add("forced1");
         InterpreterInfo info6 = new InterpreterInfo("2.4", "test", l4, dlls, forced);
 
-        InterpreterInfo info7 = new InterpreterInfo("2.4", "test", new ArrayList(), new ArrayList(), forced);
+        InterpreterInfo info7 = new InterpreterInfo("2.4", "test", new ArrayList<String>(), new ArrayList<String>(), forced);
         info7.addPredefinedCompletionsPath("c:\\temp");
 
         assertEquals(info, info2);

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceStub.java
@@ -109,7 +109,7 @@ public class WorkspaceStub implements IWorkspace {
         return null;
     }
 
-    public Map getDanglingReferences() {
+    public Map<IProject, IProject[]> getDanglingReferences() {
         return null;
     }
 


### PR DESCRIPTION
Other than Jython source code and ast-related classes, resolve warnings that complain about raw types without parameters. Only fix warnings that don't cause issues elsewhere, so many warnings still exist (but shouldn't be a big issue).
