### PR TITLE
Remove more unused imports, variables, and private methods.

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/TreeIO.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/TreeIO.java
@@ -18,7 +18,6 @@ import java.util.SortedMap;
 import org.python.pydev.core.FastBufferedReader;
 import org.python.pydev.core.ObjectsPool;
 import org.python.pydev.core.ObjectsPool.ObjectsPoolMap;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.PyPublicTreeMap;
 import org.python.pydev.shared_core.string.FastStringBuffer;

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
@@ -27,7 +27,6 @@ import org.python.pydev.editor.codecompletion.revisited.visitors.AbstractVisitor
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.jython.ast.Assign;
 import org.python.pydev.parser.jython.ast.Attribute;
-import org.python.pydev.parser.jython.ast.Call;
 import org.python.pydev.parser.jython.ast.Import;
 import org.python.pydev.parser.jython.ast.ImportFrom;
 import org.python.pydev.parser.jython.ast.Name;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyRenameResourceChange.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyRenameResourceChange.java
@@ -13,7 +13,6 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-import org.python.pydev.core.docutils.StringUtils;
 
 /**
  * Largely gotten from org.eclipse.jdt.internal.corext.refactoring.changes.RenameResourceChange

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindDefinition.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindDefinition.java
@@ -18,7 +18,6 @@ import org.python.pydev.core.ICodeCompletionASTManager;
 import org.python.pydev.core.IDefinition;
 import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.MisconfigurationException;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.editor.codecompletion.revisited.CompletionCache;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFinds.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFinds.java
@@ -27,7 +27,6 @@ import org.python.pydev.core.IModule;
 import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.MisconfigurationException;
 import org.python.pydev.core.ModulesKey;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.CompletionCache;
 import org.python.pydev.editor.codecompletion.revisited.modules.SourceModule;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
@@ -96,12 +96,10 @@ public class TddCodeGenerationQuickFixParticipant extends AbstractAnalysisMarker
                     ItemPointer[] pointers = null;
                     PySelection callPs = null;
                     TddPossibleMatches lastPossibleMatchNotFound = possibleMatch;
-                    String lastCallWithoutParensNotFound = callWithoutParens;
 
                     for (int i = 0; i < 10; i++) { //more than 10 attribute accesses in a line? No way!
 
                         lastPossibleMatchNotFound = possibleMatch;
-                        lastCallWithoutParensNotFound = callWithoutParens;
                         if (i > 0) {
                             //We have to take 1 level out of the match... i.e.: if it was self.foo.get(), search now for self.foo.
                             String line = FullRepIterable.getWithoutLastPart(possibleMatch.full);

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/PySearchInOpenDocumentsAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/PySearchInOpenDocumentsAction.java
@@ -14,7 +14,6 @@ import org.eclipse.jface.dialogs.IDialogSettings;
 import org.eclipse.jface.dialogs.InputDialog;
 import org.eclipse.ui.internal.texteditor.TextEditorPlugin;
 import org.python.pydev.core.docutils.PySelection;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.IOfflineActionWithParameters;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.shared_ui.EditorUtils;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/RefactorProcessFactory.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/RefactorProcessFactory.java
@@ -9,7 +9,6 @@
  */
 package com.python.pydev.refactoring.wizards;
 
-import org.python.pydev.core.IPythonNature;
 import org.python.pydev.editor.codecompletion.revisited.visitors.AssignDefinition;
 import org.python.pydev.editor.codecompletion.revisited.visitors.Definition;
 import org.python.pydev.editor.codecompletion.revisited.visitors.KeywordParameterDefinition;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAnyLocalProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAnyLocalProcess.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.refactoring.RefactoringRequest;
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.visitors.scope.ASTEntry;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameImportProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameImportProcess.java
@@ -13,7 +13,6 @@ import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.python.pydev.core.IModule;
 import org.python.pydev.core.ISystemModulesManager;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.CompletionCache;
 import org.python.pydev.editor.codecompletion.revisited.modules.ASTEntryWithSourceModule;

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/TextEditCreation.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/TextEditCreation.java
@@ -27,7 +27,6 @@ import org.eclipse.text.edits.ReplaceEdit;
 import org.eclipse.text.edits.TextEdit;
 import org.eclipse.text.edits.TextEditGroup;
 import org.python.pydev.core.FileUtilsFileBuffer;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.codecompletion.revisited.modules.ASTEntryWithSourceModule;
 import org.python.pydev.editor.refactoring.RefactoringRequest;
 import org.python.pydev.editorinput.PySourceLocatorBase;

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringRenameTestBase.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringRenameTestBase.java
@@ -29,7 +29,6 @@ import org.python.pydev.core.MisconfigurationException;
 import org.python.pydev.core.ModulesKey;
 import org.python.pydev.core.TestDependent;
 import org.python.pydev.core.docutils.PySelection;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.codecompletion.revisited.ASTManager;
 import org.python.pydev.editor.codecompletion.revisited.ProjectStub;
 import org.python.pydev.editor.codecompletion.revisited.modules.AbstractModule;

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RefactoringLocalTestBase.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RefactoringLocalTestBase.java
@@ -18,7 +18,6 @@ import org.eclipse.ltk.core.refactoring.Change;
 import org.eclipse.ltk.core.refactoring.RefactoringStatus;
 import org.eclipse.ltk.core.refactoring.RefactoringStatusEntry;
 import org.python.pydev.core.docutils.PySelection;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.codecompletion.revisited.CodeCompletionTestsBase;
 import org.python.pydev.editor.codecompletion.revisited.modules.CompiledModule;
 import org.python.pydev.editor.refactoring.AbstractPyRefactoring;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SendPyExceptionCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SendPyExceptionCommand.java
@@ -6,7 +6,6 @@
  */
 package org.python.pydev.debug.model.remote;
 
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.debug.core.ConfigureExceptionsFileUtils;
 import org.python.pydev.debug.model.AbstractDebugTarget;
 import org.python.pydev.debug.model.PyExceptionBreakPointManager;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonSourceViewer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonSourceViewer.java
@@ -221,7 +221,6 @@ public class PythonSourceViewer extends SourceViewer implements IPropertyChangeL
      * @see IPropertyChangeListener#propertyChange(PropertyChangeEvent)
      */
     public void propertyChange(PropertyChangeEvent event) {
-        IContentAssistant assistant = getContentAssistant();
         String property = event.getProperty();
 
         if (JFaceResources.TEXT_FONT.equals(property)) {

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/PythonPathBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/PythonPathBlock.java
@@ -16,7 +16,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.List;
 import org.python.pydev.core.IInterpreterManager;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.debug.core.Constants;
 import org.python.pydev.debug.ui.launching.PythonRunnerConfig;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
@@ -44,17 +44,9 @@ public class PythonBreakpointPage extends PropertyPage {
 
     private Button fEnableConditionButton;
     private BreakpointConditionEditor fConditionEditor;
-    private Label fConditionIsTrue;
-    private Button fConditionHasChanged;
-    private Label fSuspendWhenLabel;
-    // Watchpoint editors
-    private Button fFieldAccess;
-    private Button fFieldModification;
-    // Method breakpoint editors
-    private Button fMethodEntry;
-    private Button fMethodExit;
-
-    private static final String fgMethodBreakpointError = "Must suspend on method entry or exit";//$NON-NLS-1$
+    //private Label fConditionIsTrue;
+    //private Button fConditionHasChanged;
+    //private Label fSuspendWhenLabel;
 
     protected Button fEnabledButton;
     protected Button fHitCountButton;
@@ -225,14 +217,6 @@ public class PythonBreakpointPage extends PropertyPage {
         }
     }
 
-    private void validateMethodBreakpoint() {
-        if (fEnabledButton.getSelection() && !(fMethodEntry.getSelection() || fMethodExit.getSelection())) {
-            addErrorMessage(fgMethodBreakpointError);
-        } else {
-            removeErrorMessage(fgMethodBreakpointError);
-        }
-    }
-
     /**
      * Creates a fully configured check button with the given text.
      * @param parent the parent composite
@@ -324,8 +308,6 @@ public class PythonBreakpointPage extends PropertyPage {
         if (fConditionEditor != null) {
             boolean enableCondition = fEnableConditionButton.getSelection();
             String condition = fConditionEditor.getCondition();
-            //boolean suspendOnTrue= fConditionIsTrue.getSelection();
-            boolean suspendOnTrue = true;
             if (breakpoint.isConditionEnabled() != enableCondition) {
                 breakpoint.setConditionEnabled(enableCondition);
             }

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
@@ -11,7 +11,6 @@ package org.python.pydev.debug.newconsole.env;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.List;
 

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/XmlRpcTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/XmlRpcTest.java
@@ -23,7 +23,6 @@ import org.apache.xmlrpc.server.XmlRpcNoSuchHandlerException;
 import org.apache.xmlrpc.server.XmlRpcServer;
 import org.apache.xmlrpc.webserver.WebServer;
 import org.python.pydev.core.TestDependent;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.shared_core.io.FileUtils;
 import org.python.pydev.shared_core.io.ThreadStreamReader;
 import org.python.pydev.shared_core.net.SocketUtil;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeSelection.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeSelection.java
@@ -19,7 +19,6 @@ import org.eclipse.jface.text.TextSelection;
 import org.eclipse.ui.texteditor.ITextEditor;
 import org.python.pydev.core.docutils.PySelection;
 import org.python.pydev.core.docutils.PythonPairMatcher;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.parser.fastparser.ScopesParser;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPrefs.java
@@ -16,7 +16,6 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.texteditor.ITextEditorActionDefinitionIds;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.docutils.WrapAndCaseUtils;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.preferences.AbstractPydevPrefs;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/RefactoringRequest.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/RefactoringRequest.java
@@ -26,7 +26,6 @@ import org.python.pydev.editor.codecompletion.revisited.modules.SourceModule;
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.nature.PythonNature;
-import org.python.pydev.plugin.nature.SystemPythonNature;
 import org.python.pydev.shared_core.structure.Tuple;
 
 /**

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureStore.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureStore.java
@@ -44,7 +44,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.QualifiedName;
 import org.eclipse.core.runtime.Status;
 import org.python.pydev.core.MisconfigurationException;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.ProjectModulesManager;
 import org.python.pydev.shared_core.io.FileUtils;

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevRootPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevRootPrefs.java
@@ -11,7 +11,6 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.plugin.PydevPlugin;
 
 public class PydevRootPrefs extends PreferencePage implements IWorkbenchPreferencePage {

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
@@ -22,7 +22,6 @@ import org.python.copiedfromeclipsesrc.JDTNotAvailableException;
 import org.python.copiedfromeclipsesrc.JavaVmLocationFinder;
 import org.python.pydev.core.IInterpreterManager;
 import org.python.pydev.core.MisconfigurationException;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.nature.PythonNature;
 import org.python.pydev.plugin.preferences.PydevPrefs;

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
@@ -32,7 +32,6 @@ import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.IPythonPathNature;
 import org.python.pydev.core.MisconfigurationException;
 import org.python.pydev.core.docutils.StringSubstitution;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.shared_core.io.FileUtils;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PySourceFormatAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PySourceFormatAction.java
@@ -18,7 +18,6 @@ import org.eclipse.core.runtime.IStatus;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.text.IDocument;
 import org.python.pydev.core.FileUtilsFileBuffer;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.docutils.SyntaxErrorException;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.actions.PyAction;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyRemoveNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyRemoveNature.java
@@ -13,7 +13,6 @@ import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
 import org.eclipse.ui.IObjectActionDelegate;
 import org.eclipse.ui.IWorkbenchPart;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.nature.PythonNature;
 

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableCombo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableCombo.java
@@ -545,16 +545,6 @@ public class TableCombo extends Composite {
         // create shell and table
         popup = new Shell(getShell(), SWT.NO_TRIM | SWT.ON_TOP);
 
-        // set style
-        int style = getStyle();
-        int tableStyle = SWT.SINGLE | SWT.V_SCROLL;
-        if ((style & SWT.FLAT) != 0)
-            tableStyle |= SWT.FLAT;
-        if ((style & SWT.RIGHT_TO_LEFT) != 0)
-            tableStyle |= SWT.RIGHT_TO_LEFT;
-        if ((style & SWT.LEFT_TO_RIGHT) != 0)
-            tableStyle |= SWT.LEFT_TO_RIGHT;
-
         // create table
         table = new Table(popup, SWT.SINGLE | SWT.FULL_SELECTION);
 

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
@@ -136,7 +136,6 @@ public class PyRenameResourceAction extends RenameResourceAction {
         if (resources.size() == 1) {
             IResource r = (IResource) resources.get(0);
             if (r instanceof IFile) {
-                IFile iFile = (IFile) r;
                 for (IEditorPart iEditorPart : dirtyEditors) {
                     IEditorInput editorInput = iEditorPart.getEditorInput();
                     Object input = editorInput.getAdapter(IResource.class);

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
@@ -23,7 +23,6 @@ import org.python.pydev.core.docutils.PyDocIterator;
 import org.python.pydev.core.docutils.PySelection;
 import org.python.pydev.core.docutils.PySelection.LineStartingScope;
 import org.python.pydev.core.docutils.PySelection.TddPossibleMatches;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.shared_core.structure.Tuple;
 
 /**

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonApplyCompletionsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonApplyCompletionsTest.java
@@ -9,7 +9,6 @@ package org.python.pydev.editor.codecompletion;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.swt.graphics.Point;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.editor.codecompletion.revisited.CodeCompletionTestsBase;

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionCalltipsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionCalltipsTest.java
@@ -10,7 +10,6 @@ import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.python.pydev.core.ICompletionState;
 import org.python.pydev.core.IToken;
-import org.python.pydev.core.docutils.StringUtils;
 import org.python.pydev.editor.codecompletion.revisited.CodeCompletionTestsBase;
 import org.python.pydev.editor.codecompletion.revisited.modules.CompiledModule;
 import org.python.pydev.shared_core.string.FastStringBuffer;


### PR DESCRIPTION
Remove the majority of remaining unused components. Those not removed are deliberately
left present, to maintain style or to prevent loss of public-access functionality.
Files not modified include tests, ast files, and files that are part of src_jython.
