### PR TITLE
Fix special methods of class pydevd_constants.Null

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevd_constants.py
+++ b/plugins/org.python.pydev/pysrc/pydevd_constants.py
@@ -191,6 +191,9 @@ class Null:
         return self
 
     def __getattr__(self, mname):
+        if len(mname) > 4 and mname[:2] == '__' and mname[-2:] == '__':
+            # Don't pretend to implement special method names.
+            raise AttributeError(mname)
         return self
 
     def __setattr__(self, name, value):
@@ -222,15 +225,6 @@ class Null:
 
     def __iter__(self):
         return iter(())
-
-    def __getinitargs__(self):
-        return ()
-
-    def __getstate__(self):
-        return {}
-
-    def __reduce__(self):
-        return (self.__class__, ())
 
 
 def call_only_once(func):


### PR DESCRIPTION
The current implementation of Null.__getattr__(self, mname) always returns self. This causes problems, if the mname is the name of a special method like '__iter__', '__getinitargs__', '__getstate__' or '__reduce__'. If a class implements special methods, it should follow the specification. For instance currently `for x in Null(): pass` causes an endless loop.

The patch adds Null.__iter__() and modifies __getattr__(self, mname) to raise AttributeError on special names. 
If you consider this modification to aggressive, please consider pulling commit 6097e285e96f44 instead. It doesn't touch __getattr__ but implements all pickling related method instead.
