### PR TITLE
Fix bug 866189: prevent Unittest errors caused by setUpClass/setUpModule...

### DIFF
--- a/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleClass_test.py
+++ b/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleClass_test.py
@@ -1,0 +1,14 @@
+import unittest
+
+class SetUpClassTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        raise ValueError("This is an INTENTIONAL value error in setUpClass.")
+
+    def test_blank(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleModule_test.py
+++ b/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleModule_test.py
@@ -1,0 +1,16 @@
+import unittest
+
+def setUpModule():
+    raise ValueError("This is an INTENTIONAL value error in setUpModule.")
+
+class SetUpModuleTest(unittest.TestCase):
+    
+    def setUp(cls):
+        pass
+
+    def test_blank(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
... exceptions

When an exception is present in setUpClass or setUpModule methods for Unittest
modules, it causes an error in PyDev's PyUnit interface. The error occurs because
the file path is a property of the test variable only when running a custom test
module, not a class or module set up. Correct this error by obtaining file path
from the error output string instead.

An exception in setUpClass/Module also causes an error when trying to access the
name of the test method being called. Correct this error by creating special cases
for these setup methods.

---

One more fix is coming after this. Right now, only tests that are run in the main module show up in the PyUnit view (importing another module and running its tests prints results to stdout, but aren't shown by the PyUnit view). I'm going to change things to the PyUnit view to display errors/failures in imported modules.

EDIT: From an old blog post of yours, I just discovered that I can run an entire source folder with Unittest. So the problem wanted to fix isn't there at all. :) So forget what I said about the one more fix.
