### PR TITLE
Bug 226: Add Null check on iProject.getLocation()

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
@@ -322,9 +322,11 @@ public class InterpreterConfigHelpers {
         IProject[] projects = root.getProjects();
         for (IProject iProject : projects) {
             IPath location = iProject.getLocation();
-            IPath abs = location.makeAbsolute();
-            if (!rootLocation.isPrefixOf(abs)) {
-                rootPaths.add(abs);
+            if (location != null) {
+                IPath abs = location.makeAbsolute();
+                if (!rootLocation.isPrefixOf(abs)) {
+                    rootPaths.add(abs);
+                }
             }
         }
         return rootPaths;


### PR DESCRIPTION
Projects are not required to have locations, i.e. getLocation can return
null, for example a Virtual project stored in memory

Fixes https://sw-brainwy.rhcloud.com/tracker/PyDev/226
