### PR TITLE
Allow Pydev launch shortcuts from context of Pydev project selection.

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTypePropertyTester.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTypePropertyTester.java
@@ -2,6 +2,7 @@ package org.python.pydev.debug.ui;
 
 import org.eclipse.core.expressions.PropertyTester;
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.runtime.IAdaptable;
 import org.python.pydev.editor.codecompletion.revisited.PythonPathHelper;
 import org.python.pydev.navigator.elements.IWrappedResource;
@@ -9,28 +10,29 @@ import org.python.pydev.navigator.elements.IWrappedResource;
 public class PythonTypePropertyTester extends PropertyTester {
 
     public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
-        IFile iFile = getIFile(receiver);
+
+        IFile iFile = null;
+
+        if (receiver instanceof IWrappedResource) {
+            IWrappedResource wrappedResource = (IWrappedResource) receiver;
+            Object actualObject = wrappedResource.getActualObject();
+            if (actualObject instanceof IProject) {
+                return true;
+            } else if (actualObject instanceof IFile) {
+                iFile = (IFile) actualObject;
+            }
+        }
+        if (receiver instanceof IAdaptable) {
+            IAdaptable iAdaptable = (IAdaptable) receiver;
+            iFile = (IFile) iAdaptable.getAdapter(IFile.class);
+        }
+
         if (iFile != null) {
             if (PythonPathHelper.markAsPyDevFileIfDetected(iFile)) {
                 return true;
             }
         }
         return false;
-    }
-
-    private IFile getIFile(Object receiver) {
-        if (receiver instanceof IWrappedResource) {
-            IWrappedResource wrappedResource = (IWrappedResource) receiver;
-            Object actualObject = wrappedResource.getActualObject();
-            if (actualObject instanceof IFile) {
-                return (IFile) actualObject;
-            }
-        }
-        if (receiver instanceof IAdaptable) {
-            IAdaptable iAdaptable = (IAdaptable) receiver;
-            return (IFile) iAdaptable.getAdapter(IFile.class);
-        }
-        return null;
     }
 
 }


### PR DESCRIPTION
org.python.pydev.debug.ui.launching.AbstractLaunchShortcut has support for displaying PythonModulePickerDialog when the underlying selection is adaptable to an IProject. PythonProjectSourceFolder meets the critera. Therefore PythonTypePropertyTester should permit launch shortcuts for this particular kind of project selection.
