### PR TITLE
Display meta data about numpy.ndarray

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevd_resolver.py
+++ b/plugins/org.python.pydev/pysrc/pydevd_resolver.py
@@ -344,9 +344,49 @@ class JyArrayResolver:
         ret['__len__'] = len(obj)
         return ret
 
+
+#=======================================================================================================================
+# NdArrayResolver
+#=======================================================================================================================
+class NdArrayResolver:
+    '''
+        This resolves a numpy ndarray returning some metadata about the NDArray
+    '''
+
+    def resolve(self, obj, attribute):
+        if attribute == '__internals__':
+            return defaultResolver.getDictionary(obj)
+        if attribute == 'min':
+            return obj.min()
+        if attribute == 'max':
+            return obj.max()
+        if attribute == 'shape':
+            return obj.shape
+        if attribute == 'dtype':
+            return obj.dtype
+        if attribute == 'size':
+            return obj.size
+        return None
+
+    def getDictionary(self, obj):
+        ret = dict()
+        ret['__internals__'] = defaultResolver.getDictionary(obj)
+        if obj.size >= 1000000:
+            ret['min'] = 'ndarray too big, calculating min would slow down debugging'
+            ret['max'] = 'ndarray too big, calculating max would slow down debugging'
+        else:
+            ret['min'] = obj.min()
+            ret['max'] = obj.max()
+        ret['shape'] = obj.shape
+        ret['dtype'] = obj.dtype
+        ret['size'] = obj.size
+        return ret
+
+
 defaultResolver = DefaultResolver()
 dictResolver = DictResolver()
 tupleResolver = TupleResolver()
 instanceResolver = InstanceResolver()
 jyArrayResolver = JyArrayResolver()
 setResolver = SetResolver()
+ndarrayResolver = NdArrayResolver()

--- a/plugins/org.python.pydev/pysrc/pydevd_vars.py
+++ b/plugins/org.python.pydev/pysrc/pydevd_vars.py
@@ -65,6 +65,12 @@ if not sys.platform.startswith("java"):
     except:
         pass  #not available on all python versions
 
+    try:
+        import numpy
+        typeMap.append((numpy.ndarray, pydevd_resolver.ndarrayResolver))
+    except:
+        pass  #numpy may not be installed
+
 else:  #platform is java
     from org.python import core  #@UnresolvedImport
     typeMap = [

--- a/plugins/org.python.pydev/pysrc/tests_python/_debugger_case16.py
+++ b/plugins/org.python.pydev/pysrc/tests_python/_debugger_case16.py
@@ -1,0 +1,12 @@
+# this test requires numpy to be installed
+import numpy
+
+def main():
+    smallarray = numpy.arange(100) * 1+1j
+    bigarray = numpy.arange(100000).reshape((10,10000)) # 100 thousand
+    hugearray = numpy.arange(10000000) # 10 million
+
+    pass # location of breakpoint after all arrays defined
+
+main()
+print('TEST SUCEEDED')


### PR DESCRIPTION
For numpy.ndarray, we display min, max, shape, dtype and size as first
level entries and access all internals under the **internals** tag.

Because it can take a long time to calculate min and max, we limit such
calculation to arrays size <= 1000000 (1 million)
