### PR TITLE
Fix compile against Neon platform.

### DIFF
--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/WorkspaceStub.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/WorkspaceStub.java
@@ -29,6 +29,7 @@ import org.eclipse.core.resources.IWorkspaceDescription;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.IWorkspaceRunnable;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -282,6 +283,13 @@ public class WorkspaceStub implements IWorkspace {
     @Override
     public void build(IBuildConfiguration[] buildConfigs, int kind, boolean buildReferences, IProgressMonitor monitor)
             throws CoreException {
+    }
+
+    public void run(ICoreRunnable action, ISchedulingRule rule, int flags, IProgressMonitor monitor)
+            throws CoreException {
+    }
+
+    public void run(ICoreRunnable action, IProgressMonitor monitor) throws CoreException {
     }
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEditConfiguration.java
@@ -13,6 +13,7 @@ package org.python.pydev.editor;
 
 import java.util.Map;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextHover;
@@ -80,11 +81,9 @@ public class PyEditConfiguration extends PyEditConfigurationWithoutEditor {
      * @since 3.3
      */
     @Override
-    @SuppressWarnings("unchecked")
-    protected Map<String, IPySyntaxHighlightingAndCodeCompletionEditor> getHyperlinkDetectorTargets(
+    protected Map<String, IAdaptable> getHyperlinkDetectorTargets(
             ISourceViewer sourceViewer) {
-        Map<String, IPySyntaxHighlightingAndCodeCompletionEditor> targets = super
-                .getHyperlinkDetectorTargets(sourceViewer);
+        Map<String, IAdaptable> targets = super.getHyperlinkDetectorTargets(sourceViewer);
         targets.put("org.python.pydev.editor.PythonEditor", edit); //$NON-NLS-1$
         return targets;
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyReconciler.java
@@ -56,7 +56,7 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
         private IAnnotationModel fAnnotationModel;
 
         /** Annotations to add. */
-        private Map<SpellingAnnotation, Position> fAddAnnotations;
+        private Map<Annotation, Position> fAddAnnotations;
 
         /**
          * Initializes this collector with the given annotation model.
@@ -82,7 +82,7 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
          */
         @Override
         public void beginCollecting() {
-            fAddAnnotations = new HashMap<SpellingAnnotation, Position>();
+            fAddAnnotations = new HashMap<Annotation, Position>();
         }
 
         /*
@@ -110,7 +110,7 @@ public class PyReconciler implements IReconcilingStrategy, IReconcilingStrategyE
                 //retain that object locked (the annotation model is used on lots of places, so, retaining the lock
                 //on it on a minimum priority thread is not a good thing.
                 thread.setPriority(Thread.NORM_PRIORITY);
-                Iterator<SpellingAnnotation> iter;
+                Iterator<Annotation> iter;
 
                 synchronized (fLockObject) {
                     iter = fAnnotationModel.getAnnotationIterator();

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyFoldingAction.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-201 6by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.python.pydev.editor.actions.PyAction;
 import org.python.pydev.editor.codefolding.PyProjectionAnnotation;
@@ -29,13 +30,14 @@ public abstract class PyFoldingAction extends PyAction {
      * @param model
      * @return
      */
-    protected Iterator<PyProjectionAnnotation> getAnnotationsIterator(final ProjectionAnnotationModel model, boolean useExpanded) {
+    protected Iterator<Annotation> getAnnotationsIterator(final ProjectionAnnotationModel model,
+            boolean useExpanded) {
         //put annotations in array list.
-        Iterator<PyProjectionAnnotation> iter = model.getAnnotationIterator();
+        Iterator<Annotation> iter = model.getAnnotationIterator();
         if (iter != null) {
 
             //get the not collapsed (expanded) and sort them
-            ArrayList<PyProjectionAnnotation> expanded = new ArrayList<PyProjectionAnnotation>();
+            ArrayList<Annotation> expanded = new ArrayList<Annotation>();
             while (iter.hasNext()) {
                 PyProjectionAnnotation element = (PyProjectionAnnotation) iter.next();
                 if (element.isCollapsed() == useExpanded) {
@@ -70,7 +72,7 @@ public abstract class PyFoldingAction extends PyAction {
      * @return
      */
     protected ProjectionAnnotationModel getModel() {
-        final ProjectionAnnotationModel model = (ProjectionAnnotationModel) getTextEditor().getAdapter(
+        final ProjectionAnnotationModel model = getTextEditor().getAdapter(
                 ProjectionAnnotationModel.class);
         return model;
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/codefolding/PyUnCollapseAll.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.jface.action.IAction;
+import org.eclipse.jface.text.source.Annotation;
 import org.eclipse.jface.text.source.projection.ProjectionAnnotationModel;
 import org.python.pydev.editor.codefolding.PyProjectionAnnotation;
 
@@ -33,7 +34,7 @@ public class PyUnCollapseAll extends PyFoldingAction {
 
         if (model != null) {
 
-            Iterator<PyProjectionAnnotation> iter = getAnnotationsIterator(model, true);
+            Iterator<Annotation> iter = getAnnotationsIterator(model, true);
 
             if (iter != null) {
                 //we just want to expand the roots, and we are working only with the collapsed sorted by offset.

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -167,16 +167,15 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
     /**
      * Given the ast, create the needed marks and set them in the passed model.
      */
-    @SuppressWarnings("unchecked")
     private synchronized void addMarksToModel(SimpleNode root2, ProjectionAnnotationModel model) {
         try {
             if (model != null) {
-                ArrayList<PyProjectionAnnotation> existing = new ArrayList<PyProjectionAnnotation>();
+                ArrayList<Annotation> existing = new ArrayList<Annotation>();
 
                 //get the existing annotations
-                Iterator<PyProjectionAnnotation> iter = model.getAnnotationIterator();
+                Iterator<Annotation> iter = model.getAnnotationIterator();
                 while (iter != null && iter.hasNext()) {
-                    PyProjectionAnnotation element = iter.next();
+                    Annotation element = iter.next();
                     existing.add(element);
                 }
 
@@ -211,7 +210,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
      * If we don't find that, the end of the selection is the end of the file.
      */
     private Map<ProjectionAnnotation, Position> getAnnotationsToAdd(List<FoldingEntry> nodes,
-            ProjectionAnnotationModel model, List<PyProjectionAnnotation> existing) {
+            ProjectionAnnotationModel model, List<Annotation> existing) {
 
         Map<ProjectionAnnotation, Position> annotationsToAdd = new HashMap<ProjectionAnnotation, Position>();
         try {
@@ -235,7 +234,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
      * added for it).
      */
     private Tuple<ProjectionAnnotation, Position> getAnnotationToAdd(FoldingEntry node, int start, int end,
-            ProjectionAnnotationModel model, List<PyProjectionAnnotation> existing) throws BadLocationException {
+            ProjectionAnnotationModel model, List<Annotation> existing) throws BadLocationException {
         try {
             IDocument document = editor.getDocumentProvider().getDocument(editor.getEditorInput());
             int offset = document.getLineOffset(start);
@@ -261,9 +260,9 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
      * We have to be careful not to remove existing annotations because if this happens, previous code folding is not correct.
      */
     private Tuple<ProjectionAnnotation, Position> getAnnotationToAdd(Position position, FoldingEntry node,
-            ProjectionAnnotationModel model, List<PyProjectionAnnotation> existing) {
-        for (Iterator<PyProjectionAnnotation> iter = existing.iterator(); iter.hasNext();) {
-            PyProjectionAnnotation element = iter.next();
+            ProjectionAnnotationModel model, List<Annotation> existing) {
+        for (Iterator<Annotation> iter = existing.iterator(); iter.hasNext();) {
+            Annotation element = iter.next();
             Position existingPosition = model.getPosition(element);
             if (existingPosition.equals(position)) {
                 //ok, do nothing to this annotation (neither remove nor add, as it already exists in the correct place).

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PythonCorrectionProcessor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/PythonCorrectionProcessor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2016 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -45,7 +45,6 @@ import org.python.pydev.editor.correctionassist.heuristics.AssistSurroundWith;
 import org.python.pydev.editor.correctionassist.heuristics.IAssistProps;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.shared_ui.ImageCache;
-
 
 /**
  * This class should be used to give context help
@@ -206,9 +205,9 @@ public class PythonCorrectionProcessor implements IQuickAssistProcessor {
             ICompletionProposal[] spellProps = null;
 
             IAnnotationModel annotationModel = editor.getPySourceViewer().getAnnotationModel();
-            Iterator<Object> it = annotationModel.getAnnotationIterator();
+            Iterator<Annotation> it = annotationModel.getAnnotationIterator();
             while (it.hasNext()) {
-                Object annotation = it.next();
+                Annotation annotation = it.next();
                 if (annotation instanceof SpellingAnnotation) {
                     SpellingAnnotation spellingAnnotation = (SpellingAnnotation) annotation;
                     SpellingProblem spellingProblem = spellingAnnotation.getSpellingProblem();
@@ -225,11 +224,11 @@ public class PythonCorrectionProcessor implements IQuickAssistProcessor {
 
             if (spellProps == null || (spellProps.length == 1 && spellProps[0] instanceof NoCompletionsProposal)) {
                 //no proposals from the spelling
-                return (ICompletionProposal[]) results.toArray(new ICompletionProposal[results.size()]);
+                return results.toArray(new ICompletionProposal[results.size()]);
             }
 
             //ok, add the spell problems and return...
-            ICompletionProposal[] ret = (ICompletionProposal[]) results.toArray(new ICompletionProposal[results.size()
+            ICompletionProposal[] ret = results.toArray(new ICompletionProposal[results.size()
                     + spellProps.length]);
             System.arraycopy(spellProps, 0, ret, results.size(), spellProps.length);
             return ret;
@@ -237,7 +236,7 @@ public class PythonCorrectionProcessor implements IQuickAssistProcessor {
             if (e instanceof ClassNotFoundException || e instanceof LinkageError || e instanceof NoSuchMethodException
                     || e instanceof NoSuchMethodError || e instanceof NoClassDefFoundError) {
                 //Eclipse 3.2 support
-                return (ICompletionProposal[]) results.toArray(new ICompletionProposal[results.size()]);
+                return results.toArray(new ICompletionProposal[results.size()]);
             }
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
Following changes needed to properly compile against newly generified
code:
* IWorkspace adds two new run methods to be stubbed. (not marked as
Override to allow compilataion against older platform).
* TextSourceViewerConfiguration.getHyperlinkDetectorTargets returns
Map<String, IAdaptable> which was using too specific types in Pydev
code.
* IAnnotationModel.getAnnotationIterator returns Iterator<Annotation> so
some adjustments were needed where more specific types were used.