### PR TITLE
Re-factor implementing Fabio's comments

### DIFF
--- a/plugins/org.python.pydev.debug/plugin.xml
+++ b/plugins/org.python.pydev.debug/plugin.xml
@@ -1358,6 +1358,7 @@
             activate="false"
             class="org.python.pydev.debug.ui.hover.PyDebugHover"
             description="Provides Debug Hover Info"
+            enable="true"
             id="org.python.pydev.debug.ui.hover.PyDebugHover"
             label="PyDev Debug Hover"
             preempt="false"

--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -2827,7 +2827,7 @@ if __name__ == "__main__":
             activate="false"
             class="org.python.pydev.editor.hover.PyDocstringTextHover"
             description="Provides hover text for Python docstrings"
-            enable="false"
+            enable="true"
             id="org.python.pydev.editor.hover.pyDocstringTextHover"
             label="PyDev Docstring Hover"
             preempt="false"

--- a/plugins/org.python.pydev/plugin.xml
+++ b/plugins/org.python.pydev/plugin.xml
@@ -2827,6 +2827,7 @@ if __name__ == "__main__":
             activate="false"
             class="org.python.pydev.editor.hover.PyDocstringTextHover"
             description="Provides hover text for Python docstrings"
+            enable="false"
             id="org.python.pydev.editor.hover.pyDocstringTextHover"
             label="PyDev Docstring Hover"
             preempt="false"
@@ -2839,22 +2840,11 @@ if __name__ == "__main__":
             activate="false"
             class="org.python.pydev.editor.hover.PyMarkerTextHover"
             description="Provides hover text for Python markers"
+            enable="true"
             id="org.python.pydev.editor.hover.pyMarkerTextHover"
             label="PyDev Marker Hover"
             preempt="false"
             priority="150">
-      </pyTextHover>
-   </extension>
-   <extension
-         point="org.python.pydev.pydev_hover2">
-      <pyTextHover
-            activate="false"
-            class="org.python.pydev.editor.hover.DefaultPydevCombiningHover"
-            description="Combines info from enabled hovers, in priority order, until reaching a hover with preempt == true"
-            id="org.python.pydev.editor.hover.defaultCombiningHover"
-            label="Default PyDev Combining Hover"
-            preempt="true"
-            priority="10">
       </pyTextHover>
    </extension>
  </plugin>

--- a/plugins/org.python.pydev/schema/pydev_hover2.exsd
+++ b/plugins/org.python.pydev/schema/pydev_hover2.exsd
@@ -2,9 +2,9 @@
 <!-- Schema file written by PDE -->
 <schema targetNamespace="org.python.pydev" xmlns="http://www.w3.org/2001/XMLSchema">
 <annotation>
-      <appinfo>
+      <appInfo>
          <meta.schema plugin="org.python.pydev" id="pydev_hover2" name="PyDev Text Hover2"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          This extension point allows clients to provide hover capabilities to the editor.
 Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorTextHover
@@ -13,9 +13,9 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
 
    <element name="extension">
       <annotation>
-         <appinfo>
+         <appInfo>
             <meta.element />
-         </appinfo>
+         </appInfo>
       </annotation>
       <complexType>
          <sequence>
@@ -40,9 +40,9 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
                <documentation>
                   an optional name of the extension instance
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute translatable="true"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
       </complexType>
@@ -62,19 +62,19 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
                <documentation>
                   the fully qualified class name implementing the interface &lt;code&gt;org.python.pydev.editor.hover.AbstractPyEditorTextHover&lt;/code&gt;
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute kind="java" basedOn="org.python.pydev.editor.hover.AbstractPyEditorTextHover:"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
-         <attribute name="label" type="string">
+         <attribute name="label" type="string" use="required">
             <annotation>
                <documentation>
                   the translatable label for this hover
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute translatable="true"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
          <attribute name="description" type="string">
@@ -82,9 +82,9 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
                <documentation>
                   the translatable description for this hover
                </documentation>
-               <appinfo>
+               <appInfo>
                   <meta.attribute translatable="true"/>
-               </appinfo>
+               </appInfo>
             </annotation>
          </attribute>
          <attribute name="priority" type="string" use="default" value="100">
@@ -94,17 +94,24 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="preempt" type="boolean" use="default" value="false">
+         <attribute name="preempt" type="boolean" use="required">
             <annotation>
                <documentation>
                   used by the Best Match Hover to determine whether to preempt lower priority hovers from contributing to a hover pop-up after this hover contributes hover info.
                </documentation>
             </annotation>
          </attribute>
-         <attribute name="activate" type="boolean" use="default" value="false">
+         <attribute name="activate" type="boolean" use="default" value="true">
             <annotation>
                <documentation>
                   if the attribute is set to &quot;true&quot; it will force this plug-in to be loaded on hover activation
+               </documentation>
+            </annotation>
+         </attribute>
+         <attribute name="enable" type="boolean" use="required">
+            <annotation>
+               <documentation>
+                  whether the hover should be enabled by default before the user sets any of the hover preferences.
                </documentation>
             </annotation>
          </attribute>
@@ -112,36 +119,36 @@ Clients must extend the class org.python.pydev.editor.hover.AbstractPyEditorText
    </element>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="since"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter the first release in which this extension point appears.]
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="examples"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter extension point usage example here.]
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="apiInfo"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter API information here.]
       </documentation>
    </annotation>
 
    <annotation>
-      <appinfo>
+      <appInfo>
          <meta.section type="implementation"/>
-      </appinfo>
+      </appInfo>
       <documentation>
          [Enter information about supplied implementation of this extension point.]
       </documentation>

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/AbstractPyEditorTextHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/AbstractPyEditorTextHover.java
@@ -68,9 +68,11 @@ public abstract class AbstractPyEditorTextHover implements ITextHover, ITextHove
     /*
      * @see org.eclipse.jface.text.ITextHoverExtension#getHoverControlCreator()
      */
+    @Override
     public IInformationControlCreator getHoverControlCreator() {
         return new IInformationControlCreator() {
 
+            @Override
             public IInformationControl createInformationControl(Shell parent) {
                 String tooltipAffordanceString = null;
                 try {
@@ -88,6 +90,7 @@ public abstract class AbstractPyEditorTextHover implements ITextHover, ITextHove
     /*
      * @see org.eclipse.jface.text.ITextHover#getHoverRegion(org.eclipse.jface.text.ITextViewer, int)
      */
+    @Override
     public IRegion getHoverRegion(ITextViewer textViewer, int offset) {
         //we have to set it here (otherwise we don't have thread access to the UI)
         this.textSelection = (ITextSelection) textViewer.getSelectionProvider().getSelection();
@@ -131,6 +134,7 @@ public abstract class AbstractPyEditorTextHover implements ITextHover, ITextHove
      * @see org.eclipse.jface.text.ITextHoverExtension2#getHoverInfo2(org.eclipse.jface.text.ITextViewer, org.eclipse.jface.text.IRegion)
      * @since 3.4
      */
+    @Override
     @SuppressWarnings("deprecation")
     public Object getHoverInfo2(ITextViewer textViewer, IRegion hoverRegion) {
         return getHoverInfo(textViewer, hoverRegion);

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyEditorHoverConfigurationBlock.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyEditorHoverConfigurationBlock.java
@@ -741,6 +741,7 @@ public class PyEditorHoverConfigurationBlock implements IPreferenceConfiguration
                 fUseHoverDivider.getSelection());
 
         PydevPlugin.getDefault().resetPyEditorTextHoverDescriptors();
+        PydevCombiningHover.installTextHovers();
     }
 
     /**

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyEditorTextHoverProxy.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyEditorTextHoverProxy.java
@@ -52,6 +52,7 @@ public class PyEditorTextHoverProxy implements ITextHover, ITextHoverExtension {
     /*
      * @see ITextHover#getHoverInfo(ITextViewer, IRegion)
      */
+    @SuppressWarnings("deprecation")
     @Override
     public String getHoverInfo(ITextViewer textViewer, IRegion hoverRegion) {
         if (ensureHoverCreated() && fHover.isContentTypeSupported(this.contentType)) {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
@@ -16,7 +16,6 @@ import org.eclipse.ui.progress.UIJob;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.preferences.AbstractConfigurationBlockPreferencePage;
 import org.python.pydev.plugin.preferences.IPreferenceConfigurationBlock;
-import org.python.pydev.plugin.preferences.OverlayPreferenceStore;
 import org.python.pydev.plugin.preferences.PydevPrefs;
 
 /**
@@ -39,9 +38,15 @@ public class PyHoverPreferencesPage extends AbstractConfigurationBlockPreference
 
     public static final String EDITOR_TEXT_HOVER_MODIFIER_MASKS = "EDITOR_TEXT_HOVER_MODIFIER_MASKS";
 
-    public static final String EDITOR_TEXT_HOVER_PRORITIES = "EDITOR_TEXT_HOVER_PRORITIES";
+    public static final String KEY_TEXT_HOVER_MODIFIER = "PYDEV_TEXT_HOVER_MODIFIER_";
 
-    public static final String EDITOR_TEXT_HOVER_PREEMPTS = "EDITOR_TEXT_HOVER_PREEMPTS";
+    public static final String KEY_TEXT_HOVER_MODIFIER_MASK = "PYDEV_TEXT_HOVER_MODIFIER_MASK_";
+
+    public static final String KEY_TEXT_HOVER_PRIORITY = "PYDEV_TEXT_HOVER_PRORITY_";
+
+    public static final String KEY_TEXT_HOVER_PREEMPT = "PYDEV_TEXT_HOVER_PREEMPT_";
+
+    public static final String KEY_TEXT_HOVER_ENABLE = "PYDEV_TEXT_HOVER_ENABLE_";
 
     public static final String EDITOR_ANNOTATION_ROLL_OVER = "EDITOR_ANNOTATION_ROLL_OVER"; //$NON-NLS-1$
 
@@ -109,9 +114,8 @@ public class PyHoverPreferencesPage extends AbstractConfigurationBlockPreference
     }
 
     @Override
-    protected IPreferenceConfigurationBlock createConfigurationBlock(OverlayPreferenceStore overlayPreferenceStore) {
-        config = new PyEditorHoverConfigurationBlock(this,
-                overlayPreferenceStore);
+    protected IPreferenceConfigurationBlock createConfigurationBlock() {
+        config = new PyEditorHoverConfigurationBlock(this);
         return config;
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
@@ -6,13 +6,8 @@
  */
 package org.python.pydev.editor.hover;
 
-import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Status;
-import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
-import org.eclipse.ui.progress.UIJob;
 import org.python.pydev.plugin.PydevPlugin;
 import org.python.pydev.plugin.preferences.AbstractConfigurationBlockPreferencePage;
 import org.python.pydev.plugin.preferences.IPreferenceConfigurationBlock;
@@ -68,21 +63,6 @@ public class PyHoverPreferencesPage extends AbstractConfigurationBlockPreference
     @Override
     public void init(IWorkbench workbench) {
         // pass
-    }
-
-    @Override
-    public void createControl(Composite parent) {
-        super.createControl(parent);
-        //need to delay somewhat or it won't have any effect
-        new UIJob("Show/Hide Preempt Column") {
-
-            @Override
-            public IStatus runInUIThread(IProgressMonitor monitor) {
-                config.showPreemptColumn(PyHoverPreferencesPage.getCombineHoverInfo());
-                return Status.OK_STATUS;
-            }
-
-        }.schedule(500);
     }
 
     /**@return whether the docstring should be shown when hovering.*/

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
@@ -20,8 +20,6 @@ import java.util.Iterator;
 import java.util.Map;
 
 import org.eclipse.core.runtime.Assert;
-import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.IExecutableExtensionFactory;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.swt.custom.StyleRange;
@@ -32,10 +30,9 @@ import org.eclipse.swt.graphics.GC;
 import org.eclipse.swt.widgets.Display;
 import org.python.pydev.editor.PyInformationPresenter;
 import org.python.pydev.plugin.PydevPlugin;
-import org.python.pydev.shared_core.log.Log;
 import org.python.pydev.shared_core.string.FastStringBuffer;
 
-public class DefaultPydevCombiningHover extends AbstractPyEditorTextHover implements IExecutableExtensionFactory {
+public class PydevCombiningHover extends AbstractPyEditorTextHover {
 
     public static final Object ID_DEFAULT_COMBINING_HOVER = "org.python.pydev.editor.hover.defaultCombiningHover";
 
@@ -57,7 +54,7 @@ public class DefaultPydevCombiningHover extends AbstractPyEditorTextHover implem
 
     private static final String DIVIDER_CHAR = Character.toString((char) 0xfeff2015);
 
-    public DefaultPydevCombiningHover() {
+    public PydevCombiningHover() {
         installTextHovers();
         this.addInformationPresenterControlListener(new ControlListener() {
 
@@ -90,7 +87,7 @@ public class DefaultPydevCombiningHover extends AbstractPyEditorTextHover implem
         fInstantiatedTextHovers = new ArrayList<AbstractPyEditorTextHover>(2);
 
         // populate list
-        PyEditorTextHoverDescriptor[] hoverDescs = PydevPlugin.getDefault().getPyEditorTextHoverDescriptors(false);
+        PyEditorTextHoverDescriptor[] hoverDescs = PydevPlugin.getDefault().getPyEditorTextHoverDescriptors();
         for (int i = 0; i < hoverDescs.length; i++) {
             // ensure that we don't add ourselves to the list
             if (!ID_DEFAULT_COMBINING_HOVER.equals(hoverDescs[i].getId())) {
@@ -256,6 +253,7 @@ public class DefaultPydevCombiningHover extends AbstractPyEditorTextHover implem
     /**
      * Creates divider text of a specified width
      * Must be called from the event dispatch thread
+     * 
      * @param width the desired width of the divider in pixels
      * @return the divider text
      */
@@ -298,22 +296,6 @@ public class DefaultPydevCombiningHover extends AbstractPyEditorTextHover implem
     @Override
     public boolean isContentTypeSupported(String contentType) {
         return true;
-    }
-
-    /*
-     * (non-Javadoc)
-     * @see org.eclipse.core.runtime.IExecutableExtensionFactory#create()
-     */
-    @Override
-    public Object create() throws CoreException {
-        try {
-            PyEditorTextHoverDescriptor contributedHover = PydevPlugin.getDefault()
-                    .getPyEditorCombiningTextHoverDescriptor(true);
-            return contributedHover != null ? contributedHover.createTextHover() : new DefaultPydevCombiningHover();
-        } catch (CoreException e) {
-            Log.log(e.getMessage());
-            return new DefaultPydevCombiningHover();
-        }
     }
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
@@ -36,9 +36,9 @@ public class PydevCombiningHover extends AbstractPyEditorTextHover {
 
     public static final Object ID_DEFAULT_COMBINING_HOVER = "org.python.pydev.editor.hover.defaultCombiningHover";
 
-    private ArrayList<PyEditorTextHoverDescriptor> fTextHoverSpecifications;
+    private static ArrayList<PyEditorTextHoverDescriptor> fTextHoverSpecifications;
 
-    private ArrayList<AbstractPyEditorTextHover> fInstantiatedTextHovers;
+    private static ArrayList<AbstractPyEditorTextHover> fInstantiatedTextHovers;
 
     private Map<AbstractPyEditorTextHover, PyEditorTextHoverDescriptor> hoverMap = new HashMap<AbstractPyEditorTextHover, PyEditorTextHoverDescriptor>();
 
@@ -80,7 +80,7 @@ public class PydevCombiningHover extends AbstractPyEditorTextHover {
     /**
      * Installs all text hovers.
      */
-    private void installTextHovers() {
+    public static void installTextHovers() {
 
         // initialize lists - indicates that the initialization happened
         fTextHoverSpecifications = new ArrayList<PyEditorTextHoverDescriptor>(2);

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/ConfigurationElementAttributeSorter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/ConfigurationElementAttributeSorter.java
@@ -64,14 +64,15 @@ public abstract class ConfigurationElementAttributeSorter {
          * @see Comparator#compare(java.lang.Object, java.lang.Object)
          * @since 2.0
          */
+        @Override
         public int compare(O object0, O object1) {
 
             if (object0 instanceof PyEditorTextHoverDescriptor && object1 instanceof PyEditorTextHoverDescriptor) {
 
                 PyEditorTextHoverDescriptor descr0 = (PyEditorTextHoverDescriptor) object0;
                 PyEditorTextHoverDescriptor descr1 = (PyEditorTextHoverDescriptor) object1;
-                if (descr0.fPriority != null && descr1.fPriority != null) {
-                    return descr0.fPriority.compareTo(descr1.fPriority);
+                if (descr0.getPriority() != null && descr1.getPriority() != null) {
+                    return descr0.getPriority().compareTo(descr1.getPriority());
                 }
                 IConfigurationElement e0 = getConfigurationElement(object0);
                 IConfigurationElement e1 = getConfigurationElement(object1);

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
@@ -24,7 +24,6 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
-import org.eclipse.core.runtime.IExtensionRegistry;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -45,7 +44,6 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 import org.osgi.service.prefs.BackingStoreException;
-import org.python.pydev.core.ExtensionHelper;
 import org.python.pydev.core.IInterpreterInfo;
 import org.python.pydev.core.IInterpreterManager;
 import org.python.pydev.core.IPythonNature;
@@ -53,8 +51,9 @@ import org.python.pydev.core.MisconfigurationException;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.SyncSystemModulesManagerScheduler;
 import org.python.pydev.editor.codecompletion.shell.AbstractShell;
-import org.python.pydev.editor.hover.DefaultPydevCombiningHover;
 import org.python.pydev.editor.hover.PyEditorTextHoverDescriptor;
+import org.python.pydev.editor.hover.PyHoverPreferencesPage;
+import org.python.pydev.editor.hover.PydevCombiningHover;
 import org.python.pydev.plugin.nature.PythonNature;
 import org.python.pydev.plugin.nature.SystemPythonNature;
 import org.python.pydev.plugin.preferences.PydevPrefs;
@@ -205,6 +204,8 @@ public class PydevPlugin extends AbstractUIPlugin {
     public static final String DEFAULT_PYDEV_SCOPE = "org.python.pydev";
 
     private boolean isAlive;
+
+    private static PyEditorTextHoverDescriptor combiningHoverDescriptor;
 
     /**
      * The constructor.
@@ -647,11 +648,10 @@ public class PydevPlugin extends AbstractUIPlugin {
      *
      * @return an array of PyEditorTextHoverDescriptor
      */
-    public synchronized PyEditorTextHoverDescriptor[] getPyEditorTextHoverDescriptors(
-            boolean useRegisteredExtensionPolintValues) {
-        if (fPyEditorTextHoverDescriptors == null || useRegisteredExtensionPolintValues) {
+    public synchronized PyEditorTextHoverDescriptor[] getPyEditorTextHoverDescriptors() {
+        if (fPyEditorTextHoverDescriptors == null) {
             fPyEditorTextHoverDescriptors = PyEditorTextHoverDescriptor
-                    .getContributedHovers(useRegisteredExtensionPolintValues);
+                    .getContributedHovers();
             ConfigurationElementAttributeSorter sorter = new ConfigurationElementAttributeSorter() {
                 /*
                  * @see org.eclipse.ui.texteditor.ConfigurationElementSorter#getConfigurationElement(java.lang.Object)
@@ -665,35 +665,6 @@ public class PydevPlugin extends AbstractUIPlugin {
         }
 
         return fPyEditorTextHoverDescriptors;
-    }
-
-    /**
-    * Retrieves a Text Hover which combines hover info from other registered Text Hovers.
-    *
-    * @return a PyEditorTextHoverDescriptor contributed to {@link ExtensionHelper#PY_TEXT_COMBINING_HOVER}}
-    * which combines hover info from other registered Text Hovers. Returns <code>null</code> if
-    * no combining Hover has been contributed. In this case a default combining hover provided by PyDev
-    * ({@link DefaultPydevCombiningHover}) will be used.
-    * @throws a CoreException if more than one combining Hover has been registered.
-    */
-    public synchronized PyEditorTextHoverDescriptor getPyEditorCombiningTextHoverDescriptor(
-            boolean useRegisteredExtensionPolintValues) throws CoreException {
-        if (fPyEditorTextHoverDescriptors == null || useRegisteredExtensionPolintValues) {
-            IExtensionRegistry registry = Platform.getExtensionRegistry();
-            IConfigurationElement[] elements = registry
-                    .getConfigurationElementsFor(ExtensionHelper.PY_TEXT_COMBINING_HOVER);
-            if (elements.length > 1) {
-                throw new CoreException(
-                        new Status(Status.ERROR, getPluginID(), "Only one contribution to extension point " +
-                                ExtensionHelper.PY_TEXT_COMBINING_HOVER + " is permitted, but " + elements.length
-                                + " were found."));
-            }
-            PyEditorTextHoverDescriptor[] hoverDescs = PyEditorTextHoverDescriptor.createDescriptors(elements);
-            PyEditorTextHoverDescriptor.initializeFromPreferences(hoverDescs, useRegisteredExtensionPolintValues);
-            return hoverDescs.length > 0 ? hoverDescs[0] : null;
-        }
-
-        return null;
     }
 
     /**
@@ -726,6 +697,32 @@ public class PydevPlugin extends AbstractUIPlugin {
      */
     public synchronized void resetPyEditorTextHoverDescriptors() {
         fPyEditorTextHoverDescriptors = null;
+        combiningHoverDescriptor = null;
+    }
+
+    public static PyEditorTextHoverDescriptor getCombiningHoverDescriptor() {
+        if (combiningHoverDescriptor == null) {
+            combiningHoverDescriptor = new PyEditorTextHoverDescriptor(new PydevCombiningHover());
+            initializeDefaultCombiningHoverPreferences();
+            PyEditorTextHoverDescriptor.initializeHoversFromPreferences(
+                    new PyEditorTextHoverDescriptor[] { combiningHoverDescriptor });
+        }
+        return combiningHoverDescriptor;
+    }
+
+    private static void initializeDefaultCombiningHoverPreferences() {
+        PydevPrefs.getPreferenceStore().setDefault(
+                PyHoverPreferencesPage.KEY_TEXT_HOVER_MODIFIER + PydevPlugin.getCombiningHoverDescriptor().getId(),
+                PyEditorTextHoverDescriptor.NO_MODIFIER);
+        PydevPrefs.getPreferenceStore().setDefault(
+                PyHoverPreferencesPage.KEY_TEXT_HOVER_MODIFIER_MASK + PydevPlugin.getCombiningHoverDescriptor().getId(),
+                PyEditorTextHoverDescriptor.DEFAULT_MODIFIER_MASK);
+        PydevPrefs.getPreferenceStore().setDefault(
+                PyHoverPreferencesPage.KEY_TEXT_HOVER_PRIORITY + PydevPlugin.getCombiningHoverDescriptor().getId(),
+                PyEditorTextHoverDescriptor.HIGHEST_PRIORITY);
+        PydevPrefs.getPreferenceStore().setDefault(
+                PyHoverPreferencesPage.KEY_TEXT_HOVER_ENABLE + PydevPlugin.getCombiningHoverDescriptor().getId(),
+                true);
     }
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractConfigurationBlockPreferencePage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractConfigurationBlockPreferencePage.java
@@ -30,7 +30,6 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
         implements IWorkbenchPreferencePage {
 
     private IPreferenceConfigurationBlock fConfigurationBlock;
-    private OverlayPreferenceStore fOverlayStore;
 
     /**
      * Creates a new preference page.
@@ -38,12 +37,10 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
     public AbstractConfigurationBlockPreferencePage() {
         setDescription();
         setPreferenceStore();
-        fOverlayStore = new OverlayPreferenceStore(getPreferenceStore(), new OverlayPreferenceStore.OverlayKey[] {});
-        fConfigurationBlock = createConfigurationBlock(fOverlayStore);
+        fConfigurationBlock = createConfigurationBlock();
     }
 
-    protected abstract IPreferenceConfigurationBlock createConfigurationBlock(
-            OverlayPreferenceStore overlayPreferenceStore);
+    protected abstract IPreferenceConfigurationBlock createConfigurationBlock();
 
     protected abstract String getHelpId();
 
@@ -72,9 +69,6 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
     @Override
     protected Control createContents(Composite parent) {
 
-        fOverlayStore.load();
-        fOverlayStore.start();
-
         Control content = fConfigurationBlock.createControl(parent);
 
         initialize();
@@ -95,10 +89,14 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
 
         fConfigurationBlock.performOk();
 
-        fOverlayStore.propagate();
-
         PydevPlugin.flushInstanceScope();
 
+        return true;
+    }
+
+    @Override
+    public boolean performCancel() {
+        fConfigurationBlock.performCancel();
         return true;
     }
 
@@ -108,7 +106,6 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
     @Override
     public void performDefaults() {
 
-        fOverlayStore.loadDefaults();
         fConfigurationBlock.performDefaults();
 
         super.performDefaults();
@@ -121,11 +118,6 @@ public abstract class AbstractConfigurationBlockPreferencePage extends Preferenc
     public void dispose() {
 
         fConfigurationBlock.dispose();
-
-        if (fOverlayStore != null) {
-            fOverlayStore.stop();
-            fOverlayStore = null;
-        }
 
         super.dispose();
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/IPreferenceConfigurationBlock.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/IPreferenceConfigurationBlock.java
@@ -56,4 +56,11 @@ public interface IPreferenceConfigurationBlock {
      * free any resources they are holding on to.
      */
     void dispose();
+
+    /**
+     * Called when the <code>Cancel</code> button is pressed on the preference
+     * page. Implementations should revert the preference page settings to the
+     * stored preference values.
+     */
+    void performCancel();
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/OverlayPreferenceStore.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/OverlayPreferenceStore.java
@@ -14,9 +14,9 @@
 
 package org.python.pydev.plugin.preferences;
 
+import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.preference.PreferenceStore;
-import org.eclipse.core.runtime.Assert;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 
@@ -56,8 +56,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
         @Override
         public void propertyChange(PropertyChangeEvent event) {
             OverlayKey key = findOverlayKey(event.getProperty());
-            if (key != null)
+            if (key != null) {
                 propagateProperty(fParent, key, fStore);
+            }
         }
     }
 
@@ -76,8 +77,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
 
     private OverlayKey findOverlayKey(String key) {
         for (int i = 0; i < fOverlayKeys.length; i++) {
-            if (fOverlayKeys[i].fKey.equals(key))
+            if (fOverlayKeys[i].fKey.equals(key)) {
                 return fOverlayKeys[i];
+            }
         }
         return null;
     }
@@ -89,8 +91,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
     private void propagateProperty(IPreferenceStore orgin, OverlayKey key, IPreferenceStore target) {
 
         if (orgin.isDefault(key.fKey)) {
-            if (!target.isDefault(key.fKey))
+            if (!target.isDefault(key.fKey)) {
                 target.setToDefault(key.fKey);
+            }
             return;
         }
 
@@ -99,50 +102,57 @@ public class OverlayPreferenceStore implements IPreferenceStore {
 
             boolean originValue = orgin.getBoolean(key.fKey);
             boolean targetValue = target.getBoolean(key.fKey);
-            if (targetValue != originValue)
+            if (targetValue != originValue) {
                 target.setValue(key.fKey, originValue);
+            }
 
         } else if (DOUBLE == d) {
 
             double originValue = orgin.getDouble(key.fKey);
             double targetValue = target.getDouble(key.fKey);
-            if (targetValue != originValue)
+            if (targetValue != originValue) {
                 target.setValue(key.fKey, originValue);
+            }
 
         } else if (FLOAT == d) {
 
             float originValue = orgin.getFloat(key.fKey);
             float targetValue = target.getFloat(key.fKey);
-            if (targetValue != originValue)
+            if (targetValue != originValue) {
                 target.setValue(key.fKey, originValue);
+            }
 
         } else if (INT == d) {
 
             int originValue = orgin.getInt(key.fKey);
             int targetValue = target.getInt(key.fKey);
-            if (targetValue != originValue)
+            if (targetValue != originValue) {
                 target.setValue(key.fKey, originValue);
+            }
 
         } else if (LONG == d) {
 
             long originValue = orgin.getLong(key.fKey);
             long targetValue = target.getLong(key.fKey);
-            if (targetValue != originValue)
+            if (targetValue != originValue) {
                 target.setValue(key.fKey, originValue);
+            }
 
         } else if (STRING == d) {
 
             String originValue = orgin.getString(key.fKey);
             String targetValue = target.getString(key.fKey);
-            if (targetValue != null && originValue != null && !targetValue.equals(originValue))
+            if (targetValue != null && originValue != null && !targetValue.equals(originValue)) {
                 target.setValue(key.fKey, originValue);
+            }
 
         }
     }
 
     public void propagate() {
-        for (int i = 0; i < fOverlayKeys.length; i++)
+        for (int i = 0; i < fOverlayKeys.length; i++) {
             propagateProperty(fStore, fOverlayKeys[i], fParent);
+        }
     }
 
     private void loadProperty(IPreferenceStore orgin, OverlayKey key, IPreferenceStore target,
@@ -150,43 +160,49 @@ public class OverlayPreferenceStore implements IPreferenceStore {
         TypeDescriptor d = key.fDescriptor;
         if (BOOLEAN == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, true);
+            }
             target.setValue(key.fKey, orgin.getBoolean(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultBoolean(key.fKey));
 
         } else if (DOUBLE == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, 1.0D);
+            }
             target.setValue(key.fKey, orgin.getDouble(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultDouble(key.fKey));
 
         } else if (FLOAT == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, 1.0F);
+            }
             target.setValue(key.fKey, orgin.getFloat(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultFloat(key.fKey));
 
         } else if (INT == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, 1);
+            }
             target.setValue(key.fKey, orgin.getInt(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultInt(key.fKey));
 
         } else if (LONG == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, 1L);
+            }
             target.setValue(key.fKey, orgin.getLong(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultLong(key.fKey));
 
         } else if (STRING == d) {
 
-            if (forceInitialization)
+            if (forceInitialization) {
                 target.setValue(key.fKey, "1"); //$NON-NLS-1$
+            }
             target.setValue(key.fKey, orgin.getString(key.fKey));
             target.setDefault(key.fKey, orgin.getDefaultString(key.fKey));
 
@@ -194,16 +210,18 @@ public class OverlayPreferenceStore implements IPreferenceStore {
     }
 
     public void load() {
-        for (int i = 0; i < fOverlayKeys.length; i++)
+        for (int i = 0; i < fOverlayKeys.length; i++) {
             loadProperty(fParent, fOverlayKeys[i], fStore, true);
+        }
 
         fLoaded = true;
 
     }
 
     public void loadDefaults() {
-        for (int i = 0; i < fOverlayKeys.length; i++)
+        for (int i = 0; i < fOverlayKeys.length; i++) {
             setToDefault(fOverlayKeys[i].fKey);
+        }
     }
 
     public void start() {
@@ -369,8 +387,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void putValue(String name, String value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.putValue(name, value);
+        }
     }
 
     /*
@@ -378,8 +397,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, double value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -387,8 +407,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, float value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -396,8 +417,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, int value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -405,8 +427,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, long value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -414,8 +437,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, String value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -423,8 +447,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setDefault(String name, boolean value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setDefault(name, value);
+        }
     }
 
     /*
@@ -440,8 +465,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, double value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /*
@@ -449,8 +475,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, float value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /*
@@ -458,8 +485,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, int value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /*
@@ -467,8 +495,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, long value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /*
@@ -476,8 +505,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, String value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /*
@@ -485,8 +515,9 @@ public class OverlayPreferenceStore implements IPreferenceStore {
      */
     @Override
     public void setValue(String name, boolean value) {
-        if (covers(name))
+        if (covers(name)) {
             fStore.setValue(name, value);
+        }
     }
 
     /**
@@ -505,15 +536,22 @@ public class OverlayPreferenceStore implements IPreferenceStore {
         int overlayKeysLength = fOverlayKeys.length;
         OverlayKey[] result = new OverlayKey[keys.length + overlayKeysLength];
 
-        for (int i = 0, length = overlayKeysLength; i < length; i++)
+        for (int i = 0, length = overlayKeysLength; i < length; i++) {
             result[i] = fOverlayKeys[i];
+        }
 
-        for (int i = 0, length = keys.length; i < length; i++)
+        for (int i = 0, length = keys.length; i < length; i++) {
             result[overlayKeysLength + i] = keys[i];
+        }
 
         fOverlayKeys = result;
 
-        if (fLoaded)
+        if (fLoaded) {
             load();
+        }
+    }
+
+    public boolean isLoaded() {
+        return fLoaded;
     }
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/EmulatedNativeCheckBoxLabelProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/EmulatedNativeCheckBoxLabelProvider.java
@@ -15,8 +15,6 @@
  *******************************************************************************/
 package org.python.pydev.ui;
 
-import org.eclipse.jface.layout.GridDataFactory;
-import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.resource.JFaceResources;
 import org.eclipse.jface.viewers.ColumnLabelProvider;
 import org.eclipse.jface.viewers.ColumnViewer;
@@ -44,22 +42,24 @@ public abstract class EmulatedNativeCheckBoxLabelProvider extends
     private static final String CHECKED_KEY = "CHECKED";
     private static final String UNCHECK_KEY = "UNCHECKED";
 
+    private Shell shell = new Shell(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+            SWT.NO_TRIM | SWT.NO_BACKGROUND);
+
     public EmulatedNativeCheckBoxLabelProvider(ColumnViewer viewer) {
         if (JFaceResources.getImageRegistry().getDescriptor(CHECKED_KEY) == null) {
-            workaround();
+            workaround(viewer.getControl().getDisplay());
             JFaceResources.getImageRegistry().put(CHECKED_KEY, makeShot(viewer.getControl(), true));
             JFaceResources.getImageRegistry().put(UNCHECK_KEY, makeShot(viewer.getControl(), false));
         }
     }
 
     private Image makeShot(Control control, boolean type) {
-        // Hopefully no platform uses exactly this color because we'll make
-        // it transparent in the image.
+        /* Hopefully no platform uses exactly this color because we'll make
+           it transparent in the image.*/
         Color greenScreen = new Color(control.getDisplay(), 222, 223, 224);
 
-        Shell shell = new Shell(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
+        shell = new Shell(PlatformUI.getWorkbench().getActiveWorkbenchWindow().getShell(),
                 SWT.NO_TRIM | SWT.NO_BACKGROUND);
-        shell.setLayout(GridLayoutFactory.fillDefaults().create());
 
         // otherwise we have a default gray color
         shell.setBackground(greenScreen);
@@ -67,19 +67,19 @@ public abstract class EmulatedNativeCheckBoxLabelProvider extends
         Button button = new Button(shell, SWT.CHECK | SWT.NO_BACKGROUND);
         button.setBackground(greenScreen);
         button.setSelection(type);
-        GridDataFactory.swtDefaults().align(SWT.CENTER, SWT.CENTER).applyTo(button);
 
         // otherwise an image is located in a corner
-        //        button.setLocation(1, 1);
+        button.setLocation(1, 1);
         Point bsize = button.computeSize(SWT.DEFAULT, SWT.DEFAULT);
 
         // otherwise an image is stretched by width
-        bsize.x = Math.max(bsize.x, bsize.y);
-        bsize.y = Math.max(bsize.x, bsize.y);
+        bsize.x = Math.max(bsize.x - 1, bsize.y - 1);
+        bsize.y = Math.max(bsize.x - 1, bsize.y - 1);
         button.setSize(bsize);
 
         GC gc = new GC(shell);
-        shell.setSize(bsize);
+        Point shellSize = new Point(32, 32);
+        shell.setSize(shellSize);
         shell.open();
 
         Image image = new Image(control.getDisplay(), bsize.x, bsize.y);
@@ -101,8 +101,7 @@ public abstract class EmulatedNativeCheckBoxLabelProvider extends
      * an image with a default background and no button. It's a mystery
      * why this workaround helps.
      */
-    private void workaround() {
-        Shell shell = new Shell(Display.getDefault(), SWT.NONE);
+    private void workaround(Display display) {
         shell.setSize(0, 0);
         shell.open();
         shell.close();

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/EmulatedNativeCheckBoxLabelProvider.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/EmulatedNativeCheckBoxLabelProvider.java
@@ -103,6 +103,7 @@ public abstract class EmulatedNativeCheckBoxLabelProvider extends
      */
     private void workaround() {
         Shell shell = new Shell(Display.getDefault(), SWT.NONE);
+        shell.setSize(0, 0);
         shell.open();
         shell.close();
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/utils/PyEditorMessages.properties
+++ b/plugins/org.python.pydev/src/org/python/pydev/utils/PyEditorMessages.properties
@@ -20,7 +20,7 @@
 EditorUtility_concatModifierStrings= {0} + {1}
 
 PyEditorHoverConfigurationBlock_annotationRollover=&Expand vertical ruler icons upon hovering (does not affect open editors)
-PyEditorHoverConfigurationBlock_hoverPreferences=Text &Hover key modifier preferences:
+PyEditorHoverConfigurationBlock_hoverPreferences=Text &Hover preferences:
 PyEditorHoverConfigurationBlock_keyModifier=Pressed key &modifier while hovering:
 PyEditorHoverConfigurationBlock_description=Descriptio&n:
 PyEditorHoverConfigurationBlock_modifierIsNotValid=Modifier ''{0}'' is not valid.


### PR DESCRIPTION
Enable state now a field in the extension point definition
Default pref values set from the extension point definition when contributed hovers are obtained
Contributed hovers always initialized from preferences now when retrieved, instead of specified by a boolean param
Preference keys are specified per-hover, instead of pref values for all hovers combined for each attribute.
Combining hover no longer contributed to the hover extension point, and instantiated directly instead.
Fixed a bug in the checkbox image rendered in the hover table on the preference page
Removed use of OverlayPreferenceStore in the hover preference page.
Other miscellaneous minor fixes and code cleanup