### PR TITLE
Fixes to auto-config search paths (bugs 228 & 229).

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
@@ -13,9 +13,7 @@ package org.python.pydev.ui.pythonpathconf;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.util.LinkedList;
-import java.util.SortedSet;
-import java.util.TreeSet;
+import java.util.LinkedHashSet;
 import java.util.regex.Pattern;
 
 import org.python.pydev.shared_core.io.FileUtils;
@@ -27,15 +25,16 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
     }
 
     private static class InterpreterFileFilter implements FileFilter {
-        private String expectedFilename;
+        private Pattern pattern;
 
         public InterpreterFileFilter(String expectedFilenameHead) {
-            this.expectedFilename = expectedFilenameHead;
+            pattern = Pattern.compile(expectedFilenameHead);
         }
 
         @Override
         public boolean accept(File pathname) {
-            if (!Pattern.matches(expectedFilename, pathname.getName().toLowerCase())) {
+            // Add other conditions here if stricter file validation is necessary.
+            if (!pattern.matcher(pathname.getName().toLowerCase()).matches()) {
                 return false;
             }
             return true;
@@ -53,10 +52,10 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
      * @return An array of all matching filenames found, in order of decreasing priority.
      */
     public String[] searchPaths(java.util.Set<String> pathsToSearch, String[] expectedPatterns) {
-        LinkedList<String> allPaths = new LinkedList<String>();
+        LinkedHashSet<String> allPaths = new LinkedHashSet<String>();
 
         for (String expectedPattern : expectedPatterns) {
-            SortedSet<String> paths = new TreeSet<String>();
+            LinkedHashSet<String> paths = new LinkedHashSet<String>();
             InterpreterFileFilter filter = new InterpreterFileFilter(expectedPattern);
             for (String s : pathsToSearch) {
                 if (s.trim().length() > 0) {
@@ -69,11 +68,7 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
                     }
                 }
             }
-            for (String path : paths) {
-                if (!allPaths.contains(path)) {
-                    allPaths.add(path);
-                }
-            }
+            allPaths.addAll(paths);
         }
         return allPaths.toArray(new String[allPaths.size()]);
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
@@ -12,7 +12,7 @@
 ******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -29,9 +29,9 @@ public class JythonInterpreterProviderFactory extends AbstractInterpreterProvide
             return null;
         }
 
+        Set<String> pathsToSearch = new LinkedHashSet<String>();
         try {
             Map<String, String> env = SimpleRunner.getDefaultSystemEnv(null);
-            Set<String> pathsToSearch = new HashSet<String>();
             if (env.containsKey("JYTHON_HOME")) {
                 pathsToSearch.add(env.get("JYTHON_HOME"));
             }
@@ -50,16 +50,16 @@ public class JythonInterpreterProviderFactory extends AbstractInterpreterProvide
                 final List<String> split = StringUtils.split(path, separator);
                 pathsToSearch.addAll(split);
             }
-            pathsToSearch.add("/usr/share/java");
-            pathsToSearch.add("/usr/bin");
-            pathsToSearch.add("/usr/local/bin");
-
-            String[] searchResults = searchPaths(pathsToSearch, new String[] { "jython.jar" });
-            if (searchResults.length > 0) {
-                return AlreadyInstalledInterpreterProvider.create("jython", searchResults);
-            }
         } catch (CoreException e) {
             Log.log(e);
+        }
+        pathsToSearch.add("/usr/share/java");
+        pathsToSearch.add("/usr/bin");
+        pathsToSearch.add("/usr/local/bin");
+
+        String[] searchResults = searchPaths(pathsToSearch, new String[] { "jython.jar" });
+        if (searchResults.length > 0) {
+            return AlreadyInstalledInterpreterProvider.create("jython", searchResults);
         }
 
         return null;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
@@ -13,11 +13,15 @@ package org.python.pydev.ui.pythonpathconf;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
+import org.eclipse.core.runtime.CoreException;
 import org.python.pydev.core.log.Log;
+import org.python.pydev.runners.SimpleRunner;
+import org.python.pydev.shared_core.string.StringUtils;
 import org.python.pydev.shared_core.utils.PlatformUtils;
 
 import at.jta.Key;
@@ -30,11 +34,28 @@ public class PythonInterpreterProviderFactory extends AbstractInterpreterProvide
             return null;
         }
 
-        Set<String> pathsToSearch = new HashSet<String>();
         if (!PlatformUtils.isWindowsPlatform()) {
+            Set<String> pathsToSearch = new LinkedHashSet<String>();
+            try {
+                Map<String, String> env = SimpleRunner.getDefaultSystemEnv(null);
+                if (env.containsKey("PYTHON_HOME")) {
+                    pathsToSearch.add(env.get("PYTHON_HOME"));
+                }
+                if (env.containsKey("PYTHONHOME")) {
+                    pathsToSearch.add(env.get("PYTHONHOME"));
+                }
+                if (env.containsKey("PATH")) {
+                    String path = env.get("PATH");
+                    String separator = SimpleRunner.getPythonPathSeparator();
+                    final List<String> split = StringUtils.split(path, separator);
+                    pathsToSearch.addAll(split);
+                }
+            } catch (CoreException e) {
+                Log.log(e);
+            }
             pathsToSearch.add("/usr/bin");
             pathsToSearch.add("/usr/local/bin");
-            final String[] ret = searchPaths(pathsToSearch, new String[] { "python", "python(\\d(\\.\\d)*)?" });
+            final String[] ret = searchPaths(pathsToSearch, new String[] { "python", "python(\\d(\\.\\d)*)?|pypy" });
             if (ret.length > 0) {
                 return AlreadyInstalledInterpreterProvider.create("python", ret);
             }


### PR DESCRIPTION
1) Interpreter file names must now match a regex pattern to be valid
(as opposed to just starting with a certain string).

2) Certain interpreter name patterns can be given higher priority
over others (so that Quick Auto-Config can choose the system default
Python over all others, for instance).
