### PR TITLE
Avoid unnecessary creation of a shell.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/CheckDefaultPreferencesDialog.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/CheckDefaultPreferencesDialog.java
@@ -172,8 +172,7 @@ public class CheckDefaultPreferencesDialog extends TrayDialog {
                             "Launch operation: always launch the previously selected application.",
                             "\tReason: On PyDev, F9 launches the current selection (and Ctrl+F9 launches unit-tests),\n"
                                     + "\tso it's recommended that Ctrl+F11 is set to re-launch the last launch and\n"
-                                    + "\tF11 to debug the last launch."
-                    )
+                                    + "\tF11 to debug the last launch.")
             };
             ArrayList<CheckInfo> lst = new ArrayList<>(infos.length);
 
@@ -235,7 +234,7 @@ public class CheckDefaultPreferencesDialog extends TrayDialog {
                         return;
                     }
                     Display disp = Display.getCurrent();
-                    Shell shell = new Shell(disp);
+                    Shell shell = disp.getActiveShell();
                     CheckDefaultPreferencesDialog dialog = new CheckDefaultPreferencesDialog(shell, missing);
                     showing = true;
                     try {


### PR DESCRIPTION
This prevents a spurious empty shell being created behind the editor preferences dialog.

Here is a screencast of the problem manifesting on a GTK3 system: https://fedorapeople.org/~mbooth/pydev_error.webm

This change avoids creation of the empty window and instead makes the main workbench window the parent of the dialog.