### PR TITLE
Apply performance tweaks to the auto-config path search method.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/JythonInterpreterProviderFactory.java
@@ -12,6 +12,7 @@
 ******************************************************************************/
 package org.python.pydev.ui.pythonpathconf;
 
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -57,7 +58,7 @@ public class JythonInterpreterProviderFactory extends AbstractInterpreterProvide
         pathsToSearch.add("/usr/bin");
         pathsToSearch.add("/usr/local/bin");
 
-        String[] searchResults = searchPaths(pathsToSearch, new String[] { "jython.jar" });
+        String[] searchResults = searchPaths(pathsToSearch, Arrays.asList("jython.jar"));
         if (searchResults.length > 0) {
             return AlreadyInstalledInterpreterProvider.create("jython", searchResults);
         }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
@@ -13,6 +13,7 @@ package org.python.pydev.ui.pythonpathconf;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -55,7 +56,7 @@ public class PythonInterpreterProviderFactory extends AbstractInterpreterProvide
             }
             pathsToSearch.add("/usr/bin");
             pathsToSearch.add("/usr/local/bin");
-            final String[] ret = searchPaths(pathsToSearch, new String[] { "python", "python(\\d(\\.\\d)*)?|pypy" });
+            final String[] ret = searchPaths(pathsToSearch, Arrays.asList("python", "python\\d(\\.\\d)*|pypy"));
             if (ret.length > 0) {
                 return AlreadyInstalledInterpreterProvider.create("python", ret);
             }


### PR DESCRIPTION
---

This change is in response to your last comment on fabioz#95. When I use the original version of searchPaths with target interpreters on different folders, it didn't seem to have any major problems. Nonetheless, the way the regexs are used allow paths to be discovered multiple times, which cause "absolute path" searches to happen on duplicated items that get discarded anyways. The changes I made here should reduce operations on duplicate items.

I still want to use the regex list as is (ie "python", "python#.#"), though, because the fact that discovered interpreters are often links makes it difficult to sort them by priority after their absolute paths are resolved. Let me know what you think, though.
