### PR TITLE
Ensure that a new-line is sent when initializing the console

### DIFF
--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsole.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsole.java
@@ -233,6 +233,9 @@ public class PydevConsole extends ScriptConsole {
             // Unreachable as false passed to reportUndefinedVariables above
             Log.log(e);
         }
+        if (!str.endsWith("\n")) {
+            str += "\n";
+        }
 
         if (additionalInitialComands != null) {
             str += additionalInitialComands;


### PR DESCRIPTION
It's easy for the user to omit a newline from the initial commands entry, so add a newline if they left it out.
