### PR TITLE
Prevent the "configure interpreter" button from remaining disabled.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/PyProjectPythonDetails.java
@@ -200,13 +200,7 @@ public class PyProjectPythonDetails extends PropertyPage {
                                     + interpreterManager.getInterpreterType());
 
                     }
-                    if (onSelectionChanged != null) {
-                        try {
-                            onSelectionChanged.call(null);
-                        } catch (Exception e1) {
-                            Log.log(e1);
-                        }
-                    }
+                    triggerCallback();
                 }
             };
 
@@ -261,7 +255,7 @@ public class PyProjectPythonDetails extends PropertyPage {
                                         public void run() {
                                             //Only update if the page is still there.
                                             //If something is disposed, it has been closed.
-                                            if (!radioPy.isDisposed()) {
+                                            if (!interpreterNoteText.isDisposed()) {
                                                 selectionListener.widgetSelected(null);
                                             }
                                         }
@@ -272,7 +266,11 @@ public class PyProjectPythonDetails extends PropertyPage {
                             interpreterNoteText.setText("Configuration in progress...");
                             boolean advanced = open == InterpreterConfigHelpers.CONFIG_ADV_AUTO;
                             AutoConfigMaker a = new AutoConfigMaker(interpreterType, advanced, null, null);
-                            a.autoConfigSingleApply(onJobComplete);
+                            if (a.autoConfigSingleApply(onJobComplete)) {
+                                triggerCallback();
+                            } else {
+                                selectionListener.widgetSelected(null);
+                            }
                         }
                     }
                 }
@@ -282,6 +280,16 @@ public class PyProjectPythonDetails extends PropertyPage {
             });
 
             return topComp;
+        }
+
+        private void triggerCallback() {
+            if (onSelectionChanged != null) {
+                try {
+                    onSelectionChanged.call(null);
+                } catch (Exception e1) {
+                    Log.log(e1);
+                }
+            }
         }
 
         /**

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AutoConfigMaker.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AutoConfigMaker.java
@@ -110,14 +110,14 @@ public class AutoConfigMaker {
      * in the constructor, in cases when no interpreters of that type are yet configured.
      * @param onConfigComplete An optional JobChangeAdapter to be associated with the configure operation.
      */
-    public void autoConfigSingleApply(JobChangeAdapter onConfigComplete) {
+    public boolean autoConfigSingleApply(JobChangeAdapter onConfigComplete) {
         if (interpreterManager.getInterpreterInfos().length != 0) {
-            return;
+            return false;
         }
         ObtainInterpreterInfoOperation operation = autoConfigSearch();
         //autoConfigSearch displays an error dialog if an interpreter couldn't be found, so don't display errors for null cases here.
         if (operation == null) {
-            return;
+            return false;
         }
         try {
             final IInterpreterInfo interpreterInfo = operation.result.makeCopy();
@@ -158,7 +158,7 @@ public class AutoConfigMaker {
                 applyOperationJob.addJobChangeListener(onConfigComplete);
             }
             applyOperationJob.schedule();
-            return;
+            return true;
 
         } catch (Exception e) {
             Log.log(e);
@@ -171,7 +171,7 @@ public class AutoConfigMaker {
             //show the user a message (so that it does not fail silently)...
             ErrorDialog.openError(EditorUtils.getShell(), "Unable to get info on the interpreter.",
                     errorMsg, PydevPlugin.makeStatus(IStatus.ERROR, "See error log for details.", e));
-            return;
+            return false;
         } finally {
             if (charWriter != null) {
                 Log.logInfo(charWriter.toString());


### PR DESCRIPTION
---

This fixes a bug where the "configure interpreter" link in PyProjectPythonDetails becomes permanently disabled if an interpreter configuration event fails or is cancelled.
