### PR TITLE
Add missing licenses (EPL) with an automated script.

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/builders/AdditionalInfoModulesObserver.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/builders/AdditionalInfoModulesObserver.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 /*
  * Created on Sep 24, 2006
  * @author Fabio

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/builders/InterpreterObserver.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/builders/InterpreterObserver.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2005-2012  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 /*
  * Created on 07/09/2005
  */

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/system_info_builder/InterpreterInfoBuilder.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/system_info_builder/InterpreterInfoBuilder.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package com.python.pydev.analysis.system_info_builder;
 
 import java.util.HashSet;

--- a/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/participant/CompletionParticipantBuiltinsTest.java
+++ b/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/participant/CompletionParticipantBuiltinsTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 /*
  * Created on 25/08/2005
  * 

--- a/plugins/com.python.pydev.runalltests/src/junit3/runner/ClassPathTestCollector.java
+++ b/plugins/com.python.pydev.runalltests/src/junit3/runner/ClassPathTestCollector.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package junit3.runner;
 
 import java.io.File;

--- a/plugins/com.python.pydev.runalltests/src/junit3/runner/TestCollector.java
+++ b/plugins/com.python.pydev.runalltests/src/junit3/runner/TestCollector.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package junit3.runner;
 
 import java.util.Enumeration;

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyLabelProvider.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyLabelProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package com.python.pydev.ui.hierarchy;
 
 import org.eclipse.jface.preference.JFacePreferences;

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/FileUtilsFileBuffer.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/FileUtilsFileBuffer.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core;
 
 import java.io.File;

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IMiscConstants.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IMiscConstants.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jeremy Carroll
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jeremy Carroll <jjc@syapse.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core;
 
 /**

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/MathUtils.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/MathUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core;
 
 public class MathUtils {

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/SystemUtils.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/SystemUtils.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2013  André Berg and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>           - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.core;
 
 import java.net.URL;

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/FileMock.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/FileMock.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core.resource_stubs;
 
 import org.eclipse.core.resources.IContainer;

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/FolderMock.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/FolderMock.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core.resource_stubs;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/ProjectMock.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/ProjectMock.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.core.resource_stubs;
 
 import org.eclipse.core.resources.IProject;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleActivateDebugContext.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleActivateDebugContext.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.console;
 
 import org.eclipse.debug.core.model.IProcess;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/IPropertyTraceListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/IPropertyTraceListener.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 /**

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyConsoleCodeGeneratorVariable.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyConsoleCodeGeneratorVariable.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.python.pydev.shared_interactive_console.console.codegen.IScriptConsoleCodeGenerator;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugTargetConsole.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugTargetConsole.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.eclipse.debug.core.DebugEvent;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyPropertyTraceManager.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyPropertyTraceManager.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.python.pydev.core.ListenerList;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyStackFrameConsole.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyStackFrameConsole.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.eclipse.debug.core.DebugException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyThreadConsole.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyThreadConsole.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.eclipse.debug.core.DebugException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariablesPreferences.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariablesPreferences.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.model;
 
 import org.eclipse.jface.preference.IPreferenceStore;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/EvaluateConsoleExpressionCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/EvaluateConsoleExpressionCommand.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model.remote;
 
 import org.eclipse.core.runtime.CoreException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoteDebuggerConsole.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoteDebuggerConsole.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model.remote;
 
 public class RemoteDebuggerConsole extends RemoteDebugger {

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetPropertyTraceCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetPropertyTraceCommand.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.model.remote;
 
 import org.python.pydev.debug.model.AbstractDebugTarget;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyPropertyTraceDialog.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyPropertyTraceDialog.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.ui;
 
 import java.util.List;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTypePropertyTester.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTypePropertyTester.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Roland Grunberg <rgrunber@redhat.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.ui;
 
 import org.eclipse.core.expressions.PropertyTester;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyPropertyTraceAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyPropertyTraceAction.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.ui.actions;
 
 import org.eclipse.jface.action.IAction;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/InteractiveConsoleConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/InteractiveConsoleConfigurationDelegate.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.ui.launching;
 
 import org.eclipse.core.runtime.CoreException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/AbstractShowReferencesActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/AbstractShowReferencesActionDelegate.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.ui.variables;
 
 import org.eclipse.debug.core.DebugException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowAllUppercaseReferencesActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowAllUppercaseReferencesActionDelegate.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.ui.variables;
 
 import org.eclipse.jface.viewers.Viewer;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowCapitalizedReferencesActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowCapitalizedReferencesActionDelegate.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.ui.variables;
 
 import org.eclipse.jface.viewers.Viewer;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowFunctionAndModuleReferencesActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowFunctionAndModuleReferencesActionDelegate.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.ui.variables;
 
 import org.eclipse.debug.core.DebugException;

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowPrivateReferencesActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/variables/ShowPrivateReferencesActionDelegate.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.ui.variables;
 
 import org.eclipse.debug.core.DebugException;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/ConsoleStyleProvider.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/ConsoleStyleProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/EvaluateDebugConsoleExpression.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/EvaluateDebugConsoleExpression.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import org.eclipse.core.runtime.Assert;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/HandleBackspaceAction.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/HandleBackspaceAction.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2008-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/IPydevConsoleDebugTarget.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/IPydevConsoleDebugTarget.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 /**

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsole.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsole.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import org.python.pydev.debug.newconsole.prefs.ColorManager;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsoleCommunication.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsoleCommunication.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevScriptConsoleSourceViewerConfiguration.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevScriptConsoleSourceViewerConfiguration.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2008-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/actions/DebugConsoleAction.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/actions/DebugConsoleAction.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole.actions;
 
 import org.eclipse.jface.action.IAction;

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/actions/LinkWithDebugSelectionAction.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/actions/LinkWithDebugSelectionAction.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Hussain Bohra and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Hussain Bohra <hussain.bohra@tavant.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole.actions;
 
 import java.io.File;

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
@@ -1,3 +1,16 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com>    - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+*     Fabio Zadrozny <fabiofz@gmail.com>       - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.debug.newconsole;
 
 import java.io.File;

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/DjangoProjectProperties.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/DjangoProjectProperties.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.django.ui;
 
 import java.util.Map;

--- a/plugins/org.python.pydev.mylyn/src/org/python/pydev/mylyn/Activator.java
+++ b/plugins/org.python.pydev.mylyn/src/org/python/pydev/mylyn/Activator.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.mylyn;
 
 import org.eclipse.ui.plugin.AbstractUIPlugin;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractJJTPythonGrammarState.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractJJTPythonGrammarState.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2005-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import org.python.pydev.parser.jython.Node;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTokenManagerWithConstants.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTokenManagerWithConstants.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import java.lang.reflect.Field;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/DefaultPythonGrammarActions.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/DefaultPythonGrammarActions.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2008-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import java.util.Iterator;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/IPythonGrammarActions.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/IPythonGrammarActions.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import org.python.pydev.parser.jython.ISpecialStr;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullJJTPythonGrammarState.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullJJTPythonGrammarState.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 public final class NullJJTPythonGrammarState extends AbstractJJTPythonGrammarState {

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullPythonGrammarActions.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullPythonGrammarActions.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import org.python.pydev.parser.jython.ISpecialStr;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullTreeBuilder.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/NullTreeBuilder.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser.grammarcommon;
 
 import org.python.pydev.parser.jython.SimpleNode;

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserWithoutTree.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserWithoutTree.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.parser;
 
 import junit.framework.TestCase;

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/CannotCreateContextRuntimeException.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/CannotCreateContextRuntimeException.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.ast.visitors;
 
 public class CannotCreateContextRuntimeException extends RuntimeException {

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/rewriter/Rewriter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/rewriter/Rewriter.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.ast.visitors.rewriter;
 
 import org.python.pydev.core.IGrammarVersionProvider;

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyDocumentChange.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyDocumentChange.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2010-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.core.base;
 
 import org.eclipse.core.resources.ResourcesPlugin;

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyDocumentChangeForTests.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyDocumentChangeForTests.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2010-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.core.base;
 
 import org.eclipse.core.runtime.Assert;

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyTextFileChange.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/PyTextFileChange.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2010-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.core.base;
 
 import org.eclipse.core.resources.IFile;

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IExtractMethodRefactoringRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IExtractMethodRefactoringRequest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.core.request;
 
 import org.python.pydev.refactoring.ast.adapters.AbstractScopeNode;

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/adapter/FunctionDefAdapterTestCase2.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/adapter/FunctionDefAdapterTestCase2.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.tests.adapter;
 
 import java.io.File;

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/AllTests.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/AllTests.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.tests.ast;
 
 import junit.framework.Test;

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/factory/PyAstFactoryTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/factory/PyAstFactoryTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.tests.ast.factory;
 
 import org.python.pydev.core.IGrammarVersionProvider;

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/factory/PyAstFactoryWithPrettyPrinting.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/ast/factory/PyAstFactoryWithPrettyPrinting.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.tests.ast.factory;
 
 import org.python.pydev.parser.jython.ast.Expr;

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/codegenerator/generateproperties/GeneratePropertiesRequestTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/codegenerator/generateproperties/GeneratePropertiesRequestTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.refactoring.tests.codegenerator.generateproperties;
 
 import org.python.pydev.plugin.preferences.PyCodeStylePreferencesPage;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/LineCommentAction.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/LineCommentAction.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.actions;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/LineUncommentAction.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/LineUncommentAction.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.actions;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/ToggleLineCommentAction.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/actions/ToggleLineCommentAction.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.actions;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyNewLineHelper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyNewLineHelper.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.auto_edit;
 
 import org.eclipse.jface.text.BadLocationException;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyScopeCreationHelper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyScopeCreationHelper.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_core.auto_edit;
 
 import java.util.Set;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/IIndentationStringProvider.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/IIndentationStringProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.auto_edit;
 
 public interface IIndentationStringProvider {

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/editor/IBaseEditor.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/editor/IBaseEditor.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.editor;
 
 import java.util.Map;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/log/Log.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/log/Log.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.log;
 
 import java.util.HashMap;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/BaseParser.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/BaseParser.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Alexander Kurtakov <akurtako@redhat.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_core.parsing;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/BaseParserManager.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/BaseParserManager.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2007-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.parsing;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IScopesParser.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IScopesParser.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.parsing;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ScopeEntry.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ScopeEntry.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.parsing;
 
 import org.python.pydev.shared_core.string.FastStringBuffer;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/Scopes.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/Scopes.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.parsing;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/partitioner/IMarkScanner.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/partitioner/IMarkScanner.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.partitioner;
 
 public interface IMarkScanner {

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/partitioner/PartitionMerger.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/partitioner/PartitionMerger.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.partitioner;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/process/ProcessUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/process/ProcessUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.process;
 
 import java.io.File;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/BaseParsingUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/BaseParsingUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.string;
 
 import org.eclipse.jface.text.BadLocationException;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/DocIterator.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/DocIterator.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.string;
 
 import java.util.Iterator;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/ICharacterPairMatcher2.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/ICharacterPairMatcher2.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.string;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/StringUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/StringUtils.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_core.string;
 
 import java.math.BigInteger;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/OrderedMap.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/OrderedMap.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.structure;
 
 import java.util.LinkedHashMap;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/OrderedSet.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/OrderedSet.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.structure;
 
 import java.util.Collection;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/TreeNodeContentProvider.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/TreeNodeContentProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.structure;
 
 import org.eclipse.jface.viewers.ITreeContentProvider;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/BaseExtensionHelper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/BaseExtensionHelper.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2005-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Haw-Bin Chai <hbchai@gmail.com>          - ongoing maintenance
+*     Hussain Bohra <hussain.bohra@tavant.com> - ongoing maintenance
+*     Jonah Graham <jonah@kichwacoders.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_core.utils;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/DocUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/DocUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.utils;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/PlatformUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/PlatformUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.utils;
 
 import org.eclipse.core.runtime.Platform;

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/Reflection.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/Reflection.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.utils;
 
 import java.lang.reflect.Field;

--- a/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/actions/CommentActionTest.java
+++ b/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/actions/CommentActionTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.actions;
 
 import junit.framework.TestCase;

--- a/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/auto_edit/PartitionCodeReaderTest.java
+++ b/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/auto_edit/PartitionCodeReaderTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.auto_edit;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/string/TextSelectionUtilsTest.java
+++ b/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/string/TextSelectionUtilsTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.string;
 
 import java.util.HashSet;

--- a/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/structure/TreeNodeTest.java
+++ b/plugins/org.python.pydev.shared_core/tests/org/python/pydev/shared_core/structure/TreeNodeTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_core.structure;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ScriptConsoleGlobalHistory.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ScriptConsoleGlobalHistory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console;
 
 import java.io.BufferedReader;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/IScriptConsoleCodeGenerator.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/IScriptConsoleCodeGenerator.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.codegen;
 
 /**

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/PythonSnippetUtils.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/PythonSnippetUtils.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.codegen;
 
 import java.io.File;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/SafeScriptConsoleCodeGenerator.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/SafeScriptConsoleCodeGenerator.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.codegen;
 
 import org.eclipse.core.runtime.ISafeRunnable;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/ScriptConsoleCodeGeneratorFactory.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/ScriptConsoleCodeGeneratorFactory.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.codegen;
 
 import org.eclipse.core.runtime.IAdapterFactory;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/StructuredSelectionScriptConsoleCodeGenerator.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/codegen/StructuredSelectionScriptConsoleCodeGenerator.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.codegen;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IHandleScriptAutoEditStrategy.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IHandleScriptAutoEditStrategy.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.ui.internal;
 
 import org.eclipse.jface.text.BadLocationException;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/AbstractHandleBackspaceAction.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/AbstractHandleBackspaceAction.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_interactive_console.console.ui.internal.actions;
 
 import org.eclipse.jface.text.IDocument;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ConsoleColorCache.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ConsoleColorCache.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui;
 
 import java.lang.ref.WeakReference;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/EditorUtils.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/EditorUtils.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui;
 
 import java.io.File;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/actions/ScopeSelectionAction.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/actions/ScopeSelectionAction.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_ui.actions;
 
 import java.util.Iterator;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/content_assist/DefaultContentAssist.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/content_assist/DefaultContentAssist.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2004-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.content_assist;
 
 import org.eclipse.jface.bindings.TriggerSequence;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/BaseEditor.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/BaseEditor.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.editor;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/BaseEditorCursorListener.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/BaseEditorCursorListener.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.editor;
 
 import org.eclipse.jface.text.ITextSelection;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseModel.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseModel.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.outline;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseOutlinePage.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseOutlinePage.java
@@ -1,3 +1,16 @@
+/******************************************************************************
+* Copyright (C) 2003-2013  Aleksandar Totic and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Aleksandar Totic                      - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_ui.outline;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseParsedItem.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/BaseParsedItem.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.outline;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ContentOutlinePageWithFilter.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ContentOutlinePageWithFilter.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.outline;
 
 import org.eclipse.core.runtime.ListenerList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/IParsedItem.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/IParsedItem.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.outline;
 
 import org.eclipse.swt.graphics.Image;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/AbstractCompletionProposalExtension.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/AbstractCompletionProposalExtension.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_ui.proposals;
 
 import org.eclipse.jface.text.BadLocationException;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/AbstractLinkedModeCompletionProposal.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/AbstractLinkedModeCompletionProposal.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.shared_ui.proposals;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/ICompletionStyleToggleEnabler.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/ICompletionStyleToggleEnabler.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.proposals;
 
 public interface ICompletionStyleToggleEnabler {

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/quick_outline/BaseQuickOutlineSelectionDialog.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/quick_outline/BaseQuickOutlineSelectionDialog.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.quick_outline;
 
 import org.eclipse.core.runtime.IProgressMonitor;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/templates/AbstractDocumentTemplateContextWithIndent.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/templates/AbstractDocumentTemplateContextWithIndent.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2007-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.templates;
 
 import java.util.List;

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tree/LabelProviderWithDecoration.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tree/LabelProviderWithDecoration.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.shared_ui.tree;
 
 import org.eclipse.jface.viewers.DecoratingStyledCellLabelProvider;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyExternalZipFileAnnotationModel.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyExternalZipFileAnnotationModel.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor;
 
 import org.eclipse.core.resources.IMarker;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyStringScanner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyStringScanner.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor;
 
 import org.eclipse.core.runtime.Assert;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PydevShowBrowserMessage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PydevShowBrowserMessage.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor;
 
 import org.eclipse.jface.dialogs.Dialog;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistPercentToFormat.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistPercentToFormat.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  André Berg and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>           - ongoing maintenance
+******************************************************************************/
 /*
  * Created on 2011-01-27
  *

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/PercentToBraceConverter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/PercentToBraceConverter.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  André Berg and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>           - ongoing maintenance
+******************************************************************************/
 /**
  * Convert %-format strings to {}-format.
  * 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevDateFieldNameEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevDateFieldNameEditor.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  André Berg
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+******************************************************************************/
 /**
  * 
  */

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevSaveActionsPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevSaveActionsPrefPage.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2013  André Berg and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>           - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.editor.saveactions;
 
 import java.net.MalformedURLException;

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyEditorInputFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyEditorInputFactory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011-2012  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editorinput;
 
 import java.io.File;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/MenuManagerCopiedToAddCreateMenuWithMenuParent.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/MenuManagerCopiedToAddCreateMenuWithMenuParent.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2011-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial API and implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.ui;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/NotifyViewCreated.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/NotifyViewCreated.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui;
 
 import java.util.List;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/TreeSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/TreeSelectionDialog.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2009-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.dialogs;
 
 import org.eclipse.jface.viewers.ILabelProvider;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.io.File;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AlreadyInstalledInterpreterProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AlreadyInstalledInterpreterProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 /**

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterNewCustomEntries.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterNewCustomEntries.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.util.Collection;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterProvider.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 /**

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterProviderFactory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 /**

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterNewCustomEntriesAdapter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterNewCustomEntriesAdapter.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.util.Collection;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterProviderFactory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 public class IronpythonInterpreterProviderFactory extends AbstractInterpreterProviderFactory {

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2005-2013  Fabio Zadrozny and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial API and implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Jonah Graham
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.io.File;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/TemplateSelectDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/TemplateSelectDialog.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.ui.wizards.files;
 
 import java.util.ArrayList;

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyStringScannerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyStringScannerTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor;
 
 import junit.framework.TestCase;

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/PercentToBraceConverterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/PercentToBraceConverterTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2011  André Berg
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     André Berg <andre.bergmedia@googlemail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor.correctionassist.heuristics;
 
 import org.python.pydev.editor.correctionassist.heuristics.PercentToBraceConverter;

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/MockStringVariableManager.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/MockStringVariableManager.java
@@ -1,3 +1,15 @@
+/******************************************************************************
+* Copyright (C) 2012  Jonah Graham and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Jonah Graham <jonah@kichwacoders.com> - initial API and implementation
+*     Fabio Zadrozny <fabiofz@gmail.com>    - ongoing maintenance
+******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
 import java.util.HashMap;

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PyCodeCompletionVisitorTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PyCodeCompletionVisitorTest.java
@@ -1,3 +1,14 @@
+/******************************************************************************
+* Copyright (C) 2012-2013  Fabio Zadrozny
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial API and implementation
+******************************************************************************/
 package org.python.pydev.editor.codecompletion.revisited;
 
 import java.util.ArrayList;


### PR DESCRIPTION
Use a script to find which files are missing an EPL header, and to generate & insert an EPL
header in each such file. (Ignore Jython files and auto-generated grammar files.)

---

I made the script so that it matched the same formatting as Alex's headers. I also did my best to check that the text generated is consistently correct.

If this isn't what you're looking for, this can at least be a step towards manually adding the licenses.
