### PR TITLE
Provide source packages for PyDev

### DIFF
--- a/features/org.python.pydev.feature/pom.xml
+++ b/features/org.python.pydev.feature/pom.xml
@@ -22,4 +22,41 @@
   <groupId>org.python.pydev</groupId>
   <artifactId>org.python.pydev.feature</artifactId>
   <packaging>eclipse-feature</packaging>
+  <build>
+      <plugins>
+        <plugin>
+          <groupId>org.eclipse.tycho.extras</groupId>
+          <artifactId>tycho-source-feature-plugin</artifactId>
+          <version>${tycho-extras-version}</version>
+          <executions>
+            <execution>
+              <id>source-feature</id>
+              <phase>package</phase>
+              <goals>
+                <goal>source-feature</goal>
+              </goals>
+              <configuration>
+                <excludes>
+                  <plugin id="org.python.pydev.help" />
+                </excludes>
+              </configuration>
+            </execution>
+          </executions>
+        </plugin>
+        <plugin>
+          <groupId>org.eclipse.tycho</groupId>
+          <artifactId>tycho-p2-plugin</artifactId>
+          <version>${tycho-version}</version>
+          <executions>
+            <execution>
+              <id>attach-p2-metadata</id>
+              <phase>package</phase>
+              <goals>
+                <goal>p2-metadata</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+    </plugins>
+  </build>
 </project>

--- a/features/org.python.pydev.p2-repo/category.xml
+++ b/features/org.python.pydev.p2-repo/category.xml
@@ -4,6 +4,10 @@
    
    <feature url="features/org.python.pydev.feature_0.0.0.qualifier.jar" id="org.python.pydev.feature" version="0.0.0">
       <category name="PyDev"/>
+  </feature>
+
+   <feature url="features/org.python.pydev.feature.source_0.0.0.qualifier.jar" id="org.python.pydev.feature.source" version="0.0.0">
+      <category name="PyDev"/>
    </feature>
 
    <feature url="features/org.python.pydev.mylyn.feature_0.0.0.qualifier.jar" id="org.python.pydev.mylyn.feature" version="0.0.0">

--- a/pom.xml
+++ b/pom.xml
@@ -246,6 +246,19 @@
         <artifactId>tycho-versions-plugin</artifactId>
         <version>${tycho-version}</version>
       </plugin>
+      <plugin>
+        <groupId>org.eclipse.tycho</groupId>
+        <artifactId>tycho-source-plugin</artifactId>
+        <version>${tycho-version}</version>
+        <executions>
+          <execution>
+            <id>plugin-source</id>
+            <goals>
+              <goal>plugin-source</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>


### PR DESCRIPTION
These changes provide a sdk-feature along with source plugins whenever a release is built. The benefit of this is that Eclipse will be able to automatically show the java code related to the pydev classes when using the prebuilt release package to create plugins that use PyDev.