### PR TITLE
Fix bug 866189: prevent Unittest errors caused by setUpClass/setUpModule...

### DIFF
--- a/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleClass_test.py
+++ b/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleClass_test.py
@@ -1,0 +1,14 @@
+import unittest
+
+class SetUpClassTest(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        raise ValueError("This is an INTENTIONAL value error in setUpClass.")
+
+    def test_blank(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleModule_test.py
+++ b/plugins/org.python.pydev/pysrc/tests_runfiles/samples/simpleModule_test.py
@@ -1,0 +1,16 @@
+import unittest
+
+def setUpModule():
+    raise ValueError("This is an INTENTIONAL value error in setUpModule.")
+
+class SetUpModuleTest(unittest.TestCase):
+    
+    def setUp(cls):
+        pass
+
+    def test_blank(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
... exceptions

When an exception is present in setUpClass or setUpModule methods for Unittest
modules, it causes an error in PyDev's PyUnit interface. The error occurs because
the file path is a property of the test variable only when running a custom test
module, not a class or module set up. Correct this error by obtaining file path
from the error output string instead.

An exception in setUpClass/Module also causes an error when trying to access the
name of the test method being called. Correct this error by creating special cases
for these setup methods.

This commit includes new test cases for these scenarios
(org.python.pydev/pysrc/tests_runfiles/samples/simpleClass_test.py & simpleModule_test.py).

---

Resubmitting all changes done to address bug 866189 in one pull request.
