### PR TITLE
feature: Enable hover info for Strings and comments

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/IPyHoverParticipant2.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/IPyHoverParticipant2.java
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Licensed under the terms of the Eclipse Public License (EPL).
+ * Please see the license.txt included with this distribution for details.
+ * Any modifications to this file must keep this entire header intact.
+ */
+package org.python.pydev.editor.hover;
+
+/**
+ * This is a marker interface to identify hover participants for which specialized behavior is implemented.
+ * 
+ * For example, hover participants that implement this interface will provide hover info for Strings and comments.
+ * 
+ */
+public interface IPyHoverParticipant2 extends IPyHoverParticipant {
+
+}

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/IPyHoverParticipant2.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/IPyHoverParticipant2.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2011 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2016 by Brainwy Software LTDA. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -13,5 +13,13 @@ package org.python.pydev.editor.hover;
  * 
  */
 public interface IPyHoverParticipant2 extends IPyHoverParticipant {
+
+    /**
+     * Checks if the specified content type is supported
+     * 
+     * @param contentType the content type
+     * @return true if the specified content type is supported
+     */
+    public boolean isContentTypeSupported(String contentType);
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
@@ -118,13 +118,13 @@ public class PyTextHover implements ITextHover, ITextHoverExtension {
     public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
         FastStringBuffer buf = new FastStringBuffer();
 
-        if (!pythonCommentOrMultiline) {
-            if (textViewer instanceof PySourceViewer) {
-                PySourceViewer s = (PySourceViewer) textViewer;
-                PySelection ps = new PySelection(s.getDocument(), hoverRegion.getOffset() + hoverRegion.getLength());
+        if (textViewer instanceof PySourceViewer) {
+            PySourceViewer s = (PySourceViewer) textViewer;
+            PySelection ps = new PySelection(s.getDocument(), hoverRegion.getOffset() + hoverRegion.getLength());
 
-                List<IPyHoverParticipant> participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_HOVER);
-                for (IPyHoverParticipant pyHoverParticipant : participants) {
+            List<IPyHoverParticipant> participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_HOVER);
+            for (IPyHoverParticipant pyHoverParticipant : participants) {
+                if (!pythonCommentOrMultiline || pyHoverParticipant instanceof IPyHoverParticipant2) {
                     try {
                         String hoverText = pyHoverParticipant.getHoverText(hoverRegion, s, ps, textSelection);
                         if (hoverText != null && hoverText.trim().length() > 0) {
@@ -138,13 +138,14 @@ public class PyTextHover implements ITextHover, ITextHoverExtension {
                         Log.log(e);
                     }
                 }
-
+            }
+            if (!pythonCommentOrMultiline) {
                 getMarkerHover(hoverRegion, s, buf);
                 if (PyHoverPreferencesPage.getShowDocstringOnHover()) {
                     getDocstringHover(hoverRegion, s, ps, buf);
                 }
-
             }
+
         }
         return buf.toString();
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyTextHover.java
@@ -92,6 +92,11 @@ public class PyTextHover implements ITextHover, ITextHoverExtension {
     private final boolean pythonCommentOrMultiline;
 
     /**
+     * The type of the content we're hovering over.
+     */
+    private final String contentType;
+
+    /**
      * The text selected
      */
     private ITextSelection textSelection;
@@ -112,6 +117,7 @@ public class PyTextHover implements ITextHover, ITextHoverExtension {
             }
         }
         this.pythonCommentOrMultiline = pythonCommentOrMultiline;
+        this.contentType = contentType;
     }
 
     @SuppressWarnings("unchecked")
@@ -124,7 +130,12 @@ public class PyTextHover implements ITextHover, ITextHoverExtension {
 
             List<IPyHoverParticipant> participants = ExtensionHelper.getParticipants(ExtensionHelper.PYDEV_HOVER);
             for (IPyHoverParticipant pyHoverParticipant : participants) {
-                if (!pythonCommentOrMultiline || pyHoverParticipant instanceof IPyHoverParticipant2) {
+                boolean contentTypeSupported = !pythonCommentOrMultiline;
+                if (pyHoverParticipant instanceof IPyHoverParticipant2) {
+                    contentTypeSupported = ((IPyHoverParticipant2) pyHoverParticipant)
+                            .isContentTypeSupported(this.contentType);
+                }
+                if (contentTypeSupported) {
                     try {
                         String hoverText = pyHoverParticipant.getHoverText(hoverRegion, s, ps, textSelection);
                         if (hoverText != null && hoverText.trim().length() > 0) {


### PR DESCRIPTION
Added marker interface IPyHoverParticipant2, which extends IPyHoverParticipant. For hover participants that implement this interface, hover info will be provided for strings and comments.

Unit tests executed with 131/131 successes.

reference: http://stackoverflow.com/a/34788905/2036650