### PR TITLE
Bug 982310: projects are now shown in the Pydev Package Explorer when ad...

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
@@ -36,6 +36,8 @@ import org.eclipse.ui.actions.WorkspaceModifyOperation;
 import org.eclipse.ui.wizards.newresource.BasicNewProjectResourceWizard;
 import org.eclipse.ui.wizards.newresource.BasicNewResourceWizard;
 import org.python.pydev.core.log.Log;
+import org.python.pydev.navigator.ui.PydevPackageExplorer;
+import org.python.pydev.navigator.ui.PydevPackageExplorer.PydevCommonViewer;
 import org.python.pydev.plugin.PyStructureConfigHelpers;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.shared_core.callbacks.ICallback;
@@ -268,6 +270,25 @@ public class PythonProjectWizard extends AbstractNewProjectWizard implements IEx
         IWorkingSet[] workingSets = projectPage.getWorkingSets();
         if (workingSets.length > 0) {
             PlatformUI.getWorkbench().getWorkingSetManager().addToWorkingSets(createdProject, workingSets);
+
+            //Workaround to properly show project in Package Explorer: if Top Level Elements are
+            //working sets, and the destination working set of the new project is selected, that set
+            //must be reselected in order to display the project.
+            PydevPackageExplorer pView = (PydevPackageExplorer) PlatformUI.getWorkbench()
+                    .getActiveWorkbenchWindow().getActivePage()
+                    .findView("org.python.pydev.navigator.view");
+            if (pView != null) {
+                IWorkingSet[] inputSets = ((PydevCommonViewer) pView.getCommonViewer()).getSelectedWorkingSets();
+                if (inputSets != null && inputSets.length == 1) {
+                    IWorkingSet inputSet = inputSets[0];
+                    for (IWorkingSet destinationSet : workingSets) {
+                        if (inputSet.equals(destinationSet)) {
+                            pView.getCommonViewer().setInput(inputSet);
+                            break;
+                        }
+                    }
+                }
+            }
         }
 
         // Switch to default perspective (will ask before changing)

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ui/PydevPackageExplorer.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ui/PydevPackageExplorer.java
@@ -44,7 +44,9 @@ import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IMemento;
 import org.eclipse.ui.IURIEditorInput;
 import org.eclipse.ui.IViewSite;
+import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.internal.AggregateWorkingSet;
 import org.eclipse.ui.internal.navigator.ContributorTrackingSet;
 import org.eclipse.ui.internal.navigator.NavigatorContentService;
 import org.eclipse.ui.internal.navigator.dnd.CommonDropAdapterDescriptor;
@@ -351,6 +353,14 @@ public class PydevPackageExplorer extends CommonNavigator implements IShowInTarg
                 item = getParentItem(item);
             }
             return new TreePath(segments.toArray());
+        }
+
+        public IWorkingSet[] getSelectedWorkingSets() {
+            Object input = getInput();
+            if (input instanceof AggregateWorkingSet) {
+                return ((AggregateWorkingSet) input).getComponents();
+            }
+            return null;
         }
     }
 


### PR DESCRIPTION
...ded to a selected Working Set.

If the Top Level Elements of the Pydev Package Explorer are Working Sets while at least one
working set is selected (either by means of the Select Working Set dialog or the Explorer's
drop-down menu), and a project is placed into a working set upon creation, it will now appear
in the Explorer without having to reselect anything to refresh it.
