### PR TITLE
Allow (un)marking PyDev folders as source folders with the PyDev right-c...

### DIFF
--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -109,6 +109,40 @@
 <!-- PyDev nature/project related actions -->
    <extension point="org.eclipse.ui.popupMenus">
    
+      <!-- add to PYTHONPATH -->
+      <objectContribution
+            adaptable="false"
+            id="org.python.pydev.ui.actions.container.PyAddSrcFolder"
+            objectClass="org.eclipse.core.resources.IContainer">
+         <menu id="org.python.pydev.ui.actions.menu" label="PyDev"/>
+         <action
+               class="org.python.pydev.ui.actions.container.PyAddSrcFolder"
+               enablesFor="+"
+               id="org.python.pydev.ui.actions.container.pyAddNature"
+               label="Set as Source Folder"
+               menubarPath="org.python.pydev.ui.actions.menu/pydev"
+               tooltip="Include this folder in its project's PYTHONPATH">
+         </action>
+      </objectContribution>
+
+
+      <!-- remove from PYTHONPATH -->
+      <objectContribution
+            adaptable="false"
+            id="org.python.pydev.ui.actions.container.PyRemSrcFolder"
+            objectClass="org.python.pydev.navigator.elements.PythonSourceFolder">
+         <menu id="org.python.pydev.ui.actions.menu" label="PyDev"/>
+         <action
+               class="org.python.pydev.ui.actions.container.PyRemSrcFolder"
+               enablesFor="+"
+               id="org.python.pydev.ui.actions.container.pyAddNature"
+               label="Set as non-source folder"
+               menubarPath="org.python.pydev.ui.actions.menu/pydev"
+               tooltip="Remove this folder from its project's PYTHONPATH">
+         </action>
+      </objectContribution>
+
+
       <!-- remove .pyc -->
       <objectContribution
             adaptable="true"

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyAddSrcFolder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyAddSrcFolder.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Eclipse Public License (EPL).
+ * Please see the license.txt included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package org.python.pydev.ui.actions.container;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.python.pydev.core.IPythonPathNature;
+import org.python.pydev.core.log.Log;
+import org.python.pydev.plugin.nature.PythonNature;
+import org.python.pydev.shared_core.string.StringUtils;
+
+/**
+ * Action used to add a file folder to its project's PYTHONPATH
+ * (or a project itself to its own PYTHONPATH),
+ * as an alternative to the Project Properties menu.  
+ *  
+ * @author Andrew
+ */
+public class PyAddSrcFolder extends PyContainerAction {
+
+    @Override
+    protected boolean confirmRun() {
+        return true;
+    }
+
+    @Override
+    protected void afterRun(int resourcesAffected) {
+
+    }
+
+    @Override
+    protected int doActionOnContainer(IContainer container, IProgressMonitor monitor) {
+        try {
+            IProject project = container.getProject();
+            IPythonPathNature pythonPathNature = PythonNature.getPythonPathNature(project);
+            SortedSet<String> projectSourcePathSet = new TreeSet<String>(pythonPathNature.getProjectSourcePathSet(true));
+            if (!projectSourcePathSet.add(container.getFullPath().toString())) {
+                return 0;
+            }
+            pythonPathNature.setProjectSourcePath(StringUtils.join("|", projectSourcePathSet));
+            PythonNature.getPythonNature(project).rebuildPath();
+            return 1;
+        } catch (CoreException e) {
+            Log.log(IStatus.ERROR, "Unexpected error setting project properties", e);
+        }
+        return 0;
+    }
+
+}

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyRemSrcFolder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyRemSrcFolder.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Eclipse Public License (EPL).
+ * Please see the license.txt included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package org.python.pydev.ui.actions.container;
+
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import org.eclipse.core.resources.IContainer;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.IStatus;
+import org.python.pydev.core.IPythonPathNature;
+import org.python.pydev.core.log.Log;
+import org.python.pydev.plugin.nature.PythonNature;
+import org.python.pydev.shared_core.string.StringUtils;
+
+/**
+ * Action used to remove a file folder from its project's PYTHONPATH
+ * (or a project itself from its own PYTHONPATH),
+ * as an alternative to the Project Properties menu.  
+ *  
+ * @author Andrew
+ */
+public class PyRemSrcFolder extends PyContainerAction {
+
+    @Override
+    protected boolean confirmRun() {
+        return true;
+    }
+
+    @Override
+    protected void afterRun(int resourcesAffected) {
+
+    }
+
+    @Override
+    protected int doActionOnContainer(IContainer container, IProgressMonitor monitor) {
+        try {
+            IProject project = container.getProject();
+            IPythonPathNature pythonPathNature = PythonNature.getPythonPathNature(project);
+            SortedSet<String> projectSourcePathSet = new TreeSet<String>(pythonPathNature.getProjectSourcePathSet(true));
+            if (!projectSourcePathSet.remove(container.getFullPath().toString())) {
+                return 0;
+            }
+            pythonPathNature.setProjectSourcePath(StringUtils.join("|", projectSourcePathSet));
+            PythonNature.getPythonNature(project).rebuildPath();
+            return 1;
+        } catch (CoreException e) {
+            Log.log(IStatus.ERROR, "Unexpected error setting project properties", e);
+        }
+        return 0;
+    }
+
+}


### PR DESCRIPTION
...lick context menu.

When right-clicking on a folder/project in the Package Explorer, allow the "PyDev" section
of the context menu to set the selection as a source folder (or to a non-source folder).

---

I thought it was a good idea to add this feature. The problems with it now are 1) the "disable" button appears in a different row as the "enable" one does, because they have different objectClasses, and 2) in Package Explorers that aren't the PyDev one, the "disable" never appears.
