### PR TITLE
fix pytest protocol invocation to allow for module/session scoped fixtur...

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydev_runfiles_pytest.py
+++ b/plugins/org.python.pydev/pysrc/pydev_runfiles_pytest.py
@@ -138,8 +138,11 @@ class PydevPlugin:
             if session.config.option.collectonly:
                 return True
 
-            for item in items:
-
+            for i, item in enumerate(items):
+                try:
+                    nextitem = items[i+1]
+                except IndexError:
+                    nextitem = None
                 filename = item.fspath.strpath
                 test = item.location[2]
                 start = time.time()
@@ -148,7 +151,7 @@ class PydevPlugin:
 
                 #Don't use this hook because we need the actual reports.
                 #item.config.hook.pytest_runtest_protocol(item=item)
-                reports = runner.runtestprotocol(item)
+                reports = runner.runtestprotocol(item, nextitem=nextitem)
                 delta = time.time() - start
 
                 captured_output = ''


### PR DESCRIPTION
This little change fixes pytest invocations to make fixtures more properly work.  Example of what is fixed:

```
import pytest

@pytest.fixture(scope="session")
def somefix():
      return object()

def test_1(somefix):
      assert 0, somefix

def test_2(somefix):
      assert 0, somefix
```

Without the fix the two failures will show two different `somefix` instances.   With the fix, they will be identical.

Note also that many others encountered this problem, see http://stackoverflow.com/questions/15875038/pydev-running-pytest-unit-test-with-module-shared-fixture-fails .  
