### PR TITLE
Fix python3 str vs byte on Cygwin

### DIFF
--- a/plugins/org.python.pydev/pysrc/interpreterInfo.py
+++ b/plugins/org.python.pydev/pysrc/interpreterInfo.py
@@ -63,6 +63,7 @@ if sys.platform == "cygwin":
 
         retval = ctypes.create_string_buffer(MAX_PATH)
         path = fullyNormalizePath(path)
+        path = tobytes(path)
         CCP_POSIX_TO_WIN_A = 0
         ctypes.cdll.cygwin1.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
         
@@ -121,9 +122,9 @@ def tounicode(s):
         return s.decode(file_system_encoding)
     return s
 
-def toutf8(s):
+def tobytes(s):
     if hasattr(s, 'encode'):
-        return s.encode('utf-8')
+        return s.encode(file_system_encoding)
     return s
 
 def toasciimxl(s):


### PR DESCRIPTION
As stated in http://stackoverflow.com/q/26537945, the output of
`ctypes.cdll.cygwin1.cygwin_conv_path` is always a byte string so
it doesn't work when checking it on cygwin against simple string
which is unicode string on python3
