### PR TITLE
Remove repeated names in a file's licence header.

### DIFF
--- a/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/PyDevInputWizardPage.java
+++ b/plugins/org.python.pydev.refactoring/src/org/python/pydev/refactoring/ui/pages/PyDevInputWizardPage.java
@@ -11,15 +11,12 @@
 *     Ueli Kistler
 *     Reto Schuettel
 *     Robin Stocker
-*     Reto Schüttel
-*     Robin Stocker
 * Contributors:
 *     Fabio Zadrozny <fabiofz@gmail.com> - initial implementation
 ******************************************************************************/
 /*
  * Copyright (C) 2006, 2007  Dennis Hunziker, Ueli Kistler
  * Copyright (C) 2007  Reto Schuettel, Robin Stocker
- * Copyright (C) 2007  Reto Schüttel, Robin Stocker
  *
  * IFS Institute for Software, HSR Rapperswil, Switzerland
  *


### PR DESCRIPTION
---

A small fix. This is the only IFS-licensed file with a mistake like this.
