### PR TITLE
UI improvements to New <Resource> wizards: titles, no duplicates

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonPackageSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonPackageSelectionDialog.java
@@ -67,16 +67,13 @@ public class PythonPackageSelectionDialog extends ElementTreeSelectionDialog {
                 return super.getImage(element);
             }
         }, new PackageContentProvider(selectOnlySourceFolders));
+        setAllowMultiple(false);
 
         this.selectOnlySourceFolders = selectOnlySourceFolders;
 
         //let's set the validator
         this.setValidator(new ISelectionStatusValidator() {
             public IStatus validate(Object selection[]) {
-                if (selection.length > 1) {
-                    return new Status(IStatus.ERROR, PydevPlugin.getPluginID(), IStatus.ERROR,
-                            "Only one package can be selected", null);
-                }
                 if (selection.length == 1) {
                     if (selection[0] instanceof SourceFolder) {
                         SourceFolder folder = (SourceFolder) selection[0];

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/editors/TreeWithAddRemove.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/editors/TreeWithAddRemove.java
@@ -308,6 +308,15 @@ public abstract class TreeWithAddRemove extends Composite {
      */
     private void addTreeItem(String pathAsString) {
         if (pathAsString != null && pathAsString.trim().length() > 0) {
+
+            // forbid duplicate selections
+            TreeItem[] items = tree.getItems();
+            for (int i = 0; i < items.length; i++) {
+                if (items[i].getText().equals(pathAsString)) {
+                    return;
+                }
+            }
+
             TreeItem item = new TreeItem(tree, 0);
             item.setText(pathAsString);
             item.setImage(PydevPlugin.getImageCache().get(getImageConstant()));

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizard.java
@@ -72,10 +72,11 @@ public abstract class AbstractPythonWizard extends Wizard implements INewWizard 
      */
     protected IStructuredSelection selection;
 
-    protected String description;
+    protected String title;
+    protected String description = "";
 
-    public AbstractPythonWizard(String description) {
-        this.description = description;
+    public AbstractPythonWizard(String title) {
+        this.title = title;
     }
 
     public void init(IWorkbench workbench, IStructuredSelection selection) {
@@ -103,6 +104,7 @@ public abstract class AbstractPythonWizard extends Wizard implements INewWizard 
      */
     public void addPages() {
         filePage = createPathPage();
+        filePage.setTitle(this.title);
         filePage.setDescription(this.description);
         addPage(filePage);
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizardPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizardPage.java
@@ -227,7 +227,7 @@ public abstract class AbstractPythonWizardPage extends WizardPage implements Key
                 ElementListSelectionDialog dialog = new ElementListSelectionDialog(getShell(),
                         new WorkbenchLabelProvider());
                 dialog.setTitle("Project selection");
-                dialog.setTitle("Select a project.");
+                dialog.setMessage("Select a project.");
                 dialog.setElements(ResourcesPlugin.getWorkspace().getRoot().getProjects());
                 dialog.open();
 
@@ -297,6 +297,8 @@ public abstract class AbstractPythonWizardPage extends WizardPage implements Key
                 public void widgetSelected(SelectionEvent e) {
                     try {
                         PythonPackageSelectionDialog dialog = new PythonPackageSelectionDialog(getShell(), false);
+                        dialog.setTitle("Package selection");
+                        dialog.setMessage("Select a package (or a source folder). You may also enter the\nname of a new package in the text bar on the previous page.");
                         dialog.open();
                         Object firstResult = dialog.getFirstResult();
                         if (firstResult instanceof SourceFolder) { //it is the default package
@@ -388,6 +390,8 @@ public abstract class AbstractPythonWizardPage extends WizardPage implements Key
             public void widgetSelected(SelectionEvent e) {
                 try {
                     PythonPackageSelectionDialog dialog = new PythonPackageSelectionDialog(getShell(), true);
+                    dialog.setTitle("Source folder selection");
+                    dialog.setMessage("Select a source folder.");
                     dialog.open();
                     Object firstResult = dialog.getFirstResult();
                     if (firstResult instanceof SourceFolder) {

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonModuleWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonModuleWizard.java
@@ -52,6 +52,20 @@ public class PythonModuleWizard extends AbstractPythonWizard {
                 return true;
             }
 
+            @Override
+            protected String checkNameText(String text) {
+                String result = super.checkNameText(text);
+                if (result != null) {
+                    return result;
+                }
+                IContainer p = getValidatedPackage();
+                if (p != null && p.findMember(text.concat(".py")) != null) {
+                    return "The module " + text +
+                            " already exists in " + p.getName() + ".";
+                }
+                return null;
+            }
+
         };
     }
 
@@ -84,10 +98,11 @@ public class PythonModuleWizard extends AbstractPythonWizard {
         String validatedName = filePage.getValidatedName() + FileTypesPreferencesPage.getDefaultDottedPythonExtension();
 
         IFile file = validatedPackage.getFile(new Path(validatedName));
-        if (!file.exists()) {
-            file.create(new ByteArrayInputStream(new byte[0]), true, monitor);
+        if (file.exists()) {
+            Log.log("Module already exists.");
+            return null;
         }
-
+        file.create(new ByteArrayInputStream(new byte[0]), true, monitor);
         return file;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonPackageWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonPackageWizard.java
@@ -37,6 +37,19 @@ public class PythonPackageWizard extends AbstractPythonWizard {
                 return false;
             }
 
+            @Override
+            protected String checkNameText(String text) {
+                String result = super.checkNameText(text);
+                if (result != null) {
+                    return result;
+                }
+                if (getValidatedSourceFolder().findMember(text) != null) {
+                    return "The package " + text +
+                            " already exists in the source folder " + getValidatedSourceFolder().getName() + ".";
+                }
+                return null;
+            }
+
         };
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.IPythonPathNature;
+import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.nature.PythonNature;
 
 public class PythonSourceFolderWizard extends AbstractPythonWizard {
@@ -40,6 +41,19 @@ public class PythonSourceFolderWizard extends AbstractPythonWizard {
                 return false;
             }
 
+            @Override
+            protected String checkNameText(String text) {
+                String result = super.checkNameText(text);
+                if (result != null) {
+                    return result;
+                }
+                if (getValidatedProject().findMember(text) != null) {
+                    return "The source folder " + text +
+                            " already exists in project " + getValidatedProject().getName() + ".";
+                }
+                return null;
+            }
+
         };
     }
 
@@ -59,9 +73,11 @@ public class PythonSourceFolderWizard extends AbstractPythonWizard {
             }
         }
         IFolder folder = project.getFolder(name);
-        if (!folder.exists()) {
-            folder.create(true, true, monitor);
+        if (folder.exists()) {
+            Log.log("Source folder already exists. Nothing new was created");
+            return null;
         }
+        folder.create(true, true, monitor);
         String newPath = folder.getFullPath().toString();
 
         String curr = pathNature.getProjectSourcePath(true);


### PR DESCRIPTION
Make some improvements to the New Source Folder/PyDev Package/PyDev Module wizards:
1. add persistent titles to the wizards.
2. no longer allow creation of duplicate resources. (Before this patch, giving a new
resource the same name as an existing one was valid, allowing paths to be written multiple
times to the PYTHONPATH.)
3. prohibit selection of multiple items in the PythonPackageSelectionDialog.

---

These are just some UI changes I thought were appropriate.
