### PR TITLE
Add lib-dynload dir to PYTHONPATH

### DIFF
--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.java
@@ -37,6 +37,7 @@ public class TestDependent {
     public static String PYTHON_EXE = null;
     public static String PYTHON_SITE_PACKAGES = null;
     public static String PYTHON_TEST_PACKAGES = null;
+    public static String PYTHON_LIB_DYNLOAD = null;
 
     //Python (optional): related tests won't be run if not available
     public static String PYTHON_WXPYTHON_PACKAGES = null;
@@ -87,13 +88,16 @@ public class TestDependent {
 
     public static String GetCompletePythonLib(boolean addSitePackages) {
         String dlls = "";
+        if (PYTHON_LIB_DYNLOAD == null) {
+            PYTHON_LIB_DYNLOAD = "";
+        }
         if (isWindows()) {
             dlls = "|" + PYTHON_DLLS;
         }
         if (!addSitePackages) {
-            return PYTHON_LIB + dlls;
+            return PYTHON_LIB + "|" + PYTHON_LIB_DYNLOAD + dlls;
         } else {
-            return PYTHON_LIB + "|" + PYTHON_SITE_PACKAGES + dlls;
+            return PYTHON_LIB + "|" + PYTHON_LIB_DYNLOAD + "|" + PYTHON_SITE_PACKAGES + dlls;
         }
     }
 

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.linux.properties
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.linux.properties
@@ -2,6 +2,7 @@
 PYTHON_INSTALL=/usr/lib/python2.7/
 PYTHON_EXE=/usr/bin/python2.7
 PYTHON_LIB=/usr/lib/python2.7/
+PYTHON_LIB_DYNLOAD=/usr/lib/python2.7/lib-dynload/
 PYTHON_SITE_PACKAGES=/usr/local/lib/python2.7/site-packages/
 PYTHON_30_LIB=/usr/lib/python3.2/
 

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.travis.properties
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/TestDependent.travis.properties
@@ -3,6 +3,7 @@
 PYTHON_INSTALL=/usr/lib/python2.7/
 PYTHON_EXE=/usr/bin/python2.7
 PYTHON_LIB=/usr/lib/python2.7/
+PYTHON_LIB_DYNLOAD=/usr/lib/python2.7/lib-dynload/
 PYTHON_SITE_PACKAGES=/usr/local/lib/python2.7/site-packages/
 PYTHON_30_LIB=/usr/lib/python3.2/
 


### PR DESCRIPTION
Fixed problem with module from lib-dynload (math) not being included in PYTHONPATH when running Unit Tests.

Updated linux and travis properties files. Did not modify windows property file, as PYTHON_LIB property is not used there, and I was unsure whether lib-dynload applies for Windows. (I don't have a Windows installation on which to test PyDev.)