### PR TITLE
Avoid executing test script more than one time

### DIFF
--- a/plugins/org.python.pydev/pysrc/_pydev_runfiles/pydev_runfiles.py
+++ b/plugins/org.python.pydev/pysrc/_pydev_runfiles/pydev_runfiles.py
@@ -492,8 +492,12 @@ class PydevTestRunner(object):
         #let's make sure that the paths we want are in the pythonpath...
         imports = [(s, self.__importify(s)) for s in pyfiles]
 
+        # remove duplicated sys.paths
+        sys_path = [os.path.normpath(path) for path in sys.path]
+        sys_path = list(set(sys_path))
+        
         system_paths = []
-        for s in sys.path:
+        for s in sys_path:
             system_paths.append(self.__importify(s, True))
 
 


### PR DESCRIPTION
sys.path can have the same path twice, one with slashes and second with backslashes.
For example:
D:/workspace/sandbox
D:\workspace\sandbox
In this case if the test module has a bug that prevents it from being imported, current logic tries to do it unnecessarily with the second path.

This will normalize paths and remove duplicates.
Note that path order will be changed.