### PR TITLE
Test runner fixes

### DIFF
--- a/plugins/org.python.pydev/pysrc/_pydev_runfiles/pydev_runfiles.py
+++ b/plugins/org.python.pydev/pysrc/_pydev_runfiles/pydev_runfiles.py
@@ -790,7 +790,7 @@ class PydevTestRunner(object):
                 runner.run(test_suite)
 
         if self.configuration.django:
-            MyDjangoTestSuiteRunner(run_tests).run_tests([])
+            get_django_test_suite_runner()(run_tests).run_tests([])
         else:
             run_tests()
 
@@ -802,52 +802,61 @@ class PydevTestRunner(object):
         pydev_runfiles_xml_rpc.notifyTestRunFinished(total_time)
 
 
-try:
-    # django >= 1.8
-    import django
-    from django.test.runner import DiscoverRunner
-    
-    class MyDjangoTestSuiteRunner(DiscoverRunner):
-    
-        def __init__(self, on_run_suite):
-            django.setup()
-            DiscoverRunner.__init__(self)
-            self.on_run_suite = on_run_suite
-    
-        def build_suite(self, *args, **kwargs):
-            pass
-    
-        def suite_result(self, *args, **kwargs):
-            pass
-    
-        def run_suite(self, *args, **kwargs):
-            self.on_run_suite()
-except:
-    # django < 1.8
+DJANGO_TEST_SUITE_RUNNER = None
+
+def get_django_test_suite_runner():
+    global DJANGO_TEST_SUITE_RUNNER
+    if DJANGO_TEST_SUITE_RUNNER:
+        return DJANGO_TEST_SUITE_RUNNER
     try:
-        from django.test.simple import DjangoTestSuiteRunner
-    except:
-        class DjangoTestSuiteRunner:
-            def __init__(self):
+        # django >= 1.8
+        import django
+        from django.test.runner import DiscoverRunner
+
+        class MyDjangoTestSuiteRunner(DiscoverRunner):
+
+            def __init__(self, on_run_suite):
+                django.setup()
+                DiscoverRunner.__init__(self)
+                self.on_run_suite = on_run_suite
+
+            def build_suite(self, *args, **kwargs):
                 pass
-    
-            def run_tests(self, *args, **kwargs):
-                raise AssertionError("Unable to run suite with django.test.runner.DiscoverRunner nor django.test.simple.DjangoTestSuiteRunner because it couldn't be imported.")
-    
-    class MyDjangoTestSuiteRunner(DjangoTestSuiteRunner):
-    
-        def __init__(self, on_run_suite):
-            DjangoTestSuiteRunner.__init__(self)
-            self.on_run_suite = on_run_suite
-    
-        def build_suite(self, *args, **kwargs):
-            pass
-    
-        def suite_result(self, *args, **kwargs):
-            pass
-    
-        def run_suite(self, *args, **kwargs):
-            self.on_run_suite()
+
+            def suite_result(self, *args, **kwargs):
+                pass
+
+            def run_suite(self, *args, **kwargs):
+                self.on_run_suite()
+    except:
+        # django < 1.8
+        try:
+            from django.test.simple import DjangoTestSuiteRunner
+        except:
+            class DjangoTestSuiteRunner:
+                def __init__(self):
+                    pass
+
+                def run_tests(self, *args, **kwargs):
+                    raise AssertionError("Unable to run suite with django.test.runner.DiscoverRunner nor django.test.simple.DjangoTestSuiteRunner because it couldn't be imported.")
+
+        class MyDjangoTestSuiteRunner(DjangoTestSuiteRunner):
+
+            def __init__(self, on_run_suite):
+                DjangoTestSuiteRunner.__init__(self)
+                self.on_run_suite = on_run_suite
+
+            def build_suite(self, *args, **kwargs):
+                pass
+
+            def suite_result(self, *args, **kwargs):
+                pass
+
+            def run_suite(self, *args, **kwargs):
+                self.on_run_suite()
+
+    DJANGO_TEST_SUITE_RUNNER = MyDjangoTestSuiteRunner
+    return DJANGO_TEST_SUITE_RUNNER
 
 
 #=======================================================================================================================

--- a/plugins/org.python.pydev/pysrc/runfiles.py
+++ b/plugins/org.python.pydev/pysrc/runfiles.py
@@ -53,18 +53,18 @@ def main():
         raise
     pydev_runfiles_xml_rpc.initialize_server(configuration.port)  # Note that if the port is None, a Null server will be initialized.
 
-    NOSE_FRAMEWORK = 1
-    PY_TEST_FRAMEWORK = 2
+    NOSE_FRAMEWORK = "nose"
+    PY_TEST_FRAMEWORK = "py.test"
+    test_framework = None  # Default (pydev)
     try:
         if found_other_test_framework_param:
-            test_framework = 0  # Default (pydev)
             if found_other_test_framework_param == NOSE_PARAMS:
-                import nose
                 test_framework = NOSE_FRAMEWORK
+                import nose
 
             elif found_other_test_framework_param == PY_TEST_PARAMS:
-                import pytest
                 test_framework = PY_TEST_FRAMEWORK
+                import pytest
 
             else:
                 raise ImportError()
@@ -75,16 +75,16 @@ def main():
     except ImportError:
         if found_other_test_framework_param:
             sys.stderr.write('Warning: Could not import the test runner: %s. Running with the default pydev unittest runner instead.\n' % (
-                found_other_test_framework_param,))
+                test_framework,))
 
-        test_framework = 0
+        test_framework = None
 
     # Clear any exception that may be there so that clients don't see it.
     # See: https://sourceforge.net/tracker/?func=detail&aid=3408057&group_id=85796&atid=577329
     if hasattr(sys, 'exc_clear'):
         sys.exc_clear()
 
-    if test_framework == 0:
+    if not test_framework:
 
         return pydev_runfiles.main(configuration)  # Note: still doesn't return a proper value.
 

--- a/plugins/org.python.pydev/pysrc/runfiles.py
+++ b/plugins/org.python.pydev/pysrc/runfiles.py
@@ -76,6 +76,9 @@ def main():
         if found_other_test_framework_param:
             sys.stderr.write('Warning: Could not import the test runner: %s. Running with the default pydev unittest runner instead.\n' % (
                 test_framework,))
+            if DEBUG:
+                import traceback
+                traceback.print_exception(sys.exc_info()[1])
 
         test_framework = None
 


### PR DESCRIPTION
The first two should be self explanatory.

About the third, I don't know what the actual problem is with loading `unittest` before running `pytest.main` as the py.test runner appears to work even with the error message printed, but I suppose the message is there for a reason. So the third commit prevents it, and tests also run faster when the Django imports don't need to be done.