### PR TITLE
Allow the New PyDev Project wizards to permit project creation in empty ...

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/NewProjectNameAndLocationWizardPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/NewProjectNameAndLocationWizardPage.java
@@ -589,7 +589,8 @@ public class NewProjectNameAndLocationWizardPage extends AbstractNewProjectPage 
      * content directory points to an existing project
      */
     private boolean isDotProjectFileInLocation() {
-        IPath path = getLocationPath();
+        // Want to get the path of the containing folder, even if workspace location is used
+        IPath path = new Path(getProjectLocationFieldValue());
         path = path.append(IProjectDescription.DESCRIPTION_FILE_NAME);
         return path.toFile().exists();
     }
@@ -700,22 +701,39 @@ public class NewProjectNameAndLocationWizardPage extends AbstractNewProjectPage 
             }
             if (locPath.toFile().exists()) {
                 File[] listFiles = locPath.toFile().listFiles();
-                boolean foundPy = false;
+                boolean foundInit = false;
                 for (File file : listFiles) {
                     if (file.getName().equals("__init__.py")) {
-                        foundPy = true;
+                        foundInit = true;
                         setMessage("Project location contains an __init__.py file. Consider using the location's parent folder instead.");
                         break;
                     }
-                    if (file.getName().endsWith(".py") && !foundPy) {
-                        foundPy = true;
-                        setMessage("Project location contains existing Python files. The created project will include them.");
-                    }
+                }
+                if (!foundInit && hasPyFile(locPath.toFile())) {
+                    setMessage("Project location contains existing Python files. The created project will include them.");
                 }
             }
         }
 
         return true;
+    }
+
+    private boolean hasPyFile(File file) {
+        if (file.isDirectory()) {
+            File[] listFiles = file.listFiles();
+            if (listFiles == null) {
+                return false;
+            }
+            for (File innerFile : listFiles) {
+                if (hasPyFile(innerFile)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        else {
+            return file.getName().endsWith(".py");
+        }
     }
 
     /*


### PR DESCRIPTION
...workspace folders.

Small change: instead of prohibiting non-default project locations that overlap with the
workspace, make only the workspace folder itself prohibited. Allow projects to be created
in workspace folders that lack a .project file, regardless of whether the "Default Location"
box is checked.
