### PR TITLE
PyDev used to follow symlinks when computing the real path of the python

### DIFF
--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -211,12 +212,23 @@ public class FileUtils {
         return getFileAbsolutePath(new File(f));
     }
 
+    public static String getFileAbsolutePath(String f, boolean follow_links) {
+        return getFileAbsolutePath(new File(f), follow_links);
+    }
+
     /**
      * @see #getFileAbsolutePath(String)
      */
     public static String getFileAbsolutePath(File f) {
+        return getFileAbsolutePath(f, true);
+    }
+
+    public static String getFileAbsolutePath(File f, boolean follow_links) {
         try {
-            return f.getCanonicalPath();
+            if (follow_links) {
+                return f.getCanonicalPath();
+            }
+            return f.toPath().toRealPath(LinkOption.NOFOLLOW_LINKS).toString();
         } catch (IOException e) {
             return f.getAbsolutePath();
         }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/InterpreterInputDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/dialogs/InterpreterInputDialog.java
@@ -92,7 +92,7 @@ public class InterpreterInputDialog extends AbstractKeyValueDialog {
     public Tuple<String, String> getKeyAndValueEntered() {
         Tuple<String, String> keyAndValueEntered = super.getKeyAndValueEntered();
         if (keyAndValueEntered != null) {
-            keyAndValueEntered.o2 = FileUtils.getFileAbsolutePath(finalValueValue);
+            keyAndValueEntered.o2 = FileUtils.getFileAbsolutePath(finalValueValue, false);
         }
         return keyAndValueEntered;
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/AbstractInterpreterProviderFactory.java
@@ -37,6 +37,10 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
         return INVALID;
     }
 
+    public String[] searchPaths(java.util.Set<String> pathsToSearch, final List<String> expectedPatterns) {
+        return searchPaths(pathsToSearch, expectedPatterns, true);
+    }
+
     /**
      * Searches a set of paths for files whose names match any of the provided patterns.
      * @param pathsToSearch The paths to search for files.
@@ -46,7 +50,8 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
      * patterns at index i+1.
      * @return An array of all matching filenames found, in order of decreasing priority.
      */
-    public String[] searchPaths(java.util.Set<String> pathsToSearch, final List<String> expectedPatterns) {
+    public String[] searchPaths(java.util.Set<String> pathsToSearch, final List<String> expectedPatterns,
+            boolean follow_links) {
         int n = expectedPatterns.size();
 
         @SuppressWarnings("unchecked")
@@ -72,7 +77,8 @@ public abstract class AbstractInterpreterProviderFactory implements IInterpreter
                                     pathSetsByPriority[priority] = new LinkedHashSet<String>();
                                 }
                                 LinkedHashSet<String> pathSet = pathSetsByPriority[priority];
-                                pathSet.add(FileUtils.getFileAbsolutePath(new File(file, afile.getName())));
+                                File f = new File(file, afile.getName());
+                                pathSet.add(FileUtils.getFileAbsolutePath(f, follow_links));
                             }
                         }
                     }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PythonInterpreterProviderFactory.java
@@ -56,7 +56,7 @@ public class PythonInterpreterProviderFactory extends AbstractInterpreterProvide
             }
             pathsToSearch.add("/usr/bin");
             pathsToSearch.add("/usr/local/bin");
-            final String[] ret = searchPaths(pathsToSearch, Arrays.asList("python", "python\\d(\\.\\d)*|pypy"));
+            final String[] ret = searchPaths(pathsToSearch, Arrays.asList("python", "python\\d(\\.\\d)*|pypy"), false);
             if (ret.length > 0) {
                 return AlreadyInstalledInterpreterProvider.create("python", ret);
             }


### PR DESCRIPTION
interpreter.  This would defeat virtual env on linux which creates a
symlink to the original python interpreter within the virtual
environment directories.  This patch modifies FileUtils to take an
optional follow_links argument which avoids this behavior when resolving
the interpreter path.
