### PR TITLE
Fix code analysis when the code is connected to an RTC source control

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java
@@ -533,7 +533,11 @@ public class PydevPlugin extends AbstractUIPlugin {
     public static String getIResourceOSString(IResource f) {
         URI locationURI = f.getLocationURI();
         if (locationURI != null) {
-            return FileUtils.getFileAbsolutePath(new File(locationURI));
+            try{
+                //RTC source control not return a valid uri
+                return FileUtils.getFileAbsolutePath(new File(locationURI));
+            }catch (IllegalArgumentException e) {
+            }
         }
 
         IPath rawLocation = f.getRawLocation();


### PR DESCRIPTION
The problem happened here after the commit: https://github.com/fabioz/Pydev/commit/732347236a67305ffe7ad36b4944910601cf3ba7#diff-89c232ffd444d2489d2e8b58fe1fba4fL517. It added: 

```java
URI locationURI = f.getLocationURI();
```
in [getIResourceOSString](https://github.com/fabioz/Pydev/blob/9fadc08f29675e792150b80165f53f7179af4055/plugins/org.python.pydev/src/org/python/pydev/plugin/PydevPlugin.java#L534) method. When the RTC plugin is installed, ```f.getLocationURI()``` returns something like: 
```
sourcecontrol://jazz/default/serpro.portalcidades/serpro/portalcidades/config.py
```
This is not a valid file path. So, I get an ```IllegalArgumentException```

However, the ```f.getRawLocation()``` which is called just below work.

Fixes #PyDev-622