### PR TITLE
Add support for PyLint1.0 symbolic ids (e.g. too-few-format-args instead of E1306).

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
@@ -353,6 +353,7 @@ public class PyLintVisitor extends PyDevBuilderVisitor {
                                 region = doc.getLineInformation(line);
                             }
                             String lineContents = doc.get(region.getOffset(), region.getLength());
+
                             int pos = -1;
                             if ((pos = lineContents.indexOf("IGNORE:")) != -1) {
                                 String lintW = lineContents.substring(pos + "IGNORE:".length());
@@ -370,6 +371,7 @@ public class PyLintVisitor extends PyDevBuilderVisitor {
                 }
             }
         }
+
     }
 
     @Override


### PR DESCRIPTION
The latest release of PyLint, 1.0,  deprecates the use of numeric message ids (e.g. E1306) in favor of the symbolic ids (e.g. too-few-format-args).  I've modified PyLintVisitor.java to add support for the default message format from PyLint 1.0.  The code continues to support the old (numeric) style.  I've run a rudimentary test in Linux, java 1.7.0_25 with PyLints 1.0 and 0.26.0.  
