### PR TITLE
Speed up Console history filling time

### DIFF
--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryFilteredList.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/fromeclipse/HistoryFilteredList.java
@@ -529,7 +529,7 @@ public class HistoryFilteredList extends Composite {
                 return Status.OK_STATUS;
             }
             // How many we are going to do this time.
-            int iterations = Math.min(10, fCount - currentIndex);
+            int iterations = Math.min(250, fCount - currentIndex);
             for (int i = 0; i < iterations; i++) {
                 if (monitor.isCanceled()) {
                     return Status.CANCEL_STATUS;
@@ -545,7 +545,7 @@ public class HistoryFilteredList extends Composite {
                 return Status.CANCEL_STATUS;
             }
             if (currentIndex < fCount) {
-                schedule(100);
+                schedule(0);
             } else {
                 if (indicesToSelect == null) {
                     // Make a default selection in the table if there is none.


### PR DESCRIPTION
Follow up to Pull Request 39, in response to:

> 1. I lowered the default number of entries to 200 (because with a 1000 entries the dialog to show them all got too slow to fill them all -- if you can get it to be faster, maybe this could be reverted).

I investigated why the UI takes a long time to fill. There is a heuristic in HistoryFilteredList (based on org.eclipse.ui.dialogs.FilteredList) which attempts to balance off responsiveness to GUI events (i.e. mouse/keyboard) vs how long an update of the list takes. The edit in this pull request is in a runInUIThread call. That call updates part of the list based on the current filtering. If the call updated the entire list in one go it may look the UI for a while, so instead the code adds a few elements and then reschedules it self to add a few more. The original code did 10 elements and delayed 100ms before the next update. That meant for a 1000 list entry it took 10 seconds to fill the list, even if there was nothing else happening. This heuristic value was done in 2004 (see original file ref below) and the FilteredList is used for things like the list of Eclipse Variables (e.g. ${workspace_loc} and the like). For those lists there are 20-50 items, so the worst case is 1/2 second.

I changed the code to insert 250 items in the list per iteration, and then request the job run again immediately. This allows other UI code to fit in between and keeps the UI responsive. I tested this with 10,000 items in the list and the behaviour seems quite good. Actually on Linux/GTK it is nearly instantaneous with no loss of responsiveness, but on Windows there is no loss of responsivness, but it does take a little while (1-2 seconds) to fill the history. For 1000 items in the history Windows is near instantaneous. Tests run with CPU under heavy load.

So my conclusion is that this heuristic was probably right for the original use of relatively short lists, but PyDev's use is different and hopefully most PyDev users are running faster computers too. 

The original file is here:
git://git.eclipse.org/gitroot/platform/eclipse.platform.ui.git/bundles/org.eclipse.ui.workbench/Eclipse UI/org/eclipse/ui/dialogs/FilteredList.java 

Looking forward to any review comments.
Jonah
