### PR TITLE
Fix display of multiple hyperlinks

### DIFF
--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonHyperlink.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/hyperlink/PythonHyperlink.java
@@ -37,7 +37,7 @@ public class PythonHyperlink implements IHyperlink {
 
     @Override
     public String getHyperlinkText() {
-        return null;
+        return "Go To Definition";
     }
 
     @Override


### PR DESCRIPTION
Eclipse support having more than 1 hyperlink detector active for a given
type of document and also allows a given detector to generate more than
one hyperlink object. In order for the user to allow choosing which
'action' to take, these hyperlinks need to provide a meaningful text
from getHyperlinkText as otherwise Eclipse will fill in a dummy text
(Unknown Hyperlink) into the list of hyperlinks for the text region.

So this change adds a short text indicating that the hyperlink
activation will take the user to the definition of the function/class
under the cursor.