### PR TITLE
Fix typo in PyRenameRefactoringWizard.java

### DIFF
--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameRefactoringWizard.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/wizards/rename/PyRenameRefactoringWizard.java
@@ -134,7 +134,7 @@ public class PyRenameRefactoringWizard extends RefactoringWizard {
                     if (text.length() == 0) {
                         //Accept empty for move!
                         status = new RefactoringStatus();
-                        status.addInfo("Empty text: move to source foder");
+                        status.addInfo("Empty text: move to source folder");
                     } else {
                         status = validateTextField(text);
                     }


### PR DESCRIPTION
Fix a typo in the Rename Refactoring Wizard (foder -> folder)