### PR TITLE
Add license headers based on git history.

### DIFF
--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/GetGeneratorTestWorkbench.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/GetGeneratorTestWorkbench.java
@@ -1,3 +1,15 @@
+/*******************************************************************************
+ * Copyright (C) 2011, 2013  Jonah Graham and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+ *     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance 
+ *******************************************************************************/
 package org.python.pydev.dltk.console.codegen;
 
 import junit.framework.TestCase;

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/PythonSnippetUtilsTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/PythonSnippetUtilsTest.java
@@ -1,11 +1,22 @@
+/*******************************************************************************
+ * Copyright (C) 2011, 2013  Jonah Graham and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+ *     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance 
+ *******************************************************************************/
 package org.python.pydev.dltk.console.codegen;
 
 import java.io.File;
 
-import org.python.pydev.core.docutils.StringUtils;
-import org.python.pydev.shared_interactive_console.console.codegen.PythonSnippetUtils;
-
 import junit.framework.TestCase;
+
+import org.python.pydev.shared_interactive_console.console.codegen.PythonSnippetUtils;
 
 public class PythonSnippetUtilsTest extends TestCase {
 

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/StructuredSelectionGeneratorTestWorkbench.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/codegen/StructuredSelectionGeneratorTestWorkbench.java
@@ -1,12 +1,23 @@
+/*******************************************************************************
+ * Copyright (C) 2011, 2013  Fabio Zadrozny and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ * 
+ * Contributors:
+ *     Fabio Zadrozny <fabiofz@gmail.com>    - Initial API and implementation.
+ *******************************************************************************/
 package org.python.pydev.dltk.console.codegen;
+
+import junit.framework.TestCase;
 
 import org.eclipse.jface.viewers.StructuredSelection;
 import org.python.pydev.shared_interactive_console.console.codegen.IScriptConsoleCodeGenerator;
 import org.python.pydev.shared_interactive_console.console.codegen.PythonSnippetUtils;
 import org.python.pydev.shared_interactive_console.console.codegen.SafeScriptConsoleCodeGenerator;
 import org.python.pydev.shared_interactive_console.console.codegen.StructuredSelectionScriptConsoleCodeGenerator;
-
-import junit.framework.TestCase;
 
 public class StructuredSelectionGeneratorTestWorkbench extends TestCase {
 


### PR DESCRIPTION
The original author is listed as first entry in the copyright and others
and contributors are listed after the license. This is the standard form
used in eclipse.org codebases.

Change-Id: I41d1404d594e8b48e7b44399f6125f528b2b0a7c
