### PR TITLE
Don't set pydevd.connected=True, if the connection can't be established.

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevd.py
+++ b/plugins/org.python.pydev/pysrc/pydevd.py
@@ -1471,7 +1471,14 @@ def _locked_settrace(host, stdoutToServer, stderrToServer, port, suspend, trace_
         pydevd_vm_type.SetupType()
 
         debugger = PyDB()
-        debugger.connect(host, port)
+        try:
+            debugger.connect(host, port)
+        except Exception:
+            # actually we are not connected.
+            connected = False
+            bufferStdOutToServer = False
+            bufferStdErrToServer = False
+            raise
 
         net = NetCommand(str(CMD_THREAD_CREATE), 0, '<xml><thread name="pydevd.reader" id="-1"/></xml>')
         debugger.writer.addCommand(net)


### PR DESCRIPTION
This change prevents spurious error messages, if application code calls
pydevd.settrace a second time after a failed connection attempt.

```
Traceback (most recent call last):
  File "F:\eclipse\plugins\org.python.pydev_3.1.0.201312121632\pysrc\pydevd_frame.py", line 234, in trace_dispatch
    self.doWaitSuspend(thread, frame, event, arg)
  File "F:\eclipse\plugins\org.python.pydev_3.1.0.201312121632\pysrc\pydevd_frame.py", line 38, in doWaitSuspend
    self._args[0].doWaitSuspend(*args, **kwargs)
  File "F:\eclipse\plugins\org.python.pydev_3.1.0.201312121632\pysrc\pydevd.py", line 1022, in doWaitSuspend
    self.writer.addCommand(cmd)
AttributeError: 'NoneType' object has no attribute 'addCommand'
```
