### PR TITLE
PyDev-495 Unset VIRTUAL_ENV before running external IPython to

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/runners/SimpleRunner.java
@@ -179,6 +179,8 @@ public class SimpleRunner {
 
         //Always remove PYTHONHOME from the default system env, as it doesn't work well with multiple interpreters.
         env.remove("PYTHONHOME");
+        // PyDev-495 Remove VIRTUAL_ENV as it cause IPython to munge the PYTHON_PATH
+        env.remove("VIRTUAL_ENV");
         return env;
     }
 


### PR DESCRIPTION
...protect the sys.path

IPython on startup extends the python path with that of any virtual environment pointed at by `VIRTUAL_ENV` variable. We should clear it before running.
