### PR TITLE
Add Cancel button to Select Test dialog.

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
@@ -17,6 +17,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.jface.viewers.ITreeContentProvider;
 import org.eclipse.jface.viewers.LabelProvider;
@@ -106,7 +107,14 @@ public class RunEditorAsCustomUnitTestAction extends AbstractRunEditorAction {
                     }
 
                 });
+                super.createButtonBar(parent);
                 return configTestRunner;
+            }
+
+            @Override
+            protected void createButtonsForButtonBar(Composite parent) {
+                createButton(parent, IDialogConstants.CANCEL_ID,
+                        IDialogConstants.CANCEL_LABEL, false);
             }
 
             protected Point getInitialSize() {


### PR DESCRIPTION
The dialog for "Select tests to run" (Ctrl+F9) has no cancel button, so the only way to close
it is with Alt+F4. Add a Cancel button to make closing the dialog more natural.
