### PR TITLE
fix: hover preempt works with equal prioority markers.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PyHoverPreferencesPage.java
@@ -76,7 +76,7 @@ public class PyHoverPreferencesPage extends AbstractConfigurationBlockPreference
     }
 
     /**
-     * @return whether the value of include a divider between text contributions when
+     * @return whether to include a divider between text contributions when
      * combining info from multiple Hovers.
      */
     public static boolean getUseHoverDelimiters() {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/hover/PydevCombiningHover.java
@@ -134,7 +134,7 @@ public class PydevCombiningHover extends AbstractPyEditorTextHover {
 
         boolean firstHoverInfo = true;
         //hovers are sorted by priority in descending order
-        for (AbstractPyEditorTextHover hover : fInstantiatedTextHovers) {
+        for (final AbstractPyEditorTextHover hover : fInstantiatedTextHovers) {
             if (hover == null) {
                 continue;
             }
@@ -182,7 +182,13 @@ public class PydevCombiningHover extends AbstractPyEditorTextHover {
                     }
                 }
                 currentPriority = descr.getPriority();
-                preempt = descr.isPreempt();
+
+                /* If preempt has already been set, don't unset it if a hover with the same priority
+                 * does not have preempt set
+                 */
+                if (!preempt) {
+                    preempt = descr.isPreempt();
+                }
             }
         }
         currentPriority = null;


### PR DESCRIPTION
Bugfix: hover preempt was not respected when two hovers have same priority and the first one has preempt set and the second one does not.

Also some minor code cleanup.