### PR TITLE
With an automated script, add EPL headers to source files provided by th...

### DIFF
--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ast/factory/NodeHelper.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ast/factory/NodeHelper.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/PepticPlugin.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/PepticPlugin.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/FQIdentifier.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/FQIdentifier.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/PythonModuleManager.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/PythonModuleManager.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/AbstractNodeAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/AbstractNodeAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/AbstractScopeNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/AbstractScopeNode.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapterFromClassDef.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapterFromClassDef.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapterFromTokens.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ClassDefAdapterFromTokens.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/FunctionArgAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/FunctionArgAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/FunctionDefAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/FunctionDefAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/IASTNodeAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/IASTNodeAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2011  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/IClassDefAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/IClassDefAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2011  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/INodeAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/INodeAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ModuleAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/ModuleAdapter.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/PropertyAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/PropertyAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/PropertyTextAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/PropertyTextAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/SimpleAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/SimpleAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2011  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/TextNodeAdapter.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/TextNodeAdapter.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/AbstractOffsetStrategy.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/AbstractOffsetStrategy.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/BeforeCurrentOffset.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/BeforeCurrentOffset.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/BeginOffset.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/BeginOffset.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/EndOffset.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/EndOffset.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/IOffsetStrategy.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/IOffsetStrategy.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/InitOffset.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/adapters/offsetstrategy/InitOffset.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/LocalVariablesVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/LocalVariablesVisitor.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/ParentVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/ParentVisitor.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/VisitorFactory.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/VisitorFactory.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/AbstractContextVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/AbstractContextVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ClassDefVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ClassDefVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/GlobalAttributeVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/GlobalAttributeVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/GlobalFunctionDefVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/GlobalFunctionDefVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/LocalAttributeVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/LocalAttributeVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/LocalFunctionDefVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/LocalFunctionDefVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/PropertyVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/PropertyVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ScopeAssignedVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ScopeAssignedVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ScopeVariablesVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/context/ScopeVariablesVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/info/ImportVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/info/ImportVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/position/IndentVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/position/IndentVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/position/LastLineVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/position/LastLineVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/renamer/LocalVarRenameVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/renamer/LocalVarRenameVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionException.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionException.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionExtenderVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionExtenderVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionValidationVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/selection/SelectionValidationVisitor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldRefactoring.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/ConstructorFieldRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/edit/ConstructorMethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/edit/ConstructorMethodEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/request/ConstructorFieldRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/constructorfield/request/ConstructorFieldRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesRefactoring.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/GeneratePropertiesRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/DeleteMethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/DeleteMethodEdit.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>  - initial implementation
+*     Camilo Bernal <cabernal@redhat.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/GetterMethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/GetterMethodEdit.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>  - initial implementation
+*     Camilo Bernal <cabernal@redhat.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/PropertyEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/PropertyEdit.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>  - initial implementation
+*     Camilo Bernal <cabernal@redhat.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/SetterMethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/edit/SetterMethodEdit.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>  - initial implementation
+*     Camilo Bernal <cabernal@redhat.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/request/GeneratePropertiesRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/request/GeneratePropertiesRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/request/SelectionState.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/generateproperties/request/SelectionState.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsRefactoring.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/OverrideMethodsRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/edit/MethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/edit/MethodEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/request/OverrideMethodsRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/codegenerator/overridemethods/request/OverrideMethodsRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalRefactoring.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/ExtractLocalRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/CreateLocalVariableEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/CreateLocalVariableEdit.java
@@ -1,3 +1,20 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>    - initial implementation
+*     Jonah Graham <jonah@kichwacoders.com> - ongoing maintenance
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/ReplaceDuplicateWithVariableEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/ReplaceDuplicateWithVariableEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/ReplaceWithVariableEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/edit/ReplaceWithVariableEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/request/ExtractLocalRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractlocal/request/ExtractLocalRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodRefactoring.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/ExtractMethodRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ExtractCallEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ExtractCallEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ExtractMethodEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ExtractMethodEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ParameterReturnDeduce.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/edit/ParameterReturnDeduce.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/request/ExtractMethodRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/extractmethod/request/ExtractMethodRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/inlinelocal/edit/RemoveAssignment.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/coderefactoring/inlinelocal/edit/RemoveAssignment.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/AbstractFileChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/AbstractFileChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/AbstractPythonRefactoring.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/AbstractPythonRefactoring.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/RefactoringInfo.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/base/RefactoringInfo.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/change/CompositeChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/change/CompositeChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/change/IChangeProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/change/IChangeProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractInsertEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractInsertEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2010  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractRemoveEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractRemoveEdit.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractReplaceEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractReplaceEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractTextEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/edit/AbstractTextEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/OffsetStrategyModel.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/OffsetStrategyModel.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/OffsetStrategyProvider.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/OffsetStrategyProvider.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/ClassFieldTreeProvider.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/ClassFieldTreeProvider.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/TreeNodeClassField.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/TreeNodeClassField.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/TreeNodeField.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/constructorfield/TreeNodeField.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/PropertyTreeProvider.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/PropertyTreeProvider.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/TreeAttributeNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/TreeAttributeNode.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/TreeClassNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/generateproperties/TreeClassNode.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/ClassMethodsTreeProvider.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/ClassMethodsTreeProvider.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/ClassTreeNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/ClassTreeNode.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/FunctionTreeNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/overridemethods/FunctionTreeNode.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/tree/ITreeNode.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/tree/ITreeNode.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/tree/TreeNodeSimple.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/model/tree/TreeNodeSimple.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IRefactoringRequest.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IRefactoringRequest.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IRequestProcessor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/request/IRequestProcessor.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/validator/NameValidator.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/core/validator/NameValidator.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/messages/Messages.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/messages/Messages.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ConstructorFieldAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ConstructorFieldAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ExtractLocalAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ExtractLocalAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ExtractMethodAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/ExtractMethodAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/GeneratePropertiesAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/GeneratePropertiesAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/OverrideMethodsAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/OverrideMethodsAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/internal/AbstractRefactoringAction.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/actions/internal/AbstractRefactoringAction.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/LabeledEdit.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/LabeledEdit.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/PepticImageCache.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/PepticImageCache.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/PythonRefactoringWizard.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/PythonRefactoringWizard.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/TreeLabelProvider.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/core/TreeLabelProvider.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/ConstructorFieldPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/ConstructorFieldPage.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/GeneratePropertiesPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/GeneratePropertiesPage.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/OverrideMethodsPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/OverrideMethodsPage.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/PyDevInputWizardPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/PyDevInputWizardPage.java
@@ -1,3 +1,21 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+*     Reto Schüttel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/core/SimpleTableItem.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/core/SimpleTableItem.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractlocal/ExtractLocalInputPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractlocal/ExtractLocalInputPage.java
@@ -1,3 +1,18 @@
+/******************************************************************************
+* Copyright (C) 2007-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com>       - initial implementation
+*     Andrew Ferrazzutti <aferrazz@redhat.com> - ongoing maintenance
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/ExtractMethodComposite.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/ExtractMethodComposite.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/ExtractMethodPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/ExtractMethodPage.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/VariableCellValidator.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/extractmethod/VariableCellValidator.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/inlinelocal/InlineTempInputPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/inlinelocal/InlineTempInputPage.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/ButtonActivationListener.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/ButtonActivationListener.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/FunctionSignatureListener.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/FunctionSignatureListener.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/IValidationPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/IValidationPage.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/TableCellEditorListener.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/listener/TableCellEditorListener.java
@@ -1,3 +1,19 @@
+/******************************************************************************
+* Copyright (C) 2006-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Dennis Hunziker
+*     Ueli Kistler
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/DirectoryTraverser.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/DirectoryTraverser.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/FileUtils.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/FileUtils.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/ListUtils.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/ListUtils.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2009  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/StringUtils.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/StringUtils.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/TestUtils.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/utils/TestUtils.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/extractlocal/ExtractLocalTestCase.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/extractlocal/ExtractLocalTestCase.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/extractlocal/ExtractLocalTestSuite.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/extractlocal/ExtractLocalTestSuite.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/inlinelocal/InlineLocalTestCase.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/inlinelocal/InlineLocalTestCase.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/inlinelocal/InlineLocalTestSuite.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/coderefactoring/inlinelocal/InlineLocalTestSuite.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /* 
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/core/TestData.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/core/TestData.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/AllTests.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/AllTests.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/FileUtilsTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/FileUtilsTest.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2013  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/StringUtilsTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/StringUtilsTest.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/TestUtilsTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/tests/utils/TestUtilsTest.java
@@ -1,3 +1,17 @@
+/******************************************************************************
+* Copyright (C) 2007-2012  IFS Institute for Software and others
+*
+* All rights reserved. This program and the accompanying materials
+* are made available under the terms of the Ecliplse Public License v1.0
+* which accompanies this distribution, and is available at
+* http://www.eclipse.org/legal/epl-v10.html
+*
+* Original authors:
+*     Reto Schuettel
+*     Robin Stocker
+* Contributors:
+*     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
+******************************************************************************/
 /*
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
  *


### PR DESCRIPTION
...e IFS.

Use a script to find which files are authored by the Institute for Software, and generate &
insert an EPL header in each such file. The files' original copyright headers are retained.

---

Every added EPL header is of the same format, so if there's something you don't like, it will be there in every modified file. If there's something you want me to change about the format, let me know; it will be easy enough to fix since it's all script-generated.
