### PR TITLE
Make sure package list is up to date before we start anything else

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ env:
     - secure: "V62QbNAT4SfRSUUEE1nlpx9UmjBnW54SnMf+ZR4stM+kBZxZUT7u3XatOABNupb052xJTYGISEjPqXDZ4VqOjM6fUu902LOCCZ0U1ojyOUdpai2gFz2ajtMTzg7MFXFFuYytZ9KRSalKLOzRylXroZVJK7DUtC9NMih6dCANvbA="
 
 before_install:
+  # Make sure package list is up to date before we start anything else
+  - "sudo apt-get update -qq"
+
   # Use s3cmd to communicate with AWS S3, s3cmd uses ~/.s3cfg for keys and config...
   - "sudo apt-get install -qq s3cmd"
   # ...so make one based on the ARTIFACTS_AWS_* variables above


### PR DESCRIPTION
This should resolve the issue encountered in https://travis-ci.org/fabioz/Pydev/jobs/12286695 where apt tried to install an old package.

You should see in the log of the build of this branch[1] that instead of python-django_1.3.1-4ubuntu1.7_all.deb being fetched, python-django_1.3.1-4ubuntu1.8_all.deb is used for the install. 

This happened to work in earlier builds because either the 1.7 version was the current version or the mirror(s) had not purged it yet.

[1] https://travis-ci.org/jonahkichwacoders/Pydev/jobs/12293496
