### PR TITLE
Include Working Set configuration to the New PyDev Project wizards.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/IWizardNewProjectNameAndLocationPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/IWizardNewProjectNameAndLocationPage.java
@@ -9,6 +9,7 @@ package org.python.pydev.ui.wizards.project;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.jface.wizard.IWizardPage;
+import org.eclipse.ui.IWorkingSet;
 import org.python.pydev.core.IPythonNature;
 
 /**
@@ -56,5 +57,12 @@ public interface IWizardNewProjectNameAndLocationPage extends IWizardPage {
      * want to give the user a visual indication that it's the Default interpreter if that's the one selected)
      */
     public String getProjectInterpreter();
+
+    /**
+     * Returns the working sets to which the new project should be added.
+     *
+     * @return the selected working sets to which the new project should be added
+     */
+    public IWorkingSet[] getWorkingSets();
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
@@ -29,8 +29,11 @@ import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkingSet;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
+import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.PyStructureConfigHelpers;
 import org.python.pydev.plugin.PydevPlugin;
@@ -215,8 +218,14 @@ public class PythonProjectWizard extends AbstractNewProjectWizard implements IEx
     public boolean performFinish() {
         createdProject = createNewProject();
 
+        IWorkingSet[] workingSets = projectPage.getWorkingSets();
+        if (workingSets.length > 0) {
+            PlatformUI.getWorkbench().getWorkingSetManager().addToWorkingSets(createdProject, workingSets);
+        }
+
         // Switch to default perspective (will ask before changing)
         BasicNewProjectResourceWizard.updatePerspective(fConfigElement);
+        BasicNewResourceWizard.selectAndReveal(createdProject, workbench.getActiveWorkbenchWindow());
 
         return true;
     }


### PR DESCRIPTION
Dedicate a section of the New PyDev Project wizards for adding the project to working sets,
as new project wizards for Java, Javascript, andi some other resource types, do. This change
affects all three PyDev project types: standard, Django, and Google App Engine.

---

The working set code was taken from org.eclipse.jdt.ui. To my knowledge everything works fine, despite Eclipse throwing warnings telling me that I shouldn't be referencing things from org.eclipse.jdt.
