### PR TITLE
Bug #225: Use user supplied path to Python in preference to sys.executable

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
@@ -420,13 +420,13 @@ public abstract class AbstractInterpreterManager implements IInterpreterManager 
      * Creates the interpreter info from the output. Checks for errors.
      */
     protected static InterpreterInfo createInfoFromOutput(IProgressMonitor monitor, Tuple<String, String> outTup,
-            boolean askUser) {
+            boolean askUser, String userSpecifiedExecutable) {
         if (outTup.o1 == null || outTup.o1.trim().length() == 0) {
             throw new RuntimeException(
                     "No output was in the standard output when trying to create the interpreter info.\n"
                             + "The error output contains:>>" + outTup.o2 + "<<");
         }
-        InterpreterInfo info = InterpreterInfo.fromString(outTup.o1, askUser);
+        InterpreterInfo info = InterpreterInfo.fromString(outTup.o1, askUser, userSpecifiedExecutable);
         return info;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
@@ -66,7 +66,7 @@ public class IronpythonInterpreterManager extends AbstractInterpreterManager {
         Tuple<String, String> outTup = new SimpleIronpythonRunner().runAndGetOutputWithInterpreter(executable,
                 FileUtils.getFileAbsolutePath(script), null, null, null, monitor, "utf-8");
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, null);
 
         if (info == null) {
             //cancelled

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
@@ -77,7 +77,7 @@ public class JythonInterpreterManager extends AbstractInterpreterManager {
 
         String output = outTup.o1;
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, null);
         if (info == null) {
             //cancelled
             return null;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
@@ -68,7 +68,7 @@ public class PythonInterpreterManager extends AbstractInterpreterManager {
         Tuple<String, String> outTup = new SimplePythonRunner().runAndGetOutputWithInterpreter(executable,
                 FileUtils.getFileAbsolutePath(script), null, null, null, monitor, "utf-8");
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, executable);
 
         if (info == null) {
             //cancelled

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
@@ -283,9 +283,10 @@ public class InterpreterInfo implements IInterpreterInfo {
      *            true to prompt user about which paths to include. When the
      *            user is prompted, IInterpreterNewCustomEntries extension will
      *            be run to contribute additional entries
+     * @param userSpecifiedExecutable the path the the executable as specified by the user, or null to use that in received
      * @return new interpreter info
      */
-    public static InterpreterInfo fromString(String received, boolean askUserInOutPath) {
+    public static InterpreterInfo fromString(String received, boolean askUserInOutPath, String userSpecifiedExecutable) {
         if (received.toLowerCase().indexOf("executable") == -1) {
             throw new RuntimeException(
                     "Unable to recreate the Interpreter info (Its format changed. Please, re-create your Interpreter information).Contents found:"
@@ -427,6 +428,9 @@ public class InterpreterInfo implements IInterpreterInfo {
                         return null;
                     }
 
+                    if (userSpecifiedExecutable != null) {
+                        infoExecutable = userSpecifiedExecutable;
+                    }
                     InterpreterInfo info = new InterpreterInfo(infoVersion, infoExecutable, selection,
                             new ArrayList<String>(), forcedLibs, envVars, stringSubstitutionVars);
                     info.setName(infoName);
@@ -443,6 +447,20 @@ public class InterpreterInfo implements IInterpreterInfo {
             }
 
         }
+    }
+
+    /**
+     * 
+     * @param received
+     *            String to parse
+     * @param askUserInOutPath
+     *            true to prompt user about which paths to include. When the
+     *            user is prompted, IInterpreterNewCustomEntries extension will
+     *            be run to contribute additional entries
+     * @return new interpreter info
+     */
+    public static InterpreterInfo fromString(String received, boolean askUserInOutPath) {
+        return fromString(received, askUserInOutPath, null);
     }
 
     /**


### PR DESCRIPTION
This allows custom scripts to wrap python and be used by PyDev. In these
scripts, stuff like LD_LIBRARY_PATH can be used. An example is CCTBX
python: http://cctbx.sourceforge.net/
