### PR TITLE
Add multiprocessing to cpython's forced libs

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/InterpreterInfo.java
@@ -952,6 +952,7 @@ public class InterpreterInfo implements IInterpreterInfo {
                 forcedLibs.add("math");
                 forcedLibs.add("mmap");
                 forcedLibs.add("msvcrt");
+                forcedLibs.add("multiprocessing");
                 forcedLibs.add("nt");
                 forcedLibs.add("operator");
                 forcedLibs.add("parser");

--- a/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoOutput.txt
+++ b/plugins/org.python.pydev/tests/org/python/pydev/ui/pythonpathconf/InterpreterInfoOutput.txt
@@ -66,6 +66,7 @@
 <forced_lib>math</forced_lib>
 <forced_lib>mmap</forced_lib>
 <forced_lib>msvcrt</forced_lib>
+<forced_lib>multiprocessing</forced_lib>
 <forced_lib>nt</forced_lib>
 <forced_lib>operator</forced_lib>
 <forced_lib>parser</forced_lib>


### PR DESCRIPTION
Needed at least on Linux with 3.4 for e.g. `multiprocessing.Semaphore` to be recognized.