### PR TITLE
Exclude the directory of interpreterInfo.py as a default interpreter path.

### DIFF
--- a/plugins/org.python.pydev/pysrc/interpreterInfo.py
+++ b/plugins/org.python.pydev/pysrc/interpreterInfo.py
@@ -179,7 +179,7 @@ if __name__ == '__main__':
 
     result = []
 
-    path_used = sys.path
+    path_used = sys.path[1:] # Don't include the directory of this script as a path.
     try:
         path_used = path_used[:]  # Use a copy.
     except:


### PR DESCRIPTION
---

I've been noticing for a while that a path from my local PyDev repository was being included in the list of folders in the SYSTEM pythonpath. I thought it was odd, but I didn't think was an actual problem until I started fiddling around with Jython's Interactive Console. Instantiating Java classes (like java.lang.ClassLoader) when that path is in the pythonpath causes errors to be raised, and removing that path from sys.path stops that error from happening again.

So unless the pysrc directory is needed, I think it's safe to remove it from the list of choosable folders entirely.
