### PR TITLE
Make some minor performance & UI changes to AutoConfigMaker.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
@@ -33,7 +33,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
-import org.eclipse.swt.widgets.Shell;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 import org.eclipse.ui.dialogs.PropertyPage;
 import org.python.pydev.core.IInterpreterInfo;
@@ -43,7 +42,6 @@ import org.python.pydev.core.log.Log;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.nature.PythonNature;
 import org.python.pydev.shared_core.string.StringUtils;
-import org.python.pydev.shared_ui.EditorUtils;
 import org.python.pydev.ui.dialogs.PyDialogHelpers;
 import org.python.pydev.ui.pythonpathconf.AutoConfigMaker;
 import org.python.pydev.ui.pythonpathconf.IInterpreterProviderFactory.InterpreterType;
@@ -273,8 +271,7 @@ public class PyProjectPythonDetails extends PropertyPage {
 
                             interpreterNoteText.setText("Configuration in progress...");
                             boolean advanced = open == InterpreterConfigHelpers.CONFIG_ADV_AUTO;
-                            Shell shell = EditorUtils.getShell();
-                            AutoConfigMaker a = new AutoConfigMaker(interpreterType, advanced, null, shell, null);
+                            AutoConfigMaker a = new AutoConfigMaker(interpreterType, advanced, null, null);
                             a.autoConfigSingleApply(onJobComplete);
                         }
                     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/AbstractInterpreterManager.java
@@ -284,7 +284,7 @@ public abstract class AbstractInterpreterManager implements IInterpreterManager 
                         }
                         boolean advanced = ret == InterpreterConfigHelpers.CONFIG_ADV_AUTO;
                         Shell shell = EditorUtils.getShell();
-                        AutoConfigMaker a = new AutoConfigMaker(interpreterType, advanced, null, shell, null);
+                        AutoConfigMaker a = new AutoConfigMaker(interpreterType, advanced, null, null);
                         a.autoConfigSingleApply(null);
                     }
                 }
@@ -423,13 +423,15 @@ public abstract class AbstractInterpreterManager implements IInterpreterManager 
      * Creates the interpreter info from the output. Checks for errors.
      */
     protected static InterpreterInfo createInfoFromOutput(IProgressMonitor monitor, Tuple<String, String> outTup,
-            boolean askUser, String userSpecifiedExecutable) {
+            boolean askUser, String executableName, Boolean executableIsUserSpecified) {
         if (outTup.o1 == null || outTup.o1.trim().length() == 0) {
             throw new RuntimeException(
-                    "No output was in the standard output when trying to create the interpreter info.\n"
-                            + "The error output contains:>>" + outTup.o2 + "<<");
+                    "No output was in the standard output when"
+                            + "\ntrying to create the interpreter info for: " + executableName
+                            + "\nThe error output contains:>>" + outTup.o2 + "<<");
         }
-        InterpreterInfo info = InterpreterInfo.fromString(outTup.o1, askUser, userSpecifiedExecutable);
+        InterpreterInfo info = InterpreterInfo.fromString(outTup.o1, askUser,
+                executableIsUserSpecified ? executableName : null);
         return info;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/IronpythonInterpreterManager.java
@@ -66,7 +66,7 @@ public class IronpythonInterpreterManager extends AbstractInterpreterManager {
         Tuple<String, String> outTup = new SimpleIronpythonRunner().runAndGetOutputWithInterpreter(executable,
                 FileUtils.getFileAbsolutePath(script), null, null, null, monitor, "utf-8");
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, null);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, executable, false);
 
         if (info == null) {
             //cancelled

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/JythonInterpreterManager.java
@@ -72,12 +72,13 @@ public class JythonInterpreterManager extends AbstractInterpreterManager {
         File script = getInterpreterInfoPy();
 
         //gets the info for the python side
-        Tuple<String, String> outTup = new SimpleJythonRunner().runAndGetOutputWithJar(FileUtils.getFileAbsolutePath(script),
+        Tuple<String, String> outTup = new SimpleJythonRunner().runAndGetOutputWithJar(
+                FileUtils.getFileAbsolutePath(script),
                 executable, null, null, null, monitor, "utf-8");
 
         String output = outTup.o1;
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, null);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, executable, false);
         if (info == null) {
             //cancelled
             return null;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/interpreters/PythonInterpreterManager.java
@@ -68,7 +68,7 @@ public class PythonInterpreterManager extends AbstractInterpreterManager {
         Tuple<String, String> outTup = new SimplePythonRunner().runAndGetOutputWithInterpreter(executable,
                 FileUtils.getFileAbsolutePath(script), null, null, null, monitor, "utf-8");
 
-        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, executable);
+        InterpreterInfo info = createInfoFromOutput(monitor, outTup, askUser, executable, true);
 
         if (info == null) {
             //cancelled

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterEditor.java
@@ -70,7 +70,6 @@ import org.python.pydev.jython.IPythonInterpreter;
 import org.python.pydev.jython.JythonPlugin;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.shared_core.structure.Tuple;
-import org.python.pydev.shared_ui.EditorUtils;
 import org.python.pydev.shared_ui.ImageCache;
 import org.python.pydev.shared_ui.UIConstants;
 import org.python.pydev.shared_ui.utils.AsynchronousProgressMonitorDialog;
@@ -903,7 +902,7 @@ public abstract class AbstractInterpreterEditor extends PythonListEditor impleme
                 //Auto-config
                 AutoConfigMaker a = new AutoConfigMaker(getInterpreterType(),
                         configType == InterpreterConfigHelpers.CONFIG_ADV_AUTO, logger,
-                        EditorUtils.getShell(), nameToInfo);
+                        nameToInfo);
                 operation = a.autoConfigSearch();
             } else {
                 //Manual config
@@ -945,7 +944,10 @@ public abstract class AbstractInterpreterEditor extends PythonListEditor impleme
             Log.log(e);
             return null;
         } finally {
-            Log.logInfo(charWriter.toString());
+            String logInfo = charWriter.toString();
+            if (logInfo.length() > 0) {
+                Log.logInfo(charWriter.toString());
+            }
         }
 
         return null;

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterConfigHelpers.java
@@ -87,39 +87,40 @@ public class InterpreterConfigHelpers {
             if (operation.e != null) {
                 logger.println("- Some error happened while getting info on the interpreter:");
                 operation.e.printStackTrace(logger);
+                String errorTitle = "Unable to get info on the interpreter: " + executable;
 
                 if (operation.e instanceof SimpleJythonRunner.JavaNotConfiguredException) {
                     SimpleJythonRunner.JavaNotConfiguredException javaNotConfiguredException = (SimpleJythonRunner.JavaNotConfiguredException) operation.e;
                     if (displayErrors) {
-                        ErrorDialog.openError(shell, "Error getting info on interpreter",
+                        ErrorDialog.openError(shell, errorTitle,
                                 javaNotConfiguredException.getMessage(), PydevPlugin.makeStatus(IStatus.ERROR,
                                         "Java vm not configured.\n", javaNotConfiguredException));
                     }
-                    throw javaNotConfiguredException;
+                    throw new Exception(javaNotConfiguredException);
 
                 } else if (operation.e instanceof JDTNotAvailableException) {
                     JDTNotAvailableException noJdtException = (JDTNotAvailableException) operation.e;
                     if (displayErrors) {
-                        ErrorDialog.openError(shell, "Error getting info on interpreter",
+                        ErrorDialog.openError(shell, errorTitle,
                                 noJdtException.getMessage(),
                                 PydevPlugin.makeStatus(IStatus.ERROR, "JDT not available.\n", noJdtException));
                     }
-                    throw noJdtException;
+                    throw new Exception(noJdtException);
 
                 } else {
                     if (displayErrors) {
                         //show the user a message (so that it does not fail silently)...
-                        String errorMsg = "Error getting info on interpreter: " + executable
+                        String errorMsg = "Unable to get info on the interpreter: " + executable
                                 + "\n\n"
                                 + "Common reasons include:\n\n" + "- Using an unsupported version\n"
                                 + "  (Python and Jython require at least version 2.1 and IronPython 2.6).\n"
                                 + "\n" + "- Specifying an invalid interpreter\n"
                                 + "  (usually a link to the actual interpreter on Mac or Linux)" + "";
-                        ErrorDialog.openError(shell, "Unable to get info on the interpreter.",
+                        ErrorDialog.openError(shell, errorTitle,
                                 errorMsg, PydevPlugin.makeStatus(IStatus.ERROR, "See error log for details.",
                                         operation.e));
                     }
-                    throw operation.e;
+                    throw new Exception(operation.e);
                 }
 
             } else if (operation.result == null) {
@@ -291,6 +292,9 @@ public class InterpreterConfigHelpers {
      */
     public static String getDuplicatedMessageError(String interpreterName, String executableOrJar,
             Map<String, IInterpreterInfo> nameToInfo) {
+        if (nameToInfo == null) {
+            return null;
+        }
         String error = null;
         if (interpreterName != null) {
             interpreterName = interpreterName.trim();


### PR DESCRIPTION
-Provide more information in error dialogs on failed configure attemtps.
-Make some minor performance tweaks.

---

The biggest change here is the extra info relayed to the error dialog in failure cases. I wanted the dialog to make a distinction between finding duplicate interpreters and actual errors, and to provide the user with a little more information than I had it say before. I apologize if the "found duplicate/error" trackers are a bit messy, but I couldn't think of anywhere else to put them that would accomplish the same purpose without being too complicated.
