### PR TITLE
Only examine the current cell when deciding how much to indent the next line

### DIFF
--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
@@ -24,6 +24,7 @@ import org.eclipse.jface.text.TextUtilities;
 import org.python.pydev.shared_core.callbacks.ICallback;
 import org.python.pydev.shared_core.log.Log;
 import org.python.pydev.shared_core.string.FastStringBuffer;
+import org.python.pydev.shared_core.string.StringUtils;
 import org.python.pydev.shared_core.string.TextSelectionUtils;
 import org.python.pydev.shared_core.structure.Tuple;
 import org.python.pydev.shared_core.utils.DocCmd;
@@ -52,6 +53,8 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
     private ScriptConsoleHistory history;
 
     private int offset;
+
+    private int historyFullLine;
 
     /**
      * Document to which this listener is attached.
@@ -201,6 +204,8 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
 
         this.offset = 0;
 
+        this.historyFullLine = 0;
+
         this.doc = null;
 
         this.consoleLineTrackers = consoleLineTrackers;
@@ -239,6 +244,9 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
                 offset = getLastLineLength();
             } catch (BadLocationException e) {
                 Log.log(e);
+            }
+            if (!result.more) {
+                historyFullLine = history.getAsList().size();
             }
         }
         appendInvitation(false);
@@ -443,7 +451,9 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
                         try {
                             processResult(arg);
                             if (finalAddedNewLine) {
-                                IDocument historyDoc = history.getAsDoc();
+                                List<String> historyList = history.getAsList();
+                                IDocument historyDoc = new Document(StringUtils.join("\n",
+                                        historyList.subList(historyFullLine, historyList.size())) + "\n");
                                 int currHistoryLen = historyDoc.getLength();
                                 if (currHistoryLen > 0) {
                                     DocCmd docCmd = new DocCmd(currHistoryLen - 1, 0, finalDelim);


### PR DESCRIPTION
This can be seen by something like:

> > > int(
> > > ...     ]
> > > SyntaxError

All subsequent lines start with 4 spaces of indent because the indenter is still reading the open parenthesis from above.
