### PR TITLE
Use S3 bucket to mirror unreliable IronPython and Jython installers

### DIFF
--- a/travisdeps.sh
+++ b/travisdeps.sh
@@ -37,7 +37,10 @@ $INSTALL python3
 # IronPython IRONPYTHON_EXE, IRONPYTHON_LIB
 # IronPython is not part of Ubuntu
 # URL for IPython download from http://ironpython.codeplex.com/releases/view/90087 (IronPython 2.7.4 Binaries link)
-wget -O /tmp/IronPython-2.7.4.zip 'http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=ironpython&DownloadId=723207&FileTime=130230841338900000&Build=20779'
+# Unfortunately it now seems problematic to automate the download directly off codeplex, therefore
+# download it off a mirror
+# OLD COMMAND: wget -O /tmp/IronPython-2.7.4.zip 'http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=ironpython&DownloadId=723207&FileTime=130230841338900000&Build=20779'
+wget -O /tmp/IronPython-2.7.4.zip https://s3.amazonaws.com/pydevbuilds2/IronPython-2.7.4.zip
 # TODO Getting all of mono-complete may be overkill
 $INSTALL mono-complete
 (cd /tmp && unzip -q /tmp/IronPython-2.7.4.zip)
@@ -47,7 +50,9 @@ chmod +x /tmp/IronPython-2.7.4/ipy.exe
 
 # Jython JYTHON_JAR_LOCATION, JYTHON_LIB_LOCATION
 # TODO Jython package in Ubuntu is not currently supported by PyDev
-wget -O /tmp/jython-installer-2.5.3.jar http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar
+# This get from Maven can sometimes be very slow, instead get it from our mirror
+# OLD COMMAND: wget -O /tmp/jython-installer-2.5.3.jar http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar
+wget -O /tmp/jython-installer-2.5.3.jar https://s3.amazonaws.com/pydevbuilds2/jython-installer-2.5.3.jar
 java -jar /tmp/jython-installer-2.5.3.jar -s -d /tmp/jython-2.5.3
 java -jar /tmp/jython-2.5.3/jython.jar -V
 java -jar /tmp/jython-2.5.3/jython.jar -c "print 'from Jython'"


### PR DESCRIPTION
Use S3 bucket to mirror unreliable IronPython and Jython installers

For now I have left the mirror of IronPython and Jython as public URLs on my bucket. I don't see any need to change that for now.

I hope this works for you, if not I will look at it more tomorrow. 

PS You may want to turn off the (much more complicated) test build until you get the main build running, especially as it will shorten your turnaround time as you fiddle with secure variables and the like. I think this diff should do it:

```
diff --git a/.travis.yml b/.travis.yml
index cf44833..9ad06a0 100644
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ language: java

 env:
   matrix:
-    - PYDEV_TEST=true
     - PYDEV_TEST=false
   global:
     # Set the DISPLAY to match the one started with xvfb below
```

Jonah
