### PR TITLE
Update the copyright dates of all outdated license headers.

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AbstractAnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AbstractAnalysisPreferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPlugin.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/CtxInsensitiveImportComplProposal.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/CtxInsensitiveImportComplProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IAnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IAnalysisPreferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IPyContextObserver.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IPyContextObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/MarkerStub.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/MarkerStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/OccurrencesAnalyzer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/OccurrencesAnalyzer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/PyContextActivator.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/PyContextActivator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/PyContextActivatorViewCreatedObserver.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/PyContextActivatorViewCreatedObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/AdditionalInfoAndIInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/AdditionalInfoAndIInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/AnalyzeOnRequestSetter.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/AnalyzeOnRequestSetter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/ForceCodeAnalysisOnTree.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/ForceCodeAnalysisOnTree.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsDialogFactory.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsDialogFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsTwoPaneElementSelector.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsTwoPaneElementSelector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsTwoPanelElementSelector2.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/GlobalsTwoPanelElementSelector2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/MatchHelper.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/MatchHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/ModuleIInfoLabelProvider.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/ModuleIInfoLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/NameIInfoLabelProvider.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/NameIInfoLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/NameIInfoStyledLabelProvider.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/NameIInfoStyledLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/PyGlobalsBrowser.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/PyGlobalsBrowser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/PyGlobalsBrowserWorkbench.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/actions/PyGlobalsBrowserWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalDependencyInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalDependencyInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalInfoWithBuild.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalInfoWithBuild.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalTokensInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractAdditionalTokensInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AbstractInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalProjectInterpreterInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalProjectInterpreterInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalSystemInterpreterInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AdditionalSystemInterpreterInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AttrInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/AttrInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/ClassInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/ClassInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/FuncInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/FuncInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/IInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/IInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/InfoFactory.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/InfoFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/InfoStrFactory.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/InfoStrFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/ModInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/ModInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/NameInfo.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/NameInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/TreeIO.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/TreeIO.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/dependencies/PyStructuralChange.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/additionalinfo/dependencies/PyStructuralChange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AbstractAnalysisBuilderRunnable.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AbstractAnalysisBuilderRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnable.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnableFactory.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnableFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnableForRemove.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderRunnableForRemove.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisBuilderVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisParserObserver.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisParserObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisRunner.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/AnalysisRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/ClearAnalysisMarkersPyEditListener.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/ClearAnalysisMarkersPyEditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/IAnalysisBuilderRunnable.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/IAnalysisBuilderRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/KeyForAnalysisRunnable.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/KeyForAnalysisRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/PreloadAdditionalInfoPyEditListener.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/builder/PreloadAdditionalInfoPyEditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/AbstractAnalysisMarkersParticipants.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/AbstractAnalysisMarkersParticipants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/AnalysisMarkersParticipants.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/AnalysisMarkersParticipants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/DontAnalyzeFileMarkerParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/DontAnalyzeFileMarkerParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IAnalysisMarkersParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IAnalysisMarkersParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IgnoreCompletionProposal.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IgnoreCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IgnoreErrorParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/IgnoreErrorParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ElementWithChildren.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ElementWithChildren.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ElementWithParent.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ElementWithParent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ForcedLibGroup.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ForcedLibGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ITreeElement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ITreeElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/IndexRoot.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/IndexRoot.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/InterpreterGroup.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/InterpreterGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/InterpretersGroup.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/InterpretersGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/LeafElement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/LeafElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/MisconfigurationElement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/MisconfigurationElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/NatureGroup.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/NatureGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ProjectsGroup.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/ProjectsGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/PyIndexContentProvider.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/PyIndexContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/PyIndexView.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/indexview/PyIndexView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/AbstractMessage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/AbstractMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/CompositeMessage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/CompositeMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/IMessage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/IMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/Message.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/Message.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/organizeimports/OrganizeImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/organizeimports/OrganizeImports.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AbstractScopeAnalyzerVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AbstractScopeAnalyzerVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AstEntryScopeAnalysisConstants.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AstEntryScopeAnalysisConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AttributeReferencesVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AttributeReferencesVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalysis.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalysis.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorForImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorForImports.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorWithoutImports.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/TokenMatching.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/TokenMatching.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/tabnanny/TabNanny.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/tabnanny/TabNanny.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AnalysisPreferencesPage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AnalysisPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AutoImportsPreferencesPage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AutoImportsPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ArgumentsChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ArgumentsChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/DuplicationChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/DuplicationChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/Found.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/Found.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/GenAndTok.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/GenAndTok.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ImportChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ImportChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/MessagesManager.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/MessagesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/NoSelfChecker.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/NoSelfChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/OccurrencesVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/OccurrencesVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/Scope.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/Scope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ScopeItems.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/ScopeItems.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/src/org/python/pydev/builder/pep8/Pep8Visitor.java
+++ b/plugins/com.python.pydev.analysis/src/org/python/pydev/builder/pep8/Pep8Visitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisPreferencesStub.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisPreferencesStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisRequestsTestWorkbench.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisRequestsTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisTestsBase.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/AnalysisTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/CtxInsensitiveImportComplProposalTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/CtxInsensitiveImportComplProposalTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/ImportsOccurrencesAnalyzerTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/ImportsOccurrencesAnalyzerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzer2Test.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzer2Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerListCompTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerListCompTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerTestOpenGL.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/OccurrencesAnalyzerTestOpenGL.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/actions/GlobalsTwoPanelElementSelector2Test.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/actions/GlobalsTwoPanelElementSelector2Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityCheckerTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoIntegrityCheckerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoTestsBase.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInfoTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInterpreterInfoTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/AdditionalInterpreterInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/InfoFactoryTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/additionalinfo/InfoFactoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipantTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipantTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/organizeimports/OrganizeImportsTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/organizeimports/OrganizeImportsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/ScopeAnalysisCommentsTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/ScopeAnalysisCommentsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/ScopeAnalyzerVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/TokenMatchingTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/scopeanalysis/TokenMatchingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/system_info_builder/InterpreterInfoBuilderTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/system_info_builder/InterpreterInfoBuilderTest.java
@@ -1,7 +1,7 @@
 package com.python.pydev.analysis.system_info_builder;
 
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/tabnanny/TabNannyIteratorTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/tabnanny/TabNannyIteratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/tabnanny/TabNannyTest.java
+++ b/plugins/com.python.pydev.analysis/tests/com/python/pydev/analysis/tabnanny/TabNannyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/CodeCompletionPreferencesInitializer.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/CodeCompletionPreferencesInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/CodecompletionPlugin.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/CodecompletionPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/PyConsoleCompletion.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ctxinsensitive/PyConsoleCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/simpleassist/KeywordsSimpleAssist.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/simpleassist/KeywordsSimpleAssist.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/simpleassist/SimpleAssistProposal.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/simpleassist/SimpleAssistProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ui/CodeCompletionPreferencesPage.java
+++ b/plugins/com.python.pydev.codecompletion/src/com/python/pydev/codecompletion/ui/CodeCompletionPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/JavaIntegrationPydevComTestWorkbench.java
+++ b/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/JavaIntegrationPydevComTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/ctxinsensitive/StuctureCreationTest.java
+++ b/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/ctxinsensitive/StuctureCreationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/parameter/ParameterCompletionTest.java
+++ b/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/parameter/ParameterCompletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/participant/CompletionParticipantTest.java
+++ b/plugins/com.python.pydev.codecompletion/tests/com/python/pydev/codecompletion/participant/CompletionParticipantTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPlugin.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/actions/EndDebugServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/actions/EndDebugServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/actions/StartDebugServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/actions/StartDebugServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/console/EvaluationConsoleInputListener.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/console/EvaluationConsoleInputListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServerOutputStream.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServerOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/PyDebugTargetServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/PyDebugTargetServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/XMLMessage.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/XMLMessage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/RemoteDebuggerServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/RemoteDebuggerServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/client_api/PydevRemoteDebuggerServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/remote/client_api/PydevRemoteDebuggerServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/DebugPreferencesPageExt.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/DebugPreferencesPageExt.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchConfigurationDelegate.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchShortcut.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/ui/launching/PydevdServerLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/tests/com/python/pydev/debug/model/MyByteArrayOutputStreamTest.java
+++ b/plugins/com.python.pydev.debug/tests/com/python/pydev/debug/model/MyByteArrayOutputStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.debug/tests/com/python/pydev/debug/remote/client_api/PydevRemoteDebuggerServerTestWorkbench.java
+++ b/plugins/com.python.pydev.debug/tests/com/python/pydev/debug/remote/client_api/PydevRemoteDebuggerServerTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.fastparser/src/com/python/pydev/fastparser/FastparserPlugin.java
+++ b/plugins/com.python.pydev.fastparser/src/com/python/pydev/fastparser/FastparserPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.fastparser/tests/com/python/pydev/fastparser/MemoVisitor.java
+++ b/plugins/com.python.pydev.fastparser/tests/com/python/pydev/fastparser/MemoVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPlugin.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPreferencesInitializer.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPreferencesInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/ActionCreatorPyEditListener.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/ActionCreatorPyEditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyFindAllOccurrences.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyFindAllOccurrences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyGoToDefinition.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyGoToDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyRename.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyRename.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyRenameInFileAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/actions/PyRenameInFileAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyChange.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyChange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyRenameResourceChange.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/changes/PyRenameResourceChange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonElementHyperlinkDetector.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonElementHyperlinkDetector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonHyperlink.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonHyperlink.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesDispatcher.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesDispatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesJob.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/markoccurrences/MarkOccurrencesJob.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/Refactorer.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/Refactorer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindDefinition.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindReferences.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFindReferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFinds.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/RefactorerFinds.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/AbstractPythonSearchQuery.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/AbstractPythonSearchQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/PythonFileSearchResult.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/PythonFileSearchResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/BasicElementLabels.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/BasicElementLabels.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/EditorOpener.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/EditorOpener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileLabelProvider.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileSearchPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileSearchPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTableContentProvider.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTableContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTreeContentProvider.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/FileTreeContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/IFileSearchContentProvider.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/IFileSearchContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/NewTextSearchActionGroup.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/NewTextSearchActionGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/OpenSearchPreferencesAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/OpenSearchPreferencesAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/PatternConstructor.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/PatternConstructor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceConfigurationPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceConfigurationPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceRefactoring.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/ReplaceRefactoring.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/SearchResultUpdater.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/SearchResultUpdater.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/SortAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/refactorer/search/copied/SortAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/search/FindOccurrencesSearchQuery.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/search/FindOccurrencesSearchQuery.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/search/FindOccurrencesSearchResultPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/search/FindOccurrencesSearchResultPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateClassOrMethodOrField.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractPyCreateClassOrMethodOrField.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractTddRefactorCompletion.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/AbstractTddRefactorCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PyCreateClass.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PyCreateClass.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PyCreateMethodOrField.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PyCreateMethodOrField.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PythonElementWizard.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/PythonElementWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddQuickFixParticipant.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddQuickFixParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletion.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletionInInexistentModule.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletionInInexistentModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletionInModule.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/tdd/TddRefactorCompletionInModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/MarkOccurrencesPreferencesPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/MarkOccurrencesPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/FindInOpenDocuments.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/FindInOpenDocuments.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/PySearchInOpenDocumentsAction.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/ui/findreplace/PySearchInOpenDocumentsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/IRefactorRenameProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/IRefactorRenameProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/RefactorProcessFactory.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/RefactorProcessFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/TextInputWizardPage.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/TextInputWizardPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/AbstractRenameRefactorProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/AbstractRenameRefactorProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/AbstractRenameWorkspaceRefactorProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/AbstractRenameWorkspaceRefactorProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAnyLocalProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAnyLocalProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAttributeProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameAttributeProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameClassProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameClassProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameEntryPoint.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameEntryPoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameFunctionProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameFunctionProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameGlobalProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameGlobalProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameImportProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameImportProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameLocalProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameLocalProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameParameterProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameParameterProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameRefactoringWizard.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameRefactoringWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameSelfAttributeProcess.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameSelfAttributeProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/TextEditCreation.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/TextEditCreation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/visitors/FindCallVisitor.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/visitors/FindCallVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/ClassHierarchySearchTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/ClassHierarchySearchTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/SearchTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/SearchTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringLocalToken.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringLocalToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringRenameTestBase.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RefactoringRenameTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameAttributeRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameAttributeRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameClassRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameClassRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest2.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameFunctionRefactoringTest2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameGlobalRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameGlobalRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameLocalRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameLocalRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameModuleRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameModuleRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameParamRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameParamRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameSelfRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/rename/RenameSelfRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RefactoringLocalTestBase.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RefactoringLocalTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameBuiltinTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameBuiltinTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameClassRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameClassRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameLocalVariableRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameLocalVariableRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameSelfVariableRefactoringTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/refactorer/refactorings/renamelocal/RenameSelfVariableRefactoringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/PyCreateClassTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/PyCreateClassTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/PyCreateMethodTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/PyCreateMethodTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipantTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/TddCodeGenerationQuickFixParticipantTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/TddTestWorkbench.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/tdd/TddTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/wizards/rename/AbstractRenameRefactorProcessTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/wizards/rename/AbstractRenameRefactorProcessTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/wizards/rename/visitors/FindCallVisitorTest.java
+++ b/plugins/com.python.pydev.refactoring/tests/com/python/pydev/refactoring/wizards/rename/visitors/FindCallVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/Activator.java
+++ b/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/Activator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllTests.java
+++ b/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllWorkbenchTests.java
+++ b/plugins/com.python.pydev.runalltests/src/com/python/pydev/runalltests2/AllWorkbenchTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/NullPrefsStore.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/NullPrefsStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/PydevExtensionInitializer.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/PydevExtensionInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/PydevPlugin.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/PydevPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/actions/OutlineEntry.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/actions/OutlineEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/actions/PyOutlineSelectionDialog.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/actions/PyOutlineSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/actions/PyShowHierarchy.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/actions/PyShowHierarchy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/actions/PyShowOutline.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/actions/PyShowOutline.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/actions/ShowOutlineLabelProvider.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/actions/ShowOutlineLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/interactiveconsole/EvaluateActionSetter.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/interactiveconsole/EvaluateActionSetter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/refactoring/IPyRefactoring2.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/refactoring/IPyRefactoring2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyNodeModel.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyNodeModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyViewer.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/HierarchyViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/PyHierarchyView.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/hierarchy/PyHierarchyView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/FileMatch.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/FileMatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/LineElement.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/LineElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/PySearchPage.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/PySearchPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceAction2.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceAction2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceDialog2.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/ReplaceDialog2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/ui/search/SearchAgainConfirmationDialog.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/ui/search/SearchAgainConfirmationDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/src/com/python/pydev/util/UIUtils.java
+++ b/plugins/com.python.pydev/src/com/python/pydev/util/UIUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/tests/com/python/pydev/ui/dialogs/PyOutlineSelectionDialogTest.java
+++ b/plugins/com.python.pydev/tests/com/python/pydev/ui/dialogs/PyOutlineSelectionDialogTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/com.python.pydev/tests/com/python/pydev/ui/hierarchy/HierarchyViewerTest.java
+++ b/plugins/com.python.pydev/tests/com/python/pydev/ui/hierarchy/HierarchyViewerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/AstPlugin.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/AstPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/DeltaSaver.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/DeltaSaver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ExtensionHelper.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ExtensionHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/FastBufferedReader.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/FastBufferedReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/FullRepIterable.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/FullRepIterable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ICodeCompletionASTManager.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ICodeCompletionASTManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionCache.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IDeltaProcessor.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IDeltaProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IGrammarVersionProvider.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IGrammarVersionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IIndentPrefs.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IIndentPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IInterpreterInfo.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IInterpreterInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IInterpreterManager.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ILocalScope.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ILocalScope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IModule.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IModulesManager.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IProjectModulesManager.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IProjectModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IPyEdit.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IPyEdit.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonNature.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonPartitions.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonPartitions.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonPathNature.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IPythonPathNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ISourceModule.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ISourceModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ISystemModulesManager.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ISystemModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IToken.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/MisconfigurationException.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/MisconfigurationException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ModulesKey.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ModulesKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ModulesKeyForZip.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ModulesKeyForZip.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/NotConfiguredInterpreterException.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/NotConfiguredInterpreterException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/NullOutputStream.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/NullOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ObjectsPool.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ObjectsPool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ProjectMisconfiguredException.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ProjectMisconfiguredException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/PropertiesHelper.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/PropertiesHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/PythonNatureWithoutProjectException.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/PythonNatureWithoutProjectException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/TupleN.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/TupleN.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/CompleteIndexKey.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/CompleteIndexKey.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/CompleteIndexValue.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/CompleteIndexValue.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/DiskCache.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/DiskCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/PyPreferencesCache.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/PyPreferencesCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/SoftHashMap.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/SoftHashMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/SoftHashMapCache.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/cache/SoftHashMapCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/IRunnableWithMonitor.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/IRunnableWithMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/RunnableAsJobsPoolThread.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/RunnableAsJobsPoolThread.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/Semaphore.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/Semaphore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/SingleJobRunningPool.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/concurrency/SingleJobRunningPool.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ImportHandle.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ImportHandle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ImportsSelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ImportsSelection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ParsingUtils.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/ParsingUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyDocIterator.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyDocIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyImportsHandling.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyImportsHandling.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyImportsIterator.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyImportsIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyPartitionScanner.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyPartitionScanner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyPartitioner.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PyPartitioner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PythonCodeReader.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PythonCodeReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PythonPairMatcher.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PythonPairMatcher.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringSubstitution.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringUtils.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/StringUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/SyntaxErrorException.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/SyntaxErrorException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/log/Log.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/log/Log.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/parser/IPyParser.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/parser/IPyParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/path_watch/EventsStackerRunnable.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/path_watch/EventsStackerRunnable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/path_watch/PathWatch.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/path_watch/PathWatch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/performanceeval/OptimizationRelatedConstants.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/performanceeval/OptimizationRelatedConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/structure/DecoratableObject.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/structure/DecoratableObject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/DeltaSaverTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/DeltaSaverTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/EncodingsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/EncodingsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/FullRepIterableTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/FullRepIterableTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/ModulesKeyTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/ModulesKeyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/ObjectsPoolTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/ObjectsPoolTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/REFTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/REFTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestCaseUtils.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestCaseUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/cache/LRUCacheTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/cache/LRUCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/cache/SoftHashMapTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/cache/SoftHashMapTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/DocUtilsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/DocUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/ImportHandleTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/ImportHandleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/ParsingUtilsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/ParsingUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/PyImportsHandlingTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/PyImportsHandlingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringEscapeUtilsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringEscapeUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringUtilsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/path_watch/PathWatchTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/path_watch/PathWatchTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIContainerStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIContainerStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIFileStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIFileStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIFolderStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIFolderStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIProjectStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIProjectStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIResourceStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIResourceStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIWorkspaceRootStub.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/resource_stubs/AbstractIWorkspaceRootStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/FastStackTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/FastStackTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/FastStringBufferTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/FastStringBufferTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/LowMemoryArrayListTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/structure/LowMemoryArrayListTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/CustomizationsPlugin.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/CustomizationsPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/CustomizationsUIConstants.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/CustomizationsUIConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AbstractAppEngineAction.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AbstractAppEngineAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AbstractAppEngineHandler.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AbstractAppEngineHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineManage.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineManage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineManageAction.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineManageAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineUpload.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineUpload.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineUploadAction.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/actions/AppEngineUploadAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineConstants.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineLaunchShortcut.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEngineLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEnginePropertyTester.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/launching/AppEnginePropertyTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/util/AppEngineProcessWindow.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/util/AppEngineProcessWindow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineConfigWizardPage.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineConfigWizardPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineTemplatePage.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineTemplatePage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineWizard.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/app_engine/wizards/AppEngineWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/common/CustomizationCommons.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/common/CustomizationCommons.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/common/ProcessWindow.java
+++ b/plugins/org.python.pydev.customizations/src/org/python/pydev/customizations/common/ProcessWindow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.customizations/tests/org/python/pydev/customizations/app_engine/wizards/AppEngineConfigWizardPageTestWorkbench.java
+++ b/plugins/org.python.pydev.customizations/tests/org/python/pydev/customizations/app_engine/wizards/AppEngineConfigWizardPageTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/CoverageCache.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/CoverageCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/ErrorFileNode.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/ErrorFileNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/FileNode.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/FileNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/FolderNode.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/FolderNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/ICoverageLeafNode.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/ICoverageLeafNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/NodeNotFoudException.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/NodeNotFoudException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCodeCoverageView.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCodeCoverageView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoverage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoverage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoveragePreferences.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/PyCoveragePreferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/RemoveCoverageMarkersListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/codecoverage/RemoveCoverageMarkersListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleCompletionsPageParticipant.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleCompletionsPageParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleRestartLaunchPageParticipant.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleRestartLaunchPageParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ScriptConsoleViewerWrapper.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ScriptConsoleViewerWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/ConfigureExceptionsFileUtils.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/ConfigureExceptionsFileUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/Constants.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/Constants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/IConsoleInputListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/IConsoleInputListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPlugin.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPreferencesInitializer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPreferencesInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTargetWithTransmission.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTargetWithTransmission.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AdapterDebug.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AdapterDebug.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/DeferredWorkbenchAdapter.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/DeferredWorkbenchAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyBreakpoint.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyBreakpoint.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyExceptionBreakPointManager.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyExceptionBreakPointManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyReloadCode.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyReloadCode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyRunToLineTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyRunToLineTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PySetNextTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PySetNextTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PySourceLocator.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PySourceLocator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyStackFrame.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyStackFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyThread.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyThread.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariable.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariable.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableCollection.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableContentProviderHack.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableContentProviderHack.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyWatchExpressionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyWatchExpressionDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/ValueModificationChecker.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/ValueModificationChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/XMLUtils.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/XMLUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/XMLUtilsTest.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/XMLUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/AbstractDebuggerCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/AbstractDebuggerCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/AbstractRemoteDebugger.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/AbstractRemoteDebugger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ChangeVariableCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ChangeVariableCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/DebuggerReader.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/DebuggerReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/DebuggerWriter.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/DebuggerWriter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/EvaluateExpressionCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/EvaluateExpressionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetFileContentsCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetFileContentsCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetFrameCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetFrameCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetVariableCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/GetVariableCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ListenConnector.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ListenConnector.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ReloadCodeCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ReloadCodeCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoteDebugger.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoteDebugger.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoveBreakpointCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RemoveBreakpointCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RunToLineCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/RunToLineCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SendPyExceptionCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SendPyExceptionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetBreakpointCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetBreakpointCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetNextCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/SetNextCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/StepCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/StepCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadKillCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadKillCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadListCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadListCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadRunCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadRunCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadSuspendCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/ThreadSuspendCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/VersionCommand.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/remote/VersionCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ClearTerminatedAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ClearTerminatedAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/CounterPanel.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/CounterPanel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/HistoryAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/HistoryAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitLaunch.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitLaunch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitServer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitServerListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/IPyUnitServerListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/InformationPresenterWithLineTracker.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/InformationPresenterWithLineTracker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PinHistoryAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PinHistoryAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitLaunch.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitLaunch.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitProgressBar.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitProgressBar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitServer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitServer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitSortListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitSortListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestResult.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestResult.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestRun.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestRun.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestStarted.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitTestStarted.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitView.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitView.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitViewServerListener.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/PyUnitViewServerListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchErrorsAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchErrorsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchInBackgroundAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RelaunchInBackgroundAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RestorePinHistoryAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/RestorePinHistoryAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/SetCurrentRunAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/SetCurrentRunAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowOnlyFailuresAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowOnlyFailuresAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowTestRunnerPreferencesAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowTestRunnerPreferencesAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowViewOnTestRunAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/ShowViewOnTestRunAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/StopAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/pyunit/StopAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/ArgumentsTab.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/ArgumentsTab.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/DebugPrefsPage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/DebugPrefsPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IDebugPreferencesPageParticipant.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IDebugPreferencesPageParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/InterpreterTab.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/InterpreterTab.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IronpythonTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IronpythonTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IronpythonUnittestTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/IronpythonUnittestTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/JythonTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/JythonTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/JythonUnittestTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/JythonUnittestTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/MainModuleTab.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/MainModuleTab.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/ProjectDependentTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/ProjectDependentTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyConfigureExceptionDialog.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyConfigureExceptionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditBreakpointSync.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditBreakpointSync.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditRunToLineAdapterFactory.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditRunToLineAdapterFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditSetNextAdapterFactory.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyEditSetNextAdapterFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyToggleBreakpointsTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PyToggleBreakpointsTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonConsoleLineTracker.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonConsoleLineTracker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonSourceViewer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonSourceViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonUnittestTabGroup.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/PythonUnittestTabGroup.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/SourceLocatorPrefsPage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/SourceLocatorPrefsPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/TableEditor.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/TableEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/UnittestArgumentsTab.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/UnittestArgumentsTab.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/AbstractBreakpointRulerAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/AbstractBreakpointRulerAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/AbstractRunEditorAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/AbstractRunEditorAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EnableDisableBreakpointRulerAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EnableDisableBreakpointRulerAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EnableDisableBreakpointRulerActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EnableDisableBreakpointRulerActionDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EvalExpressionAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/EvalExpressionAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/ISetNextTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/ISetNextTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/ManageBreakpointRulerActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/ManageBreakpointRulerActionDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyBreakpointRulerAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyBreakpointRulerAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyConfigureExceptionAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PyConfigureExceptionAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PythonBreakpointPropertiesRulerAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PythonBreakpointPropertiesRulerAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PythonBreakpointPropertiesRulerActionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/PythonBreakpointPropertiesRulerActionDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RelaunchLastAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RelaunchLastAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RestartLaunchAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RestartLaunchAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RetargetSetNextAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RetargetSetNextAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorBasedOnNatureTypeAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorBasedOnNatureTypeAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/TerminateAllLaunchesAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/TerminateAllLaunchesAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/WatchExpressionAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/WatchExpressionAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/MainModuleBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/MainModuleBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/ProgramArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/ProgramArgumentsBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/ProjectBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/ProjectBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/PythonPathBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/PythonPathBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/VMArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/VMArgumentsBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/WorkingDirectoryBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/WorkingDirectoryBlock.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/hover/PyDebugHover.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/hover/PyDebugHover.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/AbstractLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/AbstractLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/AbstractLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/AbstractLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/CoverageLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/CoverageLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/CoverageLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/CoverageLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/FileOrResource.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/FileOrResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/InterpreterTypeTester.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/InterpreterTypeTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonUnitTestLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonUnitTestLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonUnittestLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/IronpythonUnittestLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonUnitTestLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonUnitTestLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonUnittestLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/JythonUnittestLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/LaunchConfigurationCreator.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/LaunchConfigurationCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/LaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/LaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunner.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerCallbacks.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerCallbacks.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/RegularLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/RegularLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/UnitTestLaunchShortcut.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/UnitTestLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/UnittestLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/UnittestLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/BreakpointConditionEditor.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/BreakpointConditionEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/propertypages/PythonBreakpointPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsole.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCommunication.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCommunication.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCompletionProcessor.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCompletionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleConstants.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleFactory.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsolePreferencesInitializer.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsolePreferencesInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleQuickAssistProcessor.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleQuickAssistProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsoleFrame.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevDebugConsoleFrame.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseInterpreterManager.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseProcess.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/JythonEclipseProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevSpawnedInterpreterProcess.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevSpawnedInterpreterProcess.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/prefs/ColorManager.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/prefs/ColorManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/prefs/InteractiveConsolePrefs.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/prefs/InteractiveConsolePrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/CoverageCacheTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/CoverageCacheTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/PyCodeCoverageTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/PyCodeCoverageTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/XmlRpcTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/codecoverage/XmlRpcTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/model/AbstractDebugTargetTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/model/AbstractDebugTargetTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitTestResultTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitTestResultTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitView2TestTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitView2TestTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitViewTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitViewTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitViewTestTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/pyunit/PyUnitViewTestTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/DebuggerTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/DebuggerTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/PythonConsoleLineTrackerTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/PythonConsoleLineTrackerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/SourceLocatorTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/SourceLocatorTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/launching/PythonRunnerConfigTestWorkbench.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/ui/launching/PythonRunnerConfigTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/DjangoPlugin.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/DjangoPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoAction.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoActionCreatorPyEditListener.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoActionCreatorPyEditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoCreateApp.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoCreateApp.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoCustomCommand.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoCustomCommand.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoShell.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoShell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoSyncDB.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoSyncDB.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoTestAction.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoTestAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoWar.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/DjangoWar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/PyDjangoOfflineAction.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/debug/ui/actions/PyDjangoOfflineAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoConstants.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoLaunchConfigurationDelegate.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoLaunchConfigurationDelegate.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoLaunchShortcut.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoLaunchShortcut.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoPropertyTester.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/DjangoPropertyTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/PythonFileRunner.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/launching/PythonFileRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoAddNatureAction.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoAddNatureAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoNature.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoRemoveNatureAction.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/nature/DjangoRemoveNatureAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoNewProjectPage.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoNewProjectPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoNotAvailableWizardPage.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoNotAvailableWizardPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoProjectWizard.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoProjectWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoSettingsPage.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/DjangoSettingsPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/ErrorWizardPage.java
+++ b/plugins/org.python.pydev.django/src/org/python/pydev/django/ui/wizards/project/ErrorWizardPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/IInteractiveConsole.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/IInteractiveConsole.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/IPythonInterpreter.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/IPythonInterpreter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPlugin.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/JythonPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/PythonInterpreterWrapper.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/PythonInterpreterWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/PythonInterpreterWrapperNotShared.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/PythonInterpreterWrapperNotShared.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptOutput.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptOutput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptingExtensionInitializer.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptingExtensionInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ui/JyScriptingPreferencesPage.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ui/JyScriptingPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.jython/src_jython/org/python/parser/ReaderCharStream.java
+++ b/plugins/org.python.pydev.jython/src_jython/org/python/parser/ReaderCharStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/IGrammar.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/IGrammar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/ParserPlugin.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/ParserPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParserManager.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/PyParserManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/FastDefinitionsParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/FastDefinitionsParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/FastParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/FastParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/ScopesParser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/ScopesParser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/TabNannyDocIterator.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/fastparser/TabNannyDocIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractGrammarErrorHandlers.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractGrammarErrorHandlers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractGrammarWalkHelpers.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractGrammarWalkHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractPythonGrammar.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractPythonGrammar.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTokenManager.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTokenManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTreeBuilder.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTreeBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTreeBuilderHelpers.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/AbstractTreeBuilderHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ComprehensionCollection.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ComprehensionCollection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/CtxVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/CtxVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/Decorators.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/Decorators.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/DefaultArg.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/DefaultArg.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ITreeBuilder.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ITreeBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ITreeConstants.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/ITreeConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/IdentityNode.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/IdentityNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/JJTPythonGrammarState.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/JJTPythonGrammarState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/TokensIterator.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/TokensIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/FastCharStream.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/FastCharStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ICompilerAPI.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ICompilerAPI.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ISpecialStr.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ISpecialStr.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Node.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Node.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ParseException.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/ParseException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/SimpleNode.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/SimpleNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/SpecialStr.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/SpecialStr.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Token.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Token.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/TokenMgrError.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/TokenMgrError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Visitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/jython/Visitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/AbstractLinePart.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/AbstractLinePart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/Formatter.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/Formatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IFormatter.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/ILinePartIndentMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/ILinePartIndentMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/ILinePartStatementMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/ILinePartStatementMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IPrettyPrinterPrefs.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IPrettyPrinterPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IWriterEraser.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/IWriterEraser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePart.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePart.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartIndentMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartIndentMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireAdded.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireAdded.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireIndentMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireIndentMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartRequireMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartStatementMark.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/LinePartStatementMark.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/MakeAstValidForPrettyPrintingVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/MakeAstValidForPrettyPrintingVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterDocLineEntry.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterDocLineEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterDocV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterDocV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterPrefsV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterPrefsV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterUtilsV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterUtilsV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterVisitorV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/PrettyPrinterVisitorV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriteStateV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriteStateV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriterEraserV2.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/prettyprinterv2/WriterEraserV2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/FindLastLineVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/FindLastLineVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/NodeUtils.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/NodeUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/PythonLanguageUtils.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/PythonLanguageUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/comparator/SimpleNodeComparator.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/comparator/SimpleNodeComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ASTEntry.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ASTEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ASTEntryWithChildren.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ASTEntryWithChildren.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/CodeFoldingVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/CodeFoldingVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/DefinitionsASTIteratorVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/DefinitionsASTIteratorVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorWithChildrenVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorWithChildrenVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorWithLoop.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyASTIteratorWithLoop.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyAstIteratorBase.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/EasyAstIteratorBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/GetNodeForExtractLocalVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/GetNodeForExtractLocalVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/NameIterator.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/NameIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/OutlineCreatorVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/OutlineCreatorVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/OutlineIterator.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/OutlineIterator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ReturnVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/ReturnVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/SequencialASTIteratorVisitor.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/scope/SequencialASTIteratorVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser25Test.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser25Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser26Test.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser26Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser27Test.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser27Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser30Test.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParser30Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserEditorIntegrationTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserEditorIntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserErrorsTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserErrorsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserPrintTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserPrintTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserTestBase.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PyParserTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PythonNatureStub.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/PythonNatureStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/FastDefinitionsParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/FastDefinitionsParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/FastParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/FastParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/ScopesParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/fastparser/ScopesParserTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/grammarcommon/TokensIteratorTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/grammarcommon/TokensIteratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/jython/ReaderCharStreamTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/jython/ReaderCharStreamTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/AbstractPrettyPrinterTestBase.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/AbstractPrettyPrinterTestBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/MessLinesAndColumnsVisitor.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/MessLinesAndColumnsVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinter30LibTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinter30LibTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinter30Test.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinter30Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinterLibTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinterLibTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinterTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/prettyprinter/PrettyPrinterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/profile/ParseBigFile.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/profile/ParseBigFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/NodeUtilsTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/NodeUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/ParsingUtilsTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/ParsingUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/scope/CodeFoldingVisitorTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/scope/CodeFoldingVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/scope/EasyASTIteratorTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/scope/EasyASTIteratorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/FindDuplicatesVisitor.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ast/visitors/FindDuplicatesVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/ast/visitors/FindDuplicatesVisitorTest.java
+++ b/plugins/org.python.pydev.refactoring/tests/org/python/pydev/refactoring/ast/visitors/FindDuplicatesVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/SharedCorePlugin.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/SharedCorePlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyBackspaceHelper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/auto_edit/AutoEditStrategyBackspaceHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc and Fabio Zadrozny. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc and Fabio Zadrozny. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/Cache.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/Cache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/CacheMapWrapper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/CacheMapWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/LRUCache.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/LRUCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/LRUMap.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/cache/LRUMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/CallbackWithListeners.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/CallbackWithListeners.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback0.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback0.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback2.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallback2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallbackListener.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallbackListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallbackWithListeners.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/callbacks/ICallbackWithListeners.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ExtendedByteArrayOutputStream.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ExtendedByteArrayOutputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/PipedInputStream.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/PipedInputStream.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ThreadStreamReader.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ThreadStreamReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ThreadStreamReaderPrinter.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/ThreadStreamReaderPrinter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/ErrorDescription.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/ErrorDescription.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/IModelListener.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/IModelListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/ISimpleNode.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/model/ISimpleNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/net/LocalHost.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/net/LocalHost.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/net/SocketUtil.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/net/SocketUtil.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ChangedParserInfoForObservers.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ChangedParserInfoForObservers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ErrorParserInfoForObservers.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ErrorParserInfoForObservers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver2.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver3.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/IParserObserver3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ParserScheduler.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ParserScheduler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ParsingThread.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/parsing/ParsingThread.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/FastStringBuffer.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/FastStringBuffer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/NoPeerAvailableException.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/NoPeerAvailableException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/SelectionKeeper.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/SelectionKeeper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/TextSelectionUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/TextSelectionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/CollectionFactory.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/CollectionFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/DataAndImageTreeNode.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/DataAndImageTreeNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/FastStack.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/FastStack.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/ImmutableTuple.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/ImmutableTuple.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Location.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Location.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/LowMemoryArrayList.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/LowMemoryArrayList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/TreeNode.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/TreeNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple3.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple4.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/structure/Tuple4.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/ArrayUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/ArrayUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/DocCmd.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/DocCmd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/Timer.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/utils/Timer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IXmlRpcClient.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IXmlRpcClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ScriptXmlRpcClient.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ScriptXmlRpcClient.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/IConsoleStyleProvider.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/IConsoleStyleProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/ScriptStyleRange.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/ScriptStyleRange.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ClipboardHandler.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ClipboardHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IScriptConsoleViewer2ForDocumentListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IScriptConsoleViewer2ForDocumentListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/HandleDeletePreviousWord.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/HandleDeletePreviousWord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/HandleLineStartAction.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/HandleLineStartAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/IInteractiveConsoleConstants.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/IInteractiveConsoleConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/AbstractHistoryElementListSelectionDialog.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/AbstractHistoryElementListSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryElementListSelectionDialog.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryElementListSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryFilteredList.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryFilteredList.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ColorCache.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ColorCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/FontUtils.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/FontUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/IFontUsage.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/IFontUsage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ImageCache.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/ImageCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/UIConstants.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/UIConstants.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bindings/KeyBindingHelper.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bindings/KeyBindingHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/BundleInfo.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/BundleInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/BundleUtils.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/BundleUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/IBundleInfo.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/bundle/IBundleInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/content_assist/AbstractCompletionProcessorWithCycling.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/content_assist/AbstractCompletionProcessorWithCycling.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/dialogs/DialogMemento.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/dialogs/DialogMemento.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/dialogs/TreeSelectionDialog.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/dialogs/TreeSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener2.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener3.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener4.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/IPyEditListener4.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/PyEditNotifier.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/editor/PyEditNotifier.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/field_editors/LinkFieldEditor.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/field_editors/LinkFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/field_editors/MultiStringFieldEditor.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/field_editors/MultiStringFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/AbstractOutlineFilterAction.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/AbstractOutlineFilterAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/IOutlineModel.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/IOutlineModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineLinkWithEditorAction.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineLinkWithEditorAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineSortByNameAction.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/OutlineSortByNameAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ParsedContentProvider.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ParsedContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ParsedLabelProvider.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/outline/ParsedLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/IPyCompletionProposal.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/IPyCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/PyCompletionPresentationUpdater.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/PyCompletionPresentationUpdater.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/PyCompletionProposal.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/proposals/PyCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/quick_outline/DataAndImageTreeNodeContentProvider.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/quick_outline/DataAndImageTreeNodeContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/ToolTipHandler.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/ToolTipHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/AbstractInformationPresenter.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/AbstractInformationPresenter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/AbstractTooltipInformationPresenter.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/AbstractTooltipInformationPresenter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/IInformationPresenterAsTooltip.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/IInformationPresenterAsTooltip.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/IInformationPresenterControlManager.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/IInformationPresenterControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/ITooltipInformationProvider.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/ITooltipInformationProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterControlManager.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterControlManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterControlManager2.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterControlManager2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterHelpers.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/InformationPresenterHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/StyleRangeWithCustomData.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/StyleRangeWithCustomData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/ToolTipPresenterHandler.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tooltips/presenter/ToolTipPresenterHandler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tree/PyFilteredTree.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/tree/PyFilteredTree.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/AsynchronousProgressMonitorDialog.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/AsynchronousProgressMonitorDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/IViewWithControls.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/IViewWithControls.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/PyMarkerUtils.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/PyMarkerUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/RunInUiThread.java
+++ b/plugins/org.python.pydev.shared_ui/src/org/python/pydev/shared_ui/utils/RunInUiThread.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev.shared_ui/src_overview_ruler/org/python/pydev/overview_ruler/MinimapOverviewRulerPreferencesPage.java
+++ b/plugins/org.python.pydev.shared_ui/src_overview_ruler/org/python/pydev/overview_ruler/MinimapOverviewRulerPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/JDTNotAvailableException.java
+++ b/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/JDTNotAvailableException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/JavaVmLocationFinder.java
+++ b/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/JavaVmLocationFinder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/PythonListEditor.java
+++ b/plugins/org.python.pydev/src/org/python/copiedfromeclipsesrc/PythonListEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilderPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilderPrefPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilderVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevBuilderVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevDeltaCounter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PyDevDeltaCounter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PydevGrouperVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PydevGrouperVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/PydevInternalResourceDeltaVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/PydevInternalResourceDeltaVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pycremover/PycHandlerBuilderVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pycremover/PycHandlerBuilderVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintPrefInitializer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintPrefInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintPrefPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/syntaxchecker/ClearSyntaxMarkersPyeditListener.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/syntaxchecker/ClearSyntaxMarkersPyeditListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/syntaxchecker/PySyntaxChecker.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/syntaxchecker/PySyntaxChecker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/todo/PyTodoPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/todo/PyTodoPrefPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/builder/todo/PyTodoVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/todo/PyTodoVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/changed_lines/ChangedLinesComputer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/changed_lines/ChangedLinesComputer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/changed_lines/LineComparator.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/changed_lines/LineComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/compare/PyContentViewerCreator.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/compare/PyContentViewerCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/compare/PyMergeViewer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/compare/PyMergeViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/consoles/MessageConsoles.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/consoles/MessageConsoles.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/ActionInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/ActionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/ICodeScannerKeywords.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/ICodeScannerKeywords.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/IOfflineActionWithParameters.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/IOfflineActionWithParameters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/KeyAssistDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/KeyAssistDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/OfflineActionsManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/OfflineActionsManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyCodeScanner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyCodeScanner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyColoredScanner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyColoredScanner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyDocumentProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyDocumentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyDocumentSetupParticipant.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyDocumentSetupParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyDoubleClickStrategy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyDoubleClickStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+* Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
 * Licensed under the terms of the Eclipse Public License (EPL).
 * Please see the license.txt included with this distribution for details.
 * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditBasedCodeScannerKeywords.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditBasedCodeScannerKeywords.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfigurationWithoutEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfigurationWithoutEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditTitle.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditTitle.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyLineBreakReader.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyLineBreakReader.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/StyledTextForShowingCodeFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/StyledTextForShowingCodeFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/AbstractBlockCommentAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/AbstractBlockCommentAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/FirstCharAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/FirstCharAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/IOrganizeImports.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/IOrganizeImports.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OfflineAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OfflineAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OfflineActionTarget.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OfflineActionTarget.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OrganizeImportsFixesUnused.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/OrganizeImportsFixesUnused.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Copyright (c) 2013 by Syapse, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAddBlockComment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAddBlockComment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAddSingleBlockComment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyAddSingleBlockComment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyBackspace.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyBackspace.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyComment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyComment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyConvertSpaceToTab.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyConvertSpaceToTab.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyConvertTabToSpace.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyConvertTabToSpace.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyCopyQualifiedName.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyCopyQualifiedName.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyFormatStd.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyFormatStd.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyGoToMatchingBracket.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyGoToMatchingBracket.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMethodNavigation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMethodNavigation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineDownAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineDownAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineUpAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyMoveLineUpAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyNextMethod.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyNextMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOpenAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOpenAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOrganizeImports.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyOrganizeImports.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Copyright (c) 2013 by Syapse, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyPeerLinker.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyPeerLinker.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyPreviousMethod.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyPreviousMethod.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyRemoveBlockComment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyRemoveBlockComment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeDeselection.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeDeselection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeSelection.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyScopeSelection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PySelectWord.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PySelectWord.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShiftLeft.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShiftLeft.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShowBrowser.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShowBrowser.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShowOutline.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyShowOutline.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyToggleComment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyToggleComment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyToggleForceTabs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyToggleForceTabs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyUncomment.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyUncomment.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyWrapParagraph.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyWrapParagraph.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapse.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapseAll.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyCollapseAll.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapse.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapse.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/refactoring/PyRefactorAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/refactoring/PyRefactorAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/AbstractIndentPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/AbstractIndentPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/DefaultIndentPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/DefaultIndentPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/PyAutoIndentStrategy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/PyAutoIndentStrategy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/TestIndentPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/autoedit/TestIndentPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/MarkerAnnotationAndPosition.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/MarkerAnnotationAndPosition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyEditProjection.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyEditProjection.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyProjectionAnnotation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyProjectionAnnotation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PySourceViewer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PySourceViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/commentblocks/CommentBlocksPreferences.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/commentblocks/CommentBlocksPreferences.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/FixCompletionProposal.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/FixCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/MarkerResolution.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/MarkerResolution.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PyCorrectionAssistant.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PyCorrectionAssistant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PyQuickFix.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PyQuickFix.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PythonCorrectionProcessor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PythonCorrectionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/AssistDocString.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/AssistDocString.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/DocstringsPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/DocstringsPrefPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/ParameterNamePrefixListEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/ParameterNamePrefixListEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssign.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssign.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssignCompletionProposal.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistAssignCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistImport.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistImport.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistSurroundWith.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/AssistSurroundWith.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/IAssistProps.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/heuristics/IAssistProps.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyAnnotationHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyAnnotationHover.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/model/ItemPointer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/model/ItemPointer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/model/LengthEstimator.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/model/LengthEstimator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/AbstractPyRefactoring.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/AbstractPyRefactoring.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/IPyRefactoring.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/IPyRefactoring.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/PyRefactoringFindDefinition.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/PyRefactoringFindDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/RefactoringRequest.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/refactoring/RefactoringRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/scripting/PyEditScripting.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/scripting/PyEditScripting.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/templates/PyContextType.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/templates/PyContextType.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/templates/PyTemplateVariableResolver.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/templates/PyTemplateVariableResolver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/templates/TemplateHelper.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/templates/TemplateHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyFileLabelProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyFileLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyOpenEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PyOpenEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PySourceLocatorBase.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PySourceLocatorBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PySourceLocatorPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PySourceLocatorPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevFileEditorInput.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevFileEditorInput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevZipFileEditorInput.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevZipFileEditorInput.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevZipFileStorage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editorinput/PydevZipFileStorage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/logging/DebugSettings.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/logging/DebugSettings.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/logging/PyLoggingPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/logging/PyLoggingPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideCommentsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideCommentsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideFieldsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideFieldsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideImportsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideImportsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideMagicObjectsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideMagicObjectsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideNonPublicMembersAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideNonPublicMembersAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideStaticMethodsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/OutlineHideStaticMethodsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedItem.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedItem.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedModel.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/ParsedModel.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/outline/PyOutlinePage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/outline/PyOutlinePage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/AbstractPythonNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/AbstractPythonNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonNatureListener.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonNatureListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonNatureStore.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonNatureStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonPathContributor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonPathContributor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonPathHelper.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/IPythonPathHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PyNatureReindexer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PyNatureReindexer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureListenersManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureListenersManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureStore.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonNatureStore.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonPathNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/PythonPathNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/SystemPythonNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/SystemPythonNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/IPydevPreferencesProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/IPydevPreferencesProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeFormatterPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeFormatterPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeStylePreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeStylePreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyTitlePreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyTitlePreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevRootPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevRootPrefs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/pyunit/preferences/PyUnitPrefsPage2.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/pyunit/preferences/PyUnitPrefsPage2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleExeRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleExeRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleIronpythonRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleIronpythonRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimplePythonRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimplePythonRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/runners/UniversalRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/UniversalRunner.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeContentProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeContentProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeLabelProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/tree/FileTreeLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/ColorAndStyleCache.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/ColorAndStyleCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/IViewCreatedObserver.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/IViewCreatedObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectProperties.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectProperties.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/SetOrientationAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/SetOrientationAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/StreamConsumer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/StreamConsumer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/TabVariables.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/TabVariables.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/ViewPartWithOrientation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/ViewPartWithOrientation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyAddSrcFolder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyAddSrcFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyContainerAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyContainerAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyContainerFormatterAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyContainerFormatterAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Copyright (c) 2013 by Syapse, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyDeleteErrors.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyDeleteErrors.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyDeletePycAndClassFiles.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyDeletePycAndClassFiles.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyOrganizeImportsAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyOrganizeImportsAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Copyright (c) 2013 by Syapse, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyRemSrcFolder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PyRemSrcFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PySourceFormatAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/container/PySourceFormatAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyAddNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyAddNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyRemoveNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/project/PyRemoveNature.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/resources/Py2To3.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/resources/Py2To3.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/actions/resources/PyResourceAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/actions/resources/PyResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/AbstractKeyValueDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/AbstractKeyValueDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/AbstractMapOfStringsInputDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/AbstractMapOfStringsInputDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/InterpreterInputDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/InterpreterInputDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/MapOfStringsInputDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/MapOfStringsInputDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/Package.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/Package.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/ProjectSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PyDialogHelpers.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PyDialogHelpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonModulePickerDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonModulePickerDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonPackageSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/PythonPackageSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/SelectExistingOrCreateNewDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/SelectExistingOrCreateNewDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/SourceFolder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/SourceFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/editors/TreeWithAddRemove.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/editors/TreeWithAddRemove.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/filetypes/FileTypesPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/filetypes/FileTypesPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/importsconf/ImportsPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/importsconf/ImportsPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/ChooseInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/ChooseInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IInterpreterObserver.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IInterpreterObserver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/perspective/PythonPerspectiveFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/perspective/PythonPerspectiveFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractListWithNewRemoveControl.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractListWithNewRemoveControl.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterInfoBuilder.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IInterpreterInfoBuilder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/MyEnvWorkingCopy.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/ObtainInterpreterInfoOperation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/ObtainInterpreterInfoOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PyListSelectionDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PyListSelectionDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonSelectionLibrariesDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonSelectionLibrariesDialog.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/AbstractPythonWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonModuleWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonModuleWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonPackageWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonPackageWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/files/PythonSourceFolderWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/AbstractNewProjectPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/AbstractNewProjectPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/AbstractNewProjectWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/AbstractNewProjectWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/GettingStartedPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/GettingStartedPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/PythonGettingStartedWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/gettingstarted/PythonGettingStartedWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/IWizardNewProjectNameAndLocationPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/IWizardNewProjectNameAndLocationPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/wizards/project/PythonProjectWizard.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/ComboFieldEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/ComboFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/CounterThread.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/CounterThread.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/CustomizableFieldEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/CustomizableFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/JobProgressComunicator.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/JobProgressComunicator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/LabelFieldEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/LabelFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/LabelFieldEditorWith2Cols.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/LabelFieldEditorWith2Cols.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/PrintProgressMonitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/PrintProgressMonitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressOperation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/ProgressOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/PyFileListing.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/PyFileListing.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/TableComboFieldEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/TableComboFieldEditor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableCombo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableCombo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableComboViewer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableComboViewer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableComboViewerRow.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/tablecombo/TableComboViewerRow.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractPyCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractPyCodeCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractPyCompletionProposalExtension2.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractPyCompletionProposalExtension2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractTemplateCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/AbstractTemplateCodeCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionError.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionRequest.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/CompletionRequest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyCalltipsContextInformation.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyCalltipsContextInformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyCodeCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyDevCompletionParticipant.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyDevCompletionParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyDevCompletionParticipant2.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/IPyDevCompletionParticipant2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/OverrideMethodCompletionProposal.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/OverrideMethodCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/ProposalsComparator.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/ProposalsComparator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformation.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformationFromIToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformationFromIToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionImages.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionImages.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionInitializer.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionInitializer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionPreferencesPage.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionPreferencesPage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionUtils.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyContentAssistant.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyContentAssistant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyContextInformationValidator.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyContextInformationValidator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyLinkedModeCompletionProposal.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyLinkedModeCompletionProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyStringCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyStringCodeCompletion.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonCompletionProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonCompletionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonStringCompletionProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PythonStringCompletionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ASTManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ASTManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractASTManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractASTManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AbstractToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignAnalysis.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignAnalysis.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignCompletionInfo.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/AssignCompletionInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionCache.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionParticipantsHelper.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionParticipantsHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionState.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionState.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionStateFactory.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionStateFactory.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionStateWrapper.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/CompletionStateWrapper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ConcreteToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ConcreteToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesFoundStructure.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesFoundStructure.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerCache.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerCache.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerWithBuild.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerWithBuild.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ProjectModulesManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/ProjectModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyCodeCompletionVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyCodeCompletionVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyPublicTreeMap.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PyPublicTreeMap.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelper.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SourceModuleProposal.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SourceModuleProposal.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SystemASTManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SystemASTManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SystemModulesManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/SystemModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/AbstractJavaClassModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/AbstractJavaClassModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaDefinition.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaElementToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaElementToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaModuleInProject.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaModuleInProject.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaProjectModulesManager.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaProjectModulesManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaProjectModulesManagerCreator.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaProjectModulesManagerCreator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaZipModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaZipModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JythonModulesManagerUtils.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JythonModulesManagerUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/ModulesKeyForJava.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/ModulesKeyForJava.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/ASTEntryWithSourceModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/ASTEntryWithSourceModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/AbstractModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/AbstractModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/CompiledToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/EmptyModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/EmptyModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/EmptyModuleForZip.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/EmptyModuleForZip.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/PredefinedSourceModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/PredefinedSourceModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceModule.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceToken.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/modules/SourceToken.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AbstractVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AbstractVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AssignDefinition.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AssignDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/Definition.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/Definition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindDefinitionModelVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindDefinitionModelVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindScopeVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindScopeVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/GlobalModelVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/GlobalModelVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/HeuristicFindAttrs.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/HeuristicFindAttrs.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/InnerModelVisitor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/InnerModelVisitor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/KeywordParameterDefinition.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/KeywordParameterDefinition.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/LocalScope.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/LocalScope.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/StopVisitingException.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/revisited/visitors/StopVisitingException.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/AbstractShell.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/AbstractShell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/IronpythonShell.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/IronpythonShell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/JythonShell.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/JythonShell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/ProcessCreationInfo.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/ProcessCreationInfo.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/PythonShell.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/shell/PythonShell.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/DocumentTemplateContextWithIndent.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/DocumentTemplateContextWithIndent.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContext.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContext.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyTemplateCompletionProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/templates/PyTemplateCompletionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/ISimpleAssistParticipant.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/ISimpleAssistParticipant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/ISimpleAssistParticipant2.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/ISimpleAssistParticipant2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/SimpleAssistProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/SimpleAssistProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/InterpreterInfoTreeNode.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/InterpreterInfoTreeNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/InterpreterInfoTreeNodeRoot.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/InterpreterInfoTreeNodeRoot.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/LabelAndImage.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/LabelAndImage.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ModelAdapter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ModelAdapter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ProjectInfoForPackageExplorer.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ProjectInfoForPackageExplorer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PyPackageStateSaver.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PyPackageStateSaver.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonBaseModelProvider.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonBaseModelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonLabelProvider.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonLabelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonModelProvider.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonModelProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonpathTreeNode.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonpathTreeNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonpathZipChildTreeNode.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/PythonpathZipChildTreeNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/TopLevelProjectsOrWorkingSetChoice.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/TopLevelProjectsOrWorkingSetChoice.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ZipStructure.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ZipStructure.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/Helpers.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/Helpers.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyCopyResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyCopyResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyDeleteResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyDeleteResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyMoveResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyMoveResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenExternalAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenExternalAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenPythonFileAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenPythonFileAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyOpenResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyPasteAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyPasteAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PyRenameResourceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PySetupCustomFilters.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PySetupCustomFilters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonActionProvider.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonActionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonLinkHelper.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonLinkHelper.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonRefactorActionProvider.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/PythonRefactorActionProvider.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyFilesAndFoldersOperation.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/CopyFilesAndFoldersOperation.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/PasteAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/PasteAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/PyResourceDropAdapterAssistant.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/PyResourceDropAdapterAssistant.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/WorkspaceAction.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/actions/copied/WorkspaceAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/decorator/ProblemMarkerManager.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/decorator/ProblemMarkerManager.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/decorator/ProblemsLabelDecorator.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/decorator/ProblemsLabelDecorator.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/ISortedElement.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/ISortedElement.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/IWrappedResource.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/IWrappedResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/ProjectConfigError.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/ProjectConfigError.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonFile.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonFile.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonFolder.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonNode.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonNode.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonProjectSourceFolder.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonProjectSourceFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonResource.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonSourceFolder.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonSourceFolder.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonSourceFolderActionFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/PythonSourceFolderActionFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/WrappedResource.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/elements/WrappedResource.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/AbstractFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/AbstractFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ClassFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ClassFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ClosedProjectsFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ClosedProjectsFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/CommentsFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/CommentsFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/CustomFilters.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/CustomFilters.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/DotStartFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/DotStartFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ImportsFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/ImportsFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/InterpreterInfoFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/InterpreterInfoFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PyTildaFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PyTildaFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PycFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PycFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PydevProjectsFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PydevProjectsFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PyoFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PyoFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PythonNodeFilter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/filters/PythonNodeFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/properties/PyPropertyTester.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/properties/PyPropertyTester.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/sorter/PythonModelSorter.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/sorter/PythonModelSorter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ui/PydevPackageExplorer.java
+++ b/plugins/org.python.pydev/src_navigator/org/python/pydev/navigator/ui/PydevPackageExplorer.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/copiedfromeclipsesrc/PythonCodeReaderTest.java
+++ b/plugins/org.python.pydev/tests/org/python/copiedfromeclipsesrc/PythonCodeReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/copiedfromeclipsesrc/PythonPairMatcherTest.java
+++ b/plugins/org.python.pydev/tests/org/python/copiedfromeclipsesrc/PythonPairMatcherTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/builder/todo/PyTodoVisitorTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/builder/todo/PyTodoVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/eclipseresourcestubs/FileResourceStub.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/eclipseresourcestubs/FileResourceStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyAutoIndentStrategyTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyAutoIndentStrategyTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyCodeScannerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyCodeScannerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyEditTitleTestWorkbench.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyEditTitleTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyInformationPresenterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyInformationPresenterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/PyPartitionScannerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/PyPartitionScannerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyActionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyAddBlockCommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyAddBlockCommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyAddSingleBlockCommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyAddSingleBlockCommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyBackspaceTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyBackspaceTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyCommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyCommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatStdTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatStdTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyMoveLineActionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyMoveLineActionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyOrganizeImportsTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyOrganizeImportsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyPeerLinkerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyPeerLinkerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyRemoveBlockCommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyRemoveBlockCommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyScopeSelectionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyScopeSelectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyShiftLeftTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyShiftLeftTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyToggleCommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyToggleCommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyUncommentTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyUncommentTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/SelectionKeeperTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/SelectionKeeperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/AssistDocStringTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/AssistDocStringTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistAssignTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistAssignTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistCreateInModuleTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistCreateInModuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistSurroundWithTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/correctionassist/heuristics/AssistSurroundWithTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/model/ItemPointerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/model/ItemPointerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/ironpythontests/IronpythonTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ironpythontests/IronpythonTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/jythontests/JythonTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/jythontests/JythonTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/outline/ParsedItemTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/outline/ParsedItemTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/PydevTestUtils.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/PydevTestUtils.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/FileStub2.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/FileStub2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/ProjectImportedHasAstManagerTestWorkbench.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/ProjectImportedHasAstManagerTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/ProjectStub2.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/ProjectStub2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/PythonNatureStoreTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/PythonNatureStoreTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/SaveFileWithoutNatureTestWorkbench.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/plugin/nature/SaveFileWithoutNatureTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/pythontests/AbstractBasicRunTestCase.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/pythontests/AbstractBasicRunTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/pythontests/PythonTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/pythontests/PythonTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/IronPythonUniversalRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/IronPythonUniversalRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/JythonUniversalRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/JythonUniversalRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/PythonUniversalRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/PythonUniversalRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleExeRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleExeRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleIronpythonRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleIronpythonRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleJythonRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/SimpleJythonRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/SimplePythonRunnerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/SimplePythonRunnerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/runners/ThreadStreamReaderTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/runners/ThreadStreamReaderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/BundleInfoStub.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/BundleInfoStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/SWTTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/SWTTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/interpreters/InterpreterManagerTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/interpreters/InterpreterManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/IronPythonCodeCompletionTestsBase.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/IronPythonCodeCompletionTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/IronpythonCompletionWithBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/IronpythonCompletionWithBuiltinsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformationTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCalltipsContextInformationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion2Test.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion2Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionUtilsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyCodeCompletionUtilsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyContextInformationValidatorTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PyContextInformationValidatorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonApplyCompletionsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonApplyCompletionsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletion25Test.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletion25Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionCalltipsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionCalltipsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionParametersTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionParametersTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionStringsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionStringsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithBuiltinsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithPredefinedBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithPredefinedBuiltinsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsGrammar3Test.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsGrammar3Test.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionZipsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionZipsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ASTManagerTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ASTManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/AbstractTokenTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/AbstractTokenTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/CodeCompletionTestsBase.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/CodeCompletionTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/FindActualDefinitionTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/FindActualDefinitionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/IronpythonInterpreterManagerStub.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/IronpythonInterpreterManagerStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ModuleTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ModuleTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ModulesManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ProjectModulesManagerTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ProjectModulesManagerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ProjectStub.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/ProjectStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonInterpreterManagerStub.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonInterpreterManagerStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelperTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelperTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/AbstractWorkbenchTestCase.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/AbstractWorkbenchTestCase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaClassModuleTestWorkbench.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/javaintegration/JavaClassModuleTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/AbstractJythonWorkbenchTests.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/AbstractJythonWorkbenchTests.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonCodeCompletionTestsBase.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonCodeCompletionTestsBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonCompletionWithBuiltinsTestWorkbench.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonCompletionWithBuiltinsTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonFindDefinitionTestWorkbench.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonFindDefinitionTestWorkbench.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonInterpreterManagerStub.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/jython/JythonInterpreterManagerStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AbstractVisitorTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/AbstractVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindDefinitionModelVisitorTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindDefinitionModelVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindScopeVisitorTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/visitors/FindScopeVisitorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/shell/PythonShellTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/shell/PythonShellTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContextTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/templates/PyDocumentTemplateContextTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ScriptConsoleHistoryTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ScriptConsoleHistoryTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/ScriptConsolePartitionerTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/ScriptConsolePartitionerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleDocumentListenerTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleDocumentListenerTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/actions/HandleDeletePreviousWordTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/actions/HandleDeletePreviousWordTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/FileStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/FileStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/FolderStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/FolderStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/ProjectStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/ProjectStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/PythonModelProviderTest.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/PythonModelProviderTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/PythonPathNatureStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/PythonPathNatureStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceRootStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceRootStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceStub.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/WorkspaceStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.

--- a/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/ZipStructureTest.java
+++ b/plugins/org.python.pydev/tests_navigator/org/python/pydev/navigator/ZipStructureTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.


### PR DESCRIPTION
---

All I did here was replace all end years in copyright lines to the most recent year the file was edited. If that is unnecessary, ignore this patch.
