### PR TITLE
Make object contributions only show up in python files

### DIFF
--- a/plugins/com.python.pydev.analysis/plugin.xml
+++ b/plugins/com.python.pydev.analysis/plugin.xml
@@ -177,7 +177,7 @@
                menubarPath="org.python.pydev.ui.actions.menu/pydev"
                tooltip="Force a code analysis for the selected elements (recursive)">
          </action>
-         <visibility><objectState name="projectNature" value="org.python.pydev.pythonNature"/></visibility>
+         <visibility><objectState name="contentTypeId" value="org.python.pydev.pythonfile"/></visibility>
       </objectContribution>
    </extension>
 

--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -210,7 +210,7 @@
                menubarPath="org.python.pydev.ui.actions.menu/pydev"
                tooltip="Apply 2To3 (lib2to3 must be available in the interpreter PYTHONPATH)">
          </action>
-         <visibility><objectState name="projectNature" value="org.python.pydev.pythonNature"/></visibility>
+         <visibility><objectState name="contentTypeId" value="org.python.pydev.pythonfile"/></visibility>
       </objectContribution>
 
       <!-- remove errors -->


### PR DESCRIPTION
Things like the 2to3 or the analysis actions only make sense when working
with an actual python file. However by letting them be visible based on
the project nature these actions also end up in the context menus of any
other types of editors used for files within a python project. That means
an xml file happening to sit in a python project will show these actions as
well as a simple text file.

So instead let the actions only show up for resources that are of the
python content type.