### PR TITLE
Replace non-comment occurrences of 'Iron Python' with 'IronPython'.

### DIFF
--- a/plugins/org.python.pydev.debug/plugin.xml
+++ b/plugins/org.python.pydev.debug/plugin.xml
@@ -120,7 +120,7 @@
         delegate="org.python.pydev.debug.ui.launching.IronpythonLaunchConfigurationDelegate"
         id="org.python.pydev.debug.ironpythonLaunchConfigurationType"
         modes="run, debug, interactive"
-        name="Iron Python Run"
+        name="IronPython Run"
         public="true">
 	</launchConfigurationType>
 	<launchConfigurationType
@@ -141,7 +141,7 @@
         delegate="org.python.pydev.debug.ui.launching.IronpythonUnittestLaunchConfigurationDelegate"
         id="org.python.pydev.debug.ironpythonUnittestLaunchConfigurationType"
         modes="run, debug"
-        name="Iron Python unittest"
+        name="IronPython unittest"
         public="true">
 	</launchConfigurationType>
     <launchConfigurationType
@@ -206,7 +206,7 @@
 <!--- launcher tab group -->
 <extension point="org.eclipse.debug.ui.launchConfigurationTabGroups">
 
-	<!--Iron Python-->
+	<!--IronPython-->
 	<launchConfigurationTabGroup
 		type="org.python.pydev.debug.ironpythonLaunchConfigurationType"
 		class="org.python.pydev.debug.ui.IronpythonTabGroup"
@@ -294,7 +294,7 @@
         <configurationType id="org.python.pydev.debug.regularLaunchConfigurationType"/>
 	</shortcut>
 	<shortcut
-		label="Iron Python Run"
+		label="IronPython Run"
 		icon="icons/ironpython_run.png"
 		modes="run, debug"
 		class="org.python.pydev.debug.ui.launching.IronpythonLaunchShortcut"
@@ -403,7 +403,7 @@
         <configurationType id="org.python.pydev.debug.jythonUnittestLaunchConfigurationType"/>
 	</shortcut>
 	<shortcut
-		label="Iron Python unit-test"
+		label="IronPython unit-test"
 		icon="icons/ironpython_unit.png"
 		modes="run, debug"
 		class="org.python.pydev.debug.ui.launching.IronpythonUnitTestLaunchShortcut"

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/ChooseProcessTypeDialog.java
@@ -87,7 +87,7 @@ final class ChooseProcessTypeDialog extends Dialog {
 
         checkboxForCurrentEditor = new Button(area, SWT.RADIO);
         checkboxForCurrentEditor
-                .setToolTipText("Creates a console with the PYTHONPATH used by the current editor (and jython/python/iron python depending on the project type).");
+                .setToolTipText("Creates a console with the PYTHONPATH used by the current editor (and Jython/Python/IronPython depending on the project type).");
         configureEditorButton();
 
         checkboxPython = new Button(area, SWT.RADIO);
@@ -102,8 +102,8 @@ final class ChooseProcessTypeDialog extends Dialog {
 
         checkboxIronpython = new Button(area, SWT.RADIO);
         checkboxIronpython
-                .setToolTipText("Creates an Iron Python console with the PYTHONPATH containing all the python projects in the workspace.");
-        configureButton(checkboxIronpython, "Iron Python", PydevPlugin.getIronpythonInterpreterManager());
+                .setToolTipText("Creates an IronPython console with the PYTHONPATH containing all the python projects in the workspace.");
+        configureButton(checkboxIronpython, "IronPython", PydevPlugin.getIronpythonInterpreterManager());
 
         checkboxJythonEclipse = new Button(area, SWT.RADIO);
         checkboxJythonEclipse

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/env/PydevIProcessFactory.java
@@ -241,7 +241,7 @@ public class PydevIProcessFactory {
 
             default:
                 throw new RuntimeException(
-                        "Expected interpreter manager to be python or jython or iron python related.");
+                        "Expected interpreter manager to be Python or Jython or IronPython related.");
         }
 
         if (interpreterManager.getInterpreterType() == IInterpreterManager.INTERPRETER_TYPE_JYTHON_ECLIPSE) {

--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -326,7 +326,7 @@
 	        </keywordReference>
       </page>
       <page
-            name="Interpreter - Iron Python"
+            name="Interpreter - IronPython"
             category="org.python.pydev.prefs"
             class="org.python.pydev.ui.pythonpathconf.IronpythonInterpreterPreferencesPage"
             id="org.python.pydev.ui.pythonpathconf.interpreterPreferencesPageIronpython">

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/SystemPythonNature.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/nature/SystemPythonNature.java
@@ -164,7 +164,7 @@ public class SystemPythonNature extends AbstractPythonNature implements IPythonN
                         return IPythonNature.PYTHON_VERSION_3_0;
 
                     default:
-                        throw new RuntimeException("Not python nor jython nor iron python?");
+                        throw new RuntimeException("Not Python nor Jython nor IronPython?");
                 }
             }
         }
@@ -180,7 +180,7 @@ public class SystemPythonNature extends AbstractPythonNature implements IPythonN
                 return IPythonNature.PYTHON_VERSION_LATEST;
 
             default:
-                throw new RuntimeException("Not python nor jython nor iron python?");
+                throw new RuntimeException("Not Python nor Jython nor IronPython?");
         }
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
@@ -106,7 +106,7 @@ public class PyProjectPythonDetails extends PropertyPage {
             radioJy.setText("Jython");
 
             radioIron = new Button(group, SWT.RADIO | SWT.LEFT);
-            radioIron.setText("Iron Python");
+            radioIron.setText("IronPython");
 
             //Grammar version
             versionLabel = new Label(topComp, 0);

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
@@ -48,7 +48,7 @@ public class IronpythonInterpreterManager extends AbstractInterpreterManager {
     }
 
     /**
-     * @param executable the iron python interpreter from where we should create the info
+     * @param executable the IronPython interpreter from where we should create the info
      * @param monitor a monitor to see the progress
      * 
      * @return the created interpreter info
@@ -58,7 +58,7 @@ public class IronpythonInterpreterManager extends AbstractInterpreterManager {
             boolean askUser) throws CoreException {
         boolean isJythonExecutable = InterpreterInfo.isJythonExecutable(executable);
         if (isJythonExecutable) {
-            throw new RuntimeException("A jar cannot be used in order to get the info for the iron python interpreter.");
+            throw new RuntimeException("A jar cannot be used in order to get the info for the IronPython interpreter.");
         }
 
         File script = getInterpreterInfoPy();

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
@@ -79,7 +79,7 @@ public class InterpreterConfigHelpers {
                     } else {
                         String errorMsg = "Error getting info on interpreter.\n\n"
                                 + "Common reasons include:\n\n" + "- Using an unsupported version\n"
-                                + "  (Python and Jython require at least version 2.1 and Iron Python 2.6).\n"
+                                + "  (Python and Jython require at least version 2.1 and IronPython 2.6).\n"
                                 + "\n" + "- Specifying an invalid interpreter\n"
                                 + "  (usually a link to the actual interpreter on Mac or Linux)" + "";
                         //show the user a message (so that it does not fail silently)...

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterEditor.java
@@ -28,7 +28,7 @@ public class IronpythonInterpreterEditor extends AbstractInterpreterEditor {
     @Override
     protected void doFillIntoGrid(Composite parent, int numColumns) {
         super.doFillIntoGrid(parent, numColumns);
-        this.autoConfigButton.setToolTipText("Will try to find Iron Python on the PATH (will fail if not available)");
+        this.autoConfigButton.setToolTipText("Will try to find IronPython on the PATH (will fail if not available)");
     }
 
     @Override

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/IronpythonInterpreterPreferencesPage.java
@@ -18,14 +18,14 @@ import org.python.pydev.plugin.PydevPlugin;
 public class IronpythonInterpreterPreferencesPage extends AbstractInterpreterPreferencesPage {
 
     public String getTitle() {
-        return "Iron Python Interpreters";
+        return "IronPython Interpreters";
     }
 
     /**
      * @return the title that should be used above the interpreters editor.
      */
     protected String getInterpretersTitle() {
-        return "Iron Python interpreters (e.g.: ipy.exe)";
+        return "IronPython interpreters (e.g.: ipy.exe)";
     }
 
     /**


### PR DESCRIPTION
---

I'll be sure to use "IronPython" in any future patches (namely the in-progress autoconfig patch).
