### PR TITLE
Fix some tests by updating an adapter class reference.

### DIFF
--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -2605,9 +2605,9 @@ if __name__ == "__main__":
          point="org.eclipse.core.runtime.adapters">
       <factory
             adaptableType="org.eclipse.jface.viewers.ISelection"
-            class="org.python.pydev.dltk.console.codegen.ScriptConsoleCodeGeneratorFactory">
+            class="org.python.pydev.shared_interactive_console.console.codegen.ScriptConsoleCodeGeneratorFactory">
          <adapter
-               type="org.python.pydev.dltk.console.codegen.IScriptConsoleCodeGenerator">
+               type="org.python.pydev.shared_interactive_console.console.codegen.IScriptConsoleCodeGenerator">
          </adapter>
       </factory>
    </extension>


### PR DESCRIPTION
When running StructuredSelectionGeneratorTestWorkbench, all but one of the tests fail with an NPE. This is happening from 'PythonSnippetUtils.getScriptConsoleCodeGeneratorAdapter(selection)' , which is returning null due to an adapter extension that needs to be updated.

Commit 498f321 renamed ""org.python.pydev.dltk.console.codegen.ScriptConsoleCodeGeneratorFactory" -> "org.python.pydev.shared_interactive_console.console.codegen.ScriptConsoleCodeGeneratorFactory" and "org.python.pydev.dltk.console.codegen.IScriptConsoleCodeGenerator" -> "org.python.pydev.shared_interactive_console.console.codegen.IScriptConsoleCodeGenerator" but did not update org.python.pydev/plugin.xml.
