### PR TITLE
Support automatic folding of comments when opening a file

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -219,7 +219,8 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener {
                 return null;
             }
         }
-        return new Tuple<ProjectionAnnotation, Position>(new PyProjectionAnnotation(node.getAstEntry()), position);
+        return new Tuple<ProjectionAnnotation, Position>(new PyProjectionAnnotation(node.getAstEntry(),
+                node.isCollapsed), position);
     }
 
     /*
@@ -293,8 +294,9 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener {
                 String string = it.next();
                 if (string.trim().startsWith("#")) {
                     int l = it.getCurrentLine() - 1;
+                    boolean isCollapsed = prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_COLLAPSE_COMMENTS);
                     addFoldingEntry(ret, new FoldingEntry(FoldingEntry.TYPE_COMMENT, l, l + 1, new ASTEntry(null,
-                            new commentType(string))));
+                            new commentType(string)), isCollapsed));
                 }
             }
         }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
@@ -14,7 +14,7 @@ import org.python.pydev.shared_core.string.FastStringBuffer;
 
 public class FoldingEntry {
 
-    public FoldingEntry(int type, int startLine, int endLine, ASTEntry astEntry) {
+    public FoldingEntry(int type, int startLine, int endLine, ASTEntry astEntry, boolean isCollapsed) {
         if (endLine < startLine) {
             endLine = startLine;
         }
@@ -22,6 +22,12 @@ public class FoldingEntry {
         this.startLine = startLine;
         this.endLine = endLine;
         this.astEntry = astEntry;
+        this.isCollapsed = isCollapsed;
+    }
+
+    public FoldingEntry(int type, int startLine, int endLine, ASTEntry astEntry)
+    {
+        this(type, startLine, endLine, astEntry, false);
     }
 
     public final static int TYPE_IMPORT = 1;
@@ -36,6 +42,7 @@ public class FoldingEntry {
     public int startLine;
     public int endLine;
     public ASTEntry astEntry;
+    public boolean isCollapsed;
 
     @Override
     public int hashCode() {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
@@ -86,6 +86,10 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
 
     public static final String FOLD_WITH = "FOLD_WITH";
 
+    public static final String INITIALLY_COLLAPSE_COMMENTS = "INITIALLY_COLLAPSE_COMMENTS";
+
+    public static final boolean DEFAULT_INITIALLY_COLLAPSE_COMMENTS = false;
+
     /**
      * 
      */
@@ -142,6 +146,8 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
 
         Button slaveComment = addCheckBox(top, "Fold Comments?", FOLD_COMMENTS, 0);
 
+        Button slaveCommentInitCollapse = addCheckBox(top, "Initially Fold Comments?", INITIALLY_COLLAPSE_COMMENTS, 0);
+
         Button slaveFor = addCheckBox(top, "Fold FOR statments?", FOLD_FOR, 0);
 
         Button slaveIf = addCheckBox(top, "Fold IF statments?", FOLD_IF, 0);
@@ -162,6 +168,7 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
         createDependency(master, USE_CODE_FOLDING, slaveWith);
         createDependency(master, USE_CODE_FOLDING, slaveString);
         createDependency(master, USE_CODE_FOLDING, slaveComment);
+        createDependency(master, USE_CODE_FOLDING, slaveCommentInitCollapse);
 
         return top;
 
@@ -286,6 +293,8 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, FOLD_TRY));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, FOLD_WHILE));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, FOLD_WITH));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN,
+                INITIALLY_COLLAPSE_COMMENTS));
 
         OverlayPreferenceStore.OverlayKey[] keys = new OverlayPreferenceStore.OverlayKey[overlayKeys.size()];
         overlayKeys.toArray(keys);

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyProjectionAnnotation.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyProjectionAnnotation.java
@@ -24,7 +24,8 @@ public class PyProjectionAnnotation extends ProjectionAnnotation {
 
     public ASTEntry node;
 
-    public PyProjectionAnnotation(ASTEntry node) {
+    public PyProjectionAnnotation(ASTEntry node, boolean isCollapsed) {
+        super(isCollapsed);
         this.node = node;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
@@ -158,6 +158,8 @@ public class PydevPrefsInitializer extends AbstractPreferenceInitializer {
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_CLASSDEF);
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_FUNCTIONDEF);
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_COMMENTS, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_COMMENTS);
+        node.putBoolean(PyDevCodeFoldingPrefPage.INITIALLY_COLLAPSE_COMMENTS,
+                PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_COLLAPSE_COMMENTS);
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_STRINGS, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_STRINGS);
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_WITH, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_WITH);
         node.putBoolean(PyDevCodeFoldingPrefPage.FOLD_TRY, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_TRY);

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
@@ -135,6 +135,7 @@ public class CodeFoldingSetterTest extends TestCase {
         preferences.setValue(PyDevCodeFoldingPrefPage.USE_CODE_FOLDING, value);
         preferences.setValue(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF, value);
         preferences.setValue(PyDevCodeFoldingPrefPage.FOLD_COMMENTS, value);
+        preferences.setValue(PyDevCodeFoldingPrefPage.INITIALLY_COLLAPSE_COMMENTS, value);
         preferences.setValue(PyDevCodeFoldingPrefPage.FOLD_FOR, value);
         preferences.setValue(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF, value);
         preferences.setValue(PyDevCodeFoldingPrefPage.FOLD_IF, value);
@@ -378,6 +379,7 @@ public class CodeFoldingSetterTest extends TestCase {
         setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_STRINGS);
         setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF);
         setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_COMMENTS);
+        setOptionTrue(PyDevCodeFoldingPrefPage.INITIALLY_COLLAPSE_COMMENTS);
         setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_IMPORTS);
         setOptionTrue(PyDevCodeFoldingPrefPage.USE_CODE_FOLDING);
         Document doc = new Document("" +
@@ -453,6 +455,7 @@ public class CodeFoldingSetterTest extends TestCase {
 
     public void testMarksCommentsEnabled() throws Exception {
         setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_COMMENTS);
+        setOptionTrue(PyDevCodeFoldingPrefPage.INITIALLY_COLLAPSE_COMMENTS);
         setOptionTrue(PyDevCodeFoldingPrefPage.USE_CODE_FOLDING);
         Document doc = new Document(largeDoc);
 


### PR DESCRIPTION
With this new preference users can select to automatically collapse
multi-line comments whenever the file is opened. The idea here is to reduce
the visual noise when opening a file so a user can concentrate on the actual
source.

The default for this is off to keep compatibility with older PyDev versions
so users do not suddenly miss their documentation.