### PR TITLE
Changed Simple Jython Runner to support multiple switches for console

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleJythonRunner.java
@@ -157,19 +157,18 @@ public class SimpleJythonRunner extends SimpleRunner {
             cacheDir = "-Dpython.cachedir=" + cacheDir.trim();
         }
 
-        String[] s;
+        String[] vmArgsList = vmArgs.split(" ");
+        String[] s = new String[] {
+                "-Dpython.path=" + jythonPath.toString(), "-classpath", jythonJar + pathSeparator + jythonPath,
+                "org.python.util.jython", script };
+
+        List<String> asList = new ArrayList<String>();
+        asList.add(javaLoc);
         if (cacheDir != null) {
-            s = new String[] { javaLoc, cacheDir, "-Dpython.path=" + jythonPath.toString(), "-classpath",
-                    jythonJar + pathSeparator + jythonPath, vmArgs, "org.python.util.jython", script };
-        } else {
-            s = new String[] { javaLoc,
-                    //cacheDir, no cache dir if it's not available
-                    "-Dpython.path=" + jythonPath.toString(), "-classpath", jythonJar + pathSeparator + jythonPath,
-                    vmArgs, "org.python.util.jython", script };
-
+            asList.add(cacheDir);
         }
-
-        List<String> asList = new ArrayList<String>(Arrays.asList(s));
+        asList.addAll(Arrays.asList(vmArgsList));
+        asList.addAll(Arrays.asList(s));
         asList.addAll(Arrays.asList(args));
         return asList.toArray(new String[0]);
     }


### PR DESCRIPTION
Hi!

When using jython for intaractive console, I discovered that multiple vmargs in the interactive console perferences won't work because they will be enclosed in quotation marks. So the virtual machine tries to interpret them as one parameter.
I changed this by splitting the vmargs by space and put them as list into the commandline array.

By the way it is my first github pull request, so please let me know if I have done something wrong.
Regards, Dirk
