### PR TITLE
Improve stdout/stderr buffering in the console

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleCompletionsPageParticipant.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/console/ConsoleCompletionsPageParticipant.java
@@ -44,9 +44,9 @@ import org.python.pydev.editor.codecompletion.PyCodeCompletionPreferencesPage;
 import org.python.pydev.editor.codecompletion.PyContentAssistant;
 import org.python.pydev.plugin.nature.PythonNature;
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_interactive_console.console.IScriptConsoleCommunication;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
+import org.python.pydev.shared_interactive_console.console.ui.internal.IStreamListener;
 import org.python.pydev.shared_ui.bindings.KeyBindingHelper;
 
 /**
@@ -140,8 +140,7 @@ public class ConsoleCompletionsPageParticipant implements IConsolePageParticipan
             return temp;
         }
 
-        public void execInterpreter(String command, ICallback<Object, InterpreterResponse> onResponseReceived,
-                ICallback<Object, Tuple<String, String>> onContentsReceived) {
+        public void execInterpreter(String command, ICallback<Object, InterpreterResponse> onResponseReceived) {
             throw new RuntimeException("Not implemented");
 
         }
@@ -170,6 +169,16 @@ public class ConsoleCompletionsPageParticipant implements IConsolePageParticipan
         }
 
         public void linkWithDebugSelection(boolean isLinkedWithDebug) {
+            throw new RuntimeException("Not implemented");
+        }
+
+        public void addListener(IStreamListener listener) {
+            // Should never have any stdout/stderr to report to users, so ignore.
+            throw new RuntimeException("Not implemented");
+        }
+
+        public void removeListener(IStreamListener listener) {
+            // Should never have any stdout/stderr to report to users, so ignore.
             throw new RuntimeException("Not implemented");
         }
 

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
@@ -38,11 +38,11 @@ import org.python.pydev.editor.codecompletion.PyLinkedModeCompletionProposal;
 import org.python.pydev.editor.codecompletion.templates.PyTemplateCompletionProcessor;
 import org.python.pydev.editor.simpleassist.ISimpleAssistParticipant2;
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_interactive_console.console.IScriptConsoleCommunication;
 import org.python.pydev.shared_interactive_console.console.IScriptConsoleInterpreter;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
 import org.python.pydev.shared_interactive_console.console.ui.IScriptConsoleViewer;
+import org.python.pydev.shared_interactive_console.console.ui.internal.IStreamListener;
 import org.python.pydev.shared_ui.content_assist.AbstractCompletionProcessorWithCycling;
 import org.python.pydev.shared_ui.proposals.IPyCompletionProposal;
 import org.python.pydev.shared_ui.proposals.PyCompletionProposal;
@@ -86,9 +86,8 @@ public class PydevConsoleInterpreter implements IScriptConsoleInterpreter {
      * (non-Javadoc)
      * @see com.aptana.interactive_console.console.IScriptConsoleInterpreter#exec(java.lang.String)
      */
-    public void exec(String command, final ICallback<Object, InterpreterResponse> onResponseReceived,
-            final ICallback<Object, Tuple<String, String>> onContentsReceived) {
-        consoleCommunication.execInterpreter(command, onResponseReceived, onContentsReceived);
+    public void exec(String command, final ICallback<Object, InterpreterResponse> onResponseReceived) {
+        consoleCommunication.execInterpreter(command, onResponseReceived);
     }
 
     /**
@@ -277,6 +276,14 @@ public class PydevConsoleInterpreter implements IScriptConsoleInterpreter {
 
     public IInterpreterInfo getInterpreterInfo() {
         return this.interpreterInfo;
+    }
+
+    public void addListener(IStreamListener listener) {
+        consoleCommunication.addListener(listener);
+    }
+
+    public void removeListener(IStreamListener listener) {
+        consoleCommunication.removeListener(listener);
     }
 
     public void setLaunch(ILaunch launch) {

--- a/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
+++ b/plugins/org.python.pydev.debug/tests/org/python/pydev/debug/newconsole/PydevConsoleDebugCommsTest.java
@@ -42,7 +42,6 @@ import org.python.pydev.runners.SimpleRunner;
 import org.python.pydev.shared_core.callbacks.ICallback;
 import org.python.pydev.shared_core.io.FileUtils;
 import org.python.pydev.shared_core.net.SocketUtil;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
 
 /**
@@ -219,14 +218,7 @@ public class PydevConsoleDebugCommsTest extends TestCase {
                 return null;
             }
         };
-        ICallback<Object, Tuple<String, String>> onContentsReceived = new ICallback<Object, Tuple<String, String>>() {
-
-            public Object call(Tuple<String, String> arg) {
-                return null;
-            }
-
-        };
-        pydevConsoleCommunication.execInterpreter(command, onResponseReceived, onContentsReceived);
+        pydevConsoleCommunication.execInterpreter(command, onResponseReceived);
         waitUntilNonNull(done);
     }
 

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IScriptConsoleCommunication.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IScriptConsoleCommunication.java
@@ -11,25 +11,23 @@ package org.python.pydev.shared_interactive_console.console;
 
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
+import org.python.pydev.shared_interactive_console.console.ui.internal.IStreamMonitor;
 
 /**
  * Interface for the console communication.
  * 
  * This interface is meant to be the way to communicate with the shell.
  */
-public interface IScriptConsoleCommunication {
+public interface IScriptConsoleCommunication extends IStreamMonitor {
 
     /**
      * Executes a given command in the interpreter (push a line)
      * 
      * @param command the command to be executed
-     * @param onContentsReceived 
-     * @return the response from the interpreter (contains the stdout, stderr, etc).
+     * @return the response from the interpreter.
      * @throws Exception
      */
-    void execInterpreter(String command, ICallback<Object, InterpreterResponse> onResponseReceived,
-            ICallback<Object, Tuple<String, String>> onContentsReceived);
+    void execInterpreter(String command, ICallback<Object, InterpreterResponse> onResponseReceived);
 
     /**
      * Creates the completions to be applied in the interpreter.

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IScriptConsoleInterpreter.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/IScriptConsoleInterpreter.java
@@ -10,18 +10,16 @@
 package org.python.pydev.shared_interactive_console.console;
 
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
+import org.python.pydev.shared_interactive_console.console.ui.internal.IStreamMonitor;
 
-public interface IScriptConsoleInterpreter extends IScriptConsoleShell, IConsoleRequest {
+public interface IScriptConsoleInterpreter extends IScriptConsoleShell, IConsoleRequest, IStreamMonitor {
 
     /**
      * @param command the command (entered in the console) to be executed
-     * @param onContentsReceived 
      * @return the response from the interpreter.
      * @throws Exception if something wrong happened while doing the request.
      */
-    void exec(String command, ICallback<Object, InterpreterResponse> onResponseReceived,
-            ICallback<Object, Tuple<String, String>> onContentsReceived);
+    void exec(String command, ICallback<Object, InterpreterResponse> onResponseReceived);
 
     Object getInterpreterInfo();
 

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/InterpreterResponse.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/InterpreterResponse.java
@@ -11,17 +11,11 @@ package org.python.pydev.shared_interactive_console.console;
 
 public class InterpreterResponse {
 
-    public final String out;
-
-    public final String err;
-
     public final boolean more;
 
     public final boolean need_input;
 
-    public InterpreterResponse(String out, String err, boolean more, boolean need_input) {
-        this.out = out;
-        this.err = err;
+    public InterpreterResponse(boolean more, boolean need_input) {
         this.more = more;
         this.need_input = need_input;
     }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/ScriptConsole.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/ScriptConsole.java
@@ -27,7 +27,6 @@ import org.eclipse.ui.console.IConsoleView;
 import org.eclipse.ui.console.TextConsole;
 import org.eclipse.ui.part.IPageBookViewPage;
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_core.utils.Reflection;
 import org.python.pydev.shared_interactive_console.console.IScriptConsoleInterpreter;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
@@ -116,6 +115,10 @@ public abstract class ScriptConsole extends TextConsole implements ICommandHandl
         this.interpreter = interpreter;
     }
 
+    public IScriptConsoleInterpreter getInterpreter() {
+        return this.interpreter;
+    }
+
     public ScriptConsolePrompt getPrompt() {
         return prompt;
     }
@@ -148,8 +151,7 @@ public abstract class ScriptConsole extends TextConsole implements ICommandHandl
      *
      * @param userInput that's the command to be evaluated by the user.
      */
-    public void handleCommand(String userInput, final ICallback<Object, InterpreterResponse> onResponseReceived,
-            final ICallback<Object, Tuple<String, String>> onContentsReceived) {
+    public void handleCommand(String userInput, final ICallback<Object, InterpreterResponse> onResponseReceived) {
         final Object[] listeners = consoleListeners.getListeners();
 
         //notify about the user request
@@ -173,7 +175,7 @@ public abstract class ScriptConsole extends TextConsole implements ICommandHandl
                     onResponseReceived.call(response);
                     return null;
                 }
-            }, onContentsReceived);
+            });
         }
 
     }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ICommandHandler.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ICommandHandler.java
@@ -11,11 +11,9 @@ package org.python.pydev.shared_interactive_console.console.ui.internal;
 
 
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
 
 public interface ICommandHandler {
 
-    void handleCommand(String userInput, ICallback<Object, InterpreterResponse> onResponseReceived,
-            ICallback<Object, Tuple<String, String>> onContentsReceived);
+    void handleCommand(String userInput, ICallback<Object, InterpreterResponse> onResponseReceived);
 }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IStreamListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IStreamListener.java
@@ -1,0 +1,19 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+
+/**
+ * Interface for objects which are interested in getting informed about
+ * console stream changes. A listener is informed about console stream only 
+ * when they are ready.
+ * 
+ * This does not use the same interface as iog.eclipse.debug.core as this 
+ * merges multiple streams into a single callback interface. 
+ * <p>
+ * Clients may implement this interface.
+ * </p>
+ *
+ * @see org.eclipse.jface.text.IDocument
+ */
+public interface IStreamListener {
+    void onStream(StreamMessage message);
+}

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IStreamMonitor.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/IStreamMonitor.java
@@ -1,0 +1,7 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+public interface IStreamMonitor {
+    public void addListener(IStreamListener listener);
+
+    public void removeListener(IStreamListener listener);
+}

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleSession.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleSession.java
@@ -23,14 +23,6 @@ public class ScriptConsoleSession implements IScriptConsoleListener, IScriptCons
     }
 
     public void interpreterResponse(InterpreterResponse response, ScriptConsolePrompt prompt) {
-        if (response != null) {
-            if (response.err != null && response.err.length() > 0) {
-                session.append(response.err);
-            }
-            if (response.out != null && response.out.length() > 0) {
-                session.append(response.out);
-            }
-        }
     }
 
     public void userRequest(String text, ScriptConsolePrompt prompt) {

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
@@ -707,6 +707,7 @@ public class ScriptConsoleViewer extends TextConsoleViewer implements IScriptCon
                     console.getLineTrackers(), initialCommands, strategy);
 
             this.listener.setDocument(getDocument());
+            console.getInterpreter().addListener(this.listener);
         } else {
             this.isMainViewer = false;
             this.styleProvider = existingViewer.styleProvider;

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamMessage.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamMessage.java
@@ -1,0 +1,11 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+public class StreamMessage {
+    public StreamType type;
+    public String message;
+
+    public StreamMessage(StreamType type, String message) {
+        this.type = type;
+        this.message = message;
+    }
+}

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamReader.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamReader.java
@@ -1,0 +1,75 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.concurrent.BlockingQueue;
+
+/*
+ * StreamReader spawns two threads to continually call the blocking readline
+ * on both the stdout and stderr streams coming from the child process.
+ * These streams are serialized into a single buffer which can then be consumed
+ * in a single process. 
+ * 
+ * Possible ideas: generalise this to merge any number of streams of any number
+ * of types to serialise events.
+ */
+public class StreamReader implements Runnable {
+
+    private class ThreadedStreamReader extends Thread {
+        private final StreamType type;
+        private final BufferedReader rdr;
+        private final BlockingQueue<StreamMessage> q;
+
+        ThreadedStreamReader(StreamType type, InputStream stream, BlockingQueue<StreamMessage> q) {
+            this.type = type;
+            this.rdr = new BufferedReader(new InputStreamReader(stream));
+            this.q = q;
+        }
+
+        @Override
+        public void run() {
+            /* This line separator can in theory be document dependent and hence
+             * should use TextUtilities.getDefaultLineDelimiter(doc); 
+             * however for our purposes, the console is on the local system.
+             */
+            String endl = System.getProperty("line.separator");
+            while (true) {
+                try {
+                    StreamMessage m = new StreamMessage(type, "");
+                    m.message = rdr.readLine();
+
+                    if (m.message != null) {
+                        m.message += endl;
+                    }
+
+                    q.put(m);
+
+                    if (m.message == null) {
+                        return;
+                    }
+
+                } catch (IOException e) {
+                    return;
+                } catch (InterruptedException e) {
+                    return;
+                }
+
+            }
+        }
+    }
+
+    private final ThreadedStreamReader out;
+    private final ThreadedStreamReader err;
+
+    public StreamReader(InputStream out, InputStream err, BlockingQueue<StreamMessage> q) {
+        this.out = new ThreadedStreamReader(StreamType.STDOUT, out, q);
+        this.err = new ThreadedStreamReader(StreamType.STDERR, err, q);
+    }
+
+    public void run() {
+        out.start();
+        err.start();
+    }
+}

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamType.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/StreamType.java
@@ -1,0 +1,3 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+public enum StreamType { STDOUT, STDERR };

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ThreadedStreamMonitor.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ThreadedStreamMonitor.java
@@ -1,0 +1,98 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal;
+
+import java.util.ArrayList;
+import java.util.concurrent.BlockingQueue;
+
+import org.eclipse.core.runtime.ISafeRunnable;
+import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.core.runtime.SafeRunner;
+import org.eclipse.debug.core.DebugPlugin;
+
+public class ThreadedStreamMonitor extends Thread implements IStreamMonitor {
+    private final BlockingQueue<StreamMessage> q;
+    private ListenerList listeners = new ListenerList();
+
+    public ThreadedStreamMonitor(BlockingQueue<StreamMessage> q) {
+        this.q = q;
+    }
+
+    public void addListener(IStreamListener listener) {
+        listeners.add(listener);
+    }
+
+    public void removeListener(IStreamListener listener) {
+        listeners.remove(listener);
+    }
+
+    public void run() {
+        ContentNotifier notifier = new ContentNotifier();
+
+        while (true) {
+            StreamMessage stdout = new StreamMessage(StreamType.STDOUT, "");
+            StreamMessage stderr = new StreamMessage(StreamType.STDERR, "");
+
+            ArrayList<StreamMessage> msgs = new ArrayList<StreamMessage>();
+
+            try {
+                // drainTo isn't blocking, so we take first.
+                msgs.add(q.take());
+                q.drainTo(msgs);
+                StringBuilder stdoutBuilder = new StringBuilder();
+                StringBuilder stderrBuilder = new StringBuilder();
+
+                for (StreamMessage msg : msgs ) {
+                    if (msg.message == null) {
+                        break;
+                    }
+
+                    if (msg.type == StreamType.STDOUT) {
+                        stdoutBuilder.append(msg.message);
+                    } else {
+                        stderrBuilder.append(msg.message);
+                    }
+                }
+
+                stdout.message = stdoutBuilder.toString();
+                if (stdout.message.length() > 0) {
+                    notifier.onStream(stdout);
+                }
+
+                stderr.message = stderrBuilder.toString();
+                if (stderr.message.length() > 0) {
+                    notifier.onStream(stderr);
+                }
+
+                if (msgs.get(msgs.size()-1) == null) 
+                    return;
+
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private class ContentNotifier implements ISafeRunnable {
+
+        private IStreamListener listener;
+        private StreamMessage msg;
+
+        public void handleException(Throwable exception) {
+            DebugPlugin.log(exception);
+        }
+
+        public void run() throws Exception {
+            listener.onStream(msg);
+        }
+
+        public void onStream(StreamMessage msg) {
+            this.msg = msg;
+            Object[] copiedListeners = listeners.getListeners();
+            for (int i = 0; i < copiedListeners.length; i++) {
+                listener = (IStreamListener) copiedListeners[i];
+                SafeRunner.run(this);
+            }
+            this.listener = null;
+            this.msg = null;
+        }
+    }
+}

--- a/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleDocumentListenerTest.java
+++ b/plugins/org.python.pydev/tests_dltk_console/org/python/pydev/dltk/console/ui/internal/ScriptConsoleDocumentListenerTest.java
@@ -17,7 +17,6 @@ import org.eclipse.jface.text.IDocument;
 import org.python.pydev.editor.autoedit.PyAutoIndentStrategy;
 import org.python.pydev.editor.autoedit.TestIndentPrefs;
 import org.python.pydev.shared_core.callbacks.ICallback;
-import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_interactive_console.console.InterpreterResponse;
 import org.python.pydev.shared_interactive_console.console.ScriptConsoleHistory;
 import org.python.pydev.shared_interactive_console.console.ScriptConsolePrompt;
@@ -64,10 +63,9 @@ public class ScriptConsoleDocumentListenerTest extends TestCase {
                 new ICommandHandler() {
 
                     public void handleCommand(String userInput,
-                            ICallback<Object, InterpreterResponse> onResponseReceived,
-                            ICallback<Object, Tuple<String, String>> onContentsReceived) {
+                            ICallback<Object, InterpreterResponse> onResponseReceived) {
                         commandsHandled.add(userInput);
-                        onResponseReceived.call(new InterpreterResponse("", "", false, false));
+                        onResponseReceived.call(new InterpreterResponse(false, false));
                     }
                 },
 


### PR DESCRIPTION
This substantial change rewrites a considerable amount of code to
provide an asynchronous stream for the ScriptConsoleDocumentListener to
listen to as events rather than some ad hoc event loop distributed
between several files.

This is done by providing a few new interfaces and implementations for
asynchronous stream reading and monitoring. To wit: StreamReader<..>
will listen to the Streams from stdout and stderr and add them to a
BlockingQueue. IStreamMonitor (concretely ThreadedStreamMonitor) will
listen to the same BlockingQueue and notify listeners of the new stream
inputs. Finally, the ScriptConsoleDocumentListener is not an
IStreamListener and implements the onStream message and this will add
the text to the console after some judicious prompt manipulation.
