### PR TITLE
Fix bug 987642: deleting/moving a project's source folder updates its PY...

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
@@ -73,7 +73,10 @@ public class PythonSourceFolderWizard extends AbstractPythonWizard {
         }
         if (curr.length() > 0) {
             //there is already some path
-            curr += "|" + newPath;
+            if (!curr.contains(newPath)) {
+                //only add to the path if it doesn't already contain the new path
+                curr += "|" + newPath;
+            }
         } else {
             //there is still no other path
             curr = newPath;


### PR DESCRIPTION
...THONPATH.

Deleting or moving a project's source folder no longer reports that the folder is missing.
Now, any time a source folder is removed from its parent project, that folder's path is
removed from its project's PYTHONPATH.
