### PR TITLE
Change Limit before skipping calculation of min/max

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevd_resolver.py
+++ b/plugins/org.python.pydev/pysrc/pydevd_resolver.py
@@ -371,7 +371,7 @@ class NdArrayResolver:
     def getDictionary(self, obj):
         ret = dict()
         ret['__internals__'] = defaultResolver.getDictionary(obj)
-        if obj.size >= 1000000:
+        if obj.size > 1024*1024:
             ret['min'] = 'ndarray too big, calculating min would slow down debugging'
             ret['max'] = 'ndarray too big, calculating max would slow down debugging'
         else:


### PR DESCRIPTION
As it turns out, arrays of 1024 x 1024 are common and a more logical cut-off point than 999,999 (the old limit)
