### PR TITLE
Provide GUI main loop integration through cross-thread signals/callbacks

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydev_ipython_console.py
+++ b/plugins/org.python.pydev/pysrc/pydev_ipython_console.py
@@ -6,11 +6,11 @@ import re
 #raise ImportError()
 
 try:
-    from pydev_ipython_console_010 import PyDevFrontEnd
+    from pydev_ipython_console_010 import PyDevFrontEnd, find_gui_and_backend
     sys.stderr.write('PyDev console: using IPython 0.10\n')
 except ImportError:
     #IPython 0.11 broke compatibility...
-    from pydev_ipython_console_011 import PyDevFrontEnd
+    from pydev_ipython_console_011 import PyDevFrontEnd, find_gui_and_backend
     import IPython
     sys.stderr.write('PyDev console: using IPython %s\n' % IPython.core.release.version)
  

--- a/plugins/org.python.pydev/pysrc/pydev_ipython_console_010.py
+++ b/plugins/org.python.pydev/pysrc/pydev_ipython_console_010.py
@@ -5,6 +5,56 @@ original_stdout = sys.stdout
 original_stderr = sys.stderr
 
 
+# If user specifies a GUI, that dictates the backend, otherwise we read the
+# user's mpl default from the mpl rc structure
+backends = {'tk': 'TkAgg',
+            'gtk': 'GTKAgg',
+            'wx': 'WXAgg',
+            'qt': 'Qt4Agg', # qt3 not supported
+            'qt4': 'Qt4Agg',
+            'osx': 'MacOSX',
+            'inline' : 'module://IPython.zmq.pylab.backend_inline'}
+
+# We also need a reverse backends2guis mapping that will properly choose which
+# GUI support to activate based on the desired matplotlib backend.  For the
+# most part it's just a reverse of the above dict, but we also need to add a
+# few others that map to the same GUI manually:
+backend2gui = dict(zip(backends.values(), backends.keys()))
+# In the reverse mapping, there are a few extra valid matplotlib backends that
+# map to the same GUI support
+backend2gui['GTK'] = backend2gui['GTKCairo'] = 'gtk'
+backend2gui['WX'] = 'wx'
+backend2gui['CocoaAgg'] = 'osx'
+
+
+# Backport from IPython 0.11
+def find_gui_and_backend(gui=None):
+    """Given a gui string return the gui and mpl backend.
+
+    Parameters
+    ----------
+    gui : str
+        Can be one of ('tk','gtk','wx','qt','qt4','inline').
+
+    Returns
+    -------
+    A tuple of (gui, backend) where backend is one of ('TkAgg','GTKAgg',
+    'WXAgg','Qt4Agg','module://IPython.zmq.pylab.backend_inline').
+    """
+
+    import matplotlib
+
+    if gui:
+        # select backend based on requested gui
+        backend = backends[gui]
+    else:
+        backend = matplotlib.rcParams['backend']
+        # In this case, we need to find what the appropriate gui selection call
+        # should be for IPython, so we can activate inputhook accordingly
+        gui = backend2gui.get(backend, None)
+    return gui, backend
+
+
 #=======================================================================================================================
 # PyDevFrontEnd
 #=======================================================================================================================

--- a/plugins/org.python.pydev/pysrc/pydev_ipython_console_011.py
+++ b/plugins/org.python.pydev/pysrc/pydev_ipython_console_011.py
@@ -1,6 +1,10 @@
 from IPython.frontend.terminal.interactiveshell import TerminalInteractiveShell
 from IPython.core.inputsplitter import IPythonInputSplitter
 from IPython.utils import io
+try:    # since IPython 0.12
+    from IPython.core.pylabtools import find_gui_and_backend
+except ImportError:     # IPython 0.11
+    from IPython.lib.pylabtools import find_gui_and_backend
 import sys
 import codeop, re
 original_stdout = sys.stdout

--- a/plugins/org.python.pydev/pysrc/pydevconsole.py
+++ b/plugins/org.python.pydev/pysrc/pydevconsole.py
@@ -259,7 +259,7 @@ def StartServer(host, port, client_port):
     sys.exit = _DoExit
     
     try:
-        from IPython.core.pylabtools import find_gui_and_backend
+        from pydev_ipython_console import find_gui_and_backend
         gui, _ = find_gui_and_backend()
     except Exception as ex:
         sys.stdout.write("Can't initialize GUI integration: %s\n" % str(ex))


### PR DESCRIPTION
Run the XML-RPC server in its own thread, communicating with the main thread
using GUI-dependent cross-thread signals or callbacks; this allows running a
fully responsive GUI main loop in the main thread.
