### PR TITLE
tokenize.open is only available in ver 3.2

### DIFF
--- a/plugins/org.python.pydev/pysrc/_pydev_imps/_pydev_execfile.py
+++ b/plugins/org.python.pydev/pysrc/_pydev_imps/_pydev_execfile.py
@@ -7,8 +7,16 @@ def execfile(file, glob=None, loc=None):
         loc = glob
 
     # It seems that the best way is using tokenize.open(): http://code.activestate.com/lists/python-dev/131251/
+    # but tokenize.open() is only available for python 3.2
+    # so it have to do something instead.
     import tokenize
-    stream = tokenize.open(file)  # @UndefinedVariable
+    if ('open' in dir(tokenize)) :
+        # version 3.2
+        stream = tokenize.open(file)  # @UndefinedVariable
+    else:
+        # version 3.0 or 3.1
+        detect_encoding = tokenize.detect_encoding(open(file, mode="rb" ).readline)
+        stream = open(file, encoding=detect_encoding[0])
     try:
         contents = stream.read()
     finally:


### PR DESCRIPTION
tokenize.open() is the best way to read the source file,
but tokenize.open() is only available for python 3.2.
when running at python 3.1 or 3.0,  it have to do detect source file's encoding before read file.