### PR TITLE
Make PyLint linting all project files

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/builder/pylint/PyLintVisitor.java
@@ -87,16 +87,17 @@ public class PyLintVisitor extends PyDevBuilderVisitor {
             this.document = document;
             this.location = location;
         }
-
+        
         /**
+         * @throws InterruptedException
          * @return
          */
-        private boolean canPassPyLint() {
-            if (pyLintThreads.size() < PyLintPrefPage.getMaxPyLintDelta()) {
-                pyLintThreads.add(this);
-                return true;
+        private boolean canPassPyLint() throws InterruptedException {
+            while (pyLintThreads.size() >= PyLintPrefPage.getMaxPyLintDelta()) {
+                Thread.sleep(100);
             }
-            return false;
+            pyLintThreads.add(this);
+            return true;
         }
 
         /**


### PR DESCRIPTION
IMHO, I think people would like that PyLint visits all project files whatever the number of threads. Threads are only to adjust the analysis speed.