### PR TITLE
Respect pydev_interpreter_new_custom_entries extension point

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
@@ -310,6 +310,7 @@ public class InterpreterInfo implements IInterpreterInfo {
                     }
                     NodeList xmlNodes = item.getChildNodes();
 
+                    boolean fromPythonBackend = false;
                     String infoExecutable = null;
                     String infoName = null;
                     String infoVersion = null;
@@ -344,6 +345,7 @@ public class InterpreterInfo implements IInterpreterInfo {
                                     //The python backend is expected to put path='ins' or path='out'
                                     //While our own toString() is not expected to do that.
                                     //This is probably not a very good heuristic, but it maps the current state of affairs.
+                                    fromPythonBackend = true;
                                     if (askUserInOutPath) {
                                         toAsk.add(data);
                                     }
@@ -387,10 +389,12 @@ public class InterpreterInfo implements IInterpreterInfo {
                         }
                     }
 
-                    if (askUserInOutPath) {
+                    if (fromPythonBackend) {
                         AdditionalEntries additionalEntries = new AdditionalEntries();
                         Collection<String> additionalLibraries = additionalEntries.getAdditionalLibraries();
-                        addUnique(toAsk, additionalLibraries);
+                        if (askUserInOutPath) {
+                            addUnique(toAsk, additionalLibraries);
+                        }
                         addUnique(selection, additionalLibraries);
                         addUnique(forcedLibs, additionalEntries.getAdditionalBuiltins());
 
@@ -450,7 +454,7 @@ public class InterpreterInfo implements IInterpreterInfo {
     }
 
     /**
-     * 
+     *
      * @param received
      *            String to parse
      * @param askUserInOutPath


### PR DESCRIPTION
It used to be (prior to the new auto-config changes, 9a423ec) that askUserInOutPath was the method for telling if frpmString was being
called from a user configuring a new interpreter or by restoring a previously stored one.

A previous fix in 67cef68 addressed one place where the meaning of
the variable changed. This fix extends that fix to add additional
interpreter settings with Quick-Config is used and hence askUserInOutPath
is false.
