### PR TITLE
AHLRAP-1467 Fix IPython console completion pop-up on all characters

### DIFF
--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCompletionProcessor.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleCompletionProcessor.java
@@ -55,7 +55,7 @@ public class PydevConsoleCompletionProcessor extends AbstractCompletionProcessor
 
     public char[] getCompletionProposalAutoActivationCharacters() {
         return SimpleAssistProcessor.getStaticAutoActivationCharacters(
-                PythonCompletionProcessor.getStaticCompletionProposalAutoActivationCharacters(), 0);
+                PythonCompletionProcessor.getStaticCompletionProposalAutoActivationCharacters());
     }
 
     /**

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/SimpleAssistProcessor.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/simpleassist/SimpleAssistProcessor.java
@@ -263,8 +263,7 @@ public class SimpleAssistProcessor implements IContentAssistProcessor {
      * @see org.eclipse.jface.text.contentassist.IContentAssistProcessor#getCompletionProposalAutoActivationCharacters()
      */
     public char[] getCompletionProposalAutoActivationCharacters() {
-        return getStaticAutoActivationCharacters(
-                defaultPythonProcessor.getCompletionProposalAutoActivationCharacters(), this.participants.size());
+        return getStaticAutoActivationCharacters(defaultPythonProcessor.getCompletionProposalAutoActivationCharacters());
     }
 
     /**
@@ -275,7 +274,7 @@ public class SimpleAssistProcessor implements IContentAssistProcessor {
     /**
      * @return the auto-activation chars that should be used.
      */
-    public synchronized static char[] getStaticAutoActivationCharacters(char[] defaultChars, int participantsLen) {
+    public synchronized static char[] getStaticAutoActivationCharacters(char[] defaultChars) {
         if (!listenerToClearAutoActivationAlreadySetup) {
             PydevPlugin.getDefault().getPreferenceStore().addPropertyChangeListener(new IPropertyChangeListener() {
                 public void propertyChange(PropertyChangeEvent event) {
@@ -292,7 +291,7 @@ public class SimpleAssistProcessor implements IContentAssistProcessor {
                     && PyCodeCompletionPreferencesPage.useAutocomplete();
 
             char[] c2;
-            if (participantsLen == 0 && !useAutocompleteOnAllAsciiCharsCache) {
+            if (!useAutocompleteOnAllAsciiCharsCache) {
                 c2 = defaultAutoActivationCharacters;
             } else {
                 //just use the extension for the simple if we do have it


### PR DESCRIPTION
The completion calculator caches the characters which trigger a
completion ('.', or [a-zA-Z]) based on the user preference, and whether
there is more than one completion processor registered.

The console calls the API with 0, as the number of completion
processors. The editor calls it with the number of processors specified.
 The result is inconsistent caching depending on which is called first.

This makes the cache behave consistently for the specified preference.
It's possible that there are SimpleAssistProcessors that would no longer
be invoked for every character, but, AFAICS this would only affects the
template processor, and that seems to work correctly after this change.

One easy way to reproduce this, is to enable the editor popup for every character, then disable it. While the editor no longer prompts for completions, the console continues to.
