### PR TITLE
Make e4 bundles optional.

### DIFF
--- a/plugins/org.python.pydev.shared_ui/META-INF/MANIFEST.MF
+++ b/plugins/org.python.pydev.shared_ui/META-INF/MANIFEST.MF
@@ -18,8 +18,8 @@ Require-Bundle: org.python.pydev.shared_core,
  org.eclipse.ui.workbench,
  org.eclipse.ui.views,
  org.eclipse.ui.console,
- org.eclipse.e4.ui.services,
- org.eclipse.e4.ui.css.swt.theme,
+ org.eclipse.e4.ui.services;resolution:=optional,
+ org.eclipse.e4.ui.css.swt.theme;resolution:=optional,
  org.eclipse.core.filesystem
 Bundle-ActivationPolicy: lazy
 Export-Package: org.python.pydev.overview_ruler,


### PR DESCRIPTION
The RC does not install in Eclipse 3.7.
Cannot complete the install because one or more required items could not be found.
  Software being installed: PyDev for Eclipse 3.0.0.201310301514 (org.python.pydev.feature.feature.group 3.0.0.201310301514)
  Missing requirement: Shared Ui Plug-in 3.0.0.201310301514 (org.python.pydev.shared_ui 3.0.0.201310301514) requires 'bundle org.eclipse.e4.ui.services 0.0.0' but it could not be found
  Cannot satisfy dependency:
    From: PyDev for Eclipse 3.0.0.201310301514 (org.python.pydev.feature.feature.group 3.0.0.201310301514)
    To: org.python.pydev.shared_ui [3.0.0.201310301514]

You can use this as the update site to test.
http://pydevbuilds2.s3.amazonaws.com/artifacts/branch/fix_for_3.7/release/repository

PS At Diamond we are actually using 3.8, but we don't have the backported e4 plug-ins in our target platform, so it makes it more like 3.7
