### PR TITLE
Fix the wrong signature of stackless.get_schedule_callback

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevd_stackless.py
+++ b/plugins/org.python.pydev/pysrc/pydevd_stackless.py
@@ -388,7 +388,7 @@ def patch_stackless():
         _application_set_schedule_callback = callable
         return old
 
-    def get_schedule_callback(callable):
+    def get_schedule_callback():
         global _application_set_schedule_callback
         return _application_set_schedule_callback
 


### PR DESCRIPTION
I'm sorry, but my commit d1f907bd contains a little copy and paste error. 
This pull request fixes the error.

pydevd monkey patches the function stackless.get_schedule_callback.
Previously the patched get_schedule_callback had a different signature
than the original function. See https://stackless.readthedocs.org/en/latest/library/stackless/stackless.html#stackless.get_schedule_callback
