### PR TITLE
Fix Jython parsing bug

### DIFF
--- a/plugins/org.python.pydev/pysrc/_pydev_bundle/pydev_console_utils.py
+++ b/plugins/org.python.pydev/pysrc/_pydev_bundle/pydev_console_utils.py
@@ -153,7 +153,11 @@ class BaseInterpreterInterface:
         if hasattr(self.interpreter, 'is_complete'):
             return not self.interpreter.is_complete(source)
         try:
-            code = self.interpreter.compile(source, '<input>', 'exec')
+            if IS_JYTHON:
+                symbol = 'single' # Jython does not support 'exec'
+            else:
+                symbol = 'exec'
+            code = self.interpreter.compile(source, '<input>', symbol)
         except (OverflowError, SyntaxError, ValueError):
             # Case 1
             return False


### PR DESCRIPTION
As mentioned in [715|https://sw-brainwy.rhcloud.com/tracker/PyDev/715], the interactive console (since PyDev 3.6.0) has problems parsing inputs.

This is also commented upon on line 73 of [pydevconsole.py|https://github.com/fabioz/Pydev/blob/master/plugins/org.python.pydev/pysrc/pydevconsole.py].