### PR TITLE
When printing IPython version, print the actual version.

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydev_ipython_console.py
+++ b/plugins/org.python.pydev/pysrc/pydev_ipython_console.py
@@ -11,7 +11,8 @@ try:
 except ImportError:
     #IPython 0.11 broke compatibility...
     from pydev_ipython_console_011 import PyDevFrontEnd
-    sys.stderr.write('PyDev console: using IPython 0.11\n')
+    import IPython
+    sys.stderr.write('PyDev console: using IPython %s\n' % IPython.core.release.version)
  
 
 


### PR DESCRIPTION
Currently we describe any 0.11 compatible IPython version as 0.11; this is
confusing if the actual version is later.  Print the actual version.
