### PR TITLE
Suppress invalid completions on literals numbers

### DIFF
--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
@@ -1460,4 +1460,40 @@ public final class PySelection extends TextSelectionUtils {
         return new Tuple<Integer, Integer>(0, numberOfLines);
     }
 
+    /**
+     * Is a digit, according to Python. (Can't use Character.isDigit as
+     * that allows unicode digits too.)
+     */
+    private static boolean isDigit(char c) {
+        return c >= '0' && c <= '9';
+    }
+
+    /**
+     * Return true if the completion is at the dot after a literal number.
+     * Literal numbers have no valid completions as they can be the first part of floats.
+     * 
+     * @param activationToken this comes from either the console's ActivationTokenAndQual
+     *      or editor's CompletionRequest
+     * @return true if this completion is for a number
+     */
+    public static boolean isCompletionForLiteralNumber(String activationToken) {
+        int length = activationToken.length();
+        if (length == 0) {
+            return false;
+        }
+        if (activationToken.charAt(length - 1) != '.') {
+            return false;
+        }
+        if (!isDigit(activationToken.charAt(0))) {
+            return false;
+        }
+        for (int i = 1; i < length - 1; i++) {
+            char c = activationToken.charAt(i);
+            if (!isDigit(c) && c != '_') {
+                return false;
+            }
+        }
+        return true;
+    }
+
 }

--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleInterpreter.java
@@ -130,6 +130,11 @@ public class PydevConsoleInterpreter implements IScriptConsoleInterpreter {
         String textForCompletionInConsole = PySelection
                 .getTextForCompletionInConsole(new Document(text), text.length());
 
+        if (PySelection.isCompletionForLiteralNumber(tokenAndQual.activationToken)) {
+            // suppress completions that would be invalid
+            return new ICompletionProposal[0];
+        }
+
         //Code-completion for imports
         ImportInfo importsTipper = ImportsSelection.getImportsTipperStr(text, false);
         Set<IPythonNature> natureAndRelatedNatures = getNatureAndRelatedNatures();

--- a/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion.java
+++ b/plugins/org.python.pydev/src_completions/org/python/pydev/editor/codecompletion/PyCodeCompletion.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -100,6 +101,12 @@ public class PyCodeCompletion extends AbstractPyCodeCompletion {
             //this may happen if the context is still not correctly computed in python
             return new PyStringCodeCompletion().getCodeCompletionProposals(viewer, request);
         }
+
+        if (PySelection.isCompletionForLiteralNumber(request.getActivationToken())) {
+            // suppress completions that would be invalid
+            return Collections.emptyList();
+        }
+
         if (DebugSettings.DEBUG_CODE_COMPLETION) {
             Log.toLogFile(this, "Starting getCodeCompletionProposals");
             Log.addLogLevel();

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PySelectionTest.java
@@ -871,4 +871,31 @@ public class PySelectionTest extends TestCase {
         Tuple<Integer, Integer> startEndLines = ps.getCurrentMethodStartEndLines();
         assertEquals(new Tuple<Integer, Integer>(1, 2), startEndLines);
     }
+
+    /**
+     * Test that we are identifying the correct strings to suppress completions for.
+     */
+    public void testIsCompletionForLiteralNumber() throws Exception {
+        // activation token must end with a dot to be considered for suppression
+        assertFalse(PySelection.isCompletionForLiteralNumber(""));
+        assertFalse(PySelection.isCompletionForLiteralNumber("a"));
+        assertFalse(PySelection.isCompletionForLiteralNumber("1.0"));
+
+        // things which don't look like numbers aren't considered for suppression
+        assertFalse(PySelection.isCompletionForLiteralNumber("a."));
+        assertFalse(PySelection.isCompletionForLiteralNumber("a1."));
+        assertFalse(PySelection.isCompletionForLiteralNumber("(1)."));
+
+        // floating points are allowed completions
+        assertFalse(PySelection.isCompletionForLiteralNumber("1.0."));
+        // hex numbers are also allowed completions
+        assertFalse(PySelection.isCompletionForLiteralNumber("0x0."));
+
+        // decimal numbers cannot have completions (it would be a syntax error)
+        assertTrue(PySelection.isCompletionForLiteralNumber("1."));
+        assertTrue(PySelection.isCompletionForLiteralNumber("1234."));
+
+        // Python 3.6 numbers allow _ (underscore) for readability
+        assertTrue(PySelection.isCompletionForLiteralNumber("1_1."));
+    }
 }


### PR DESCRIPTION
At the moment the console will provide completions for after the . (dot) in a number. For example 123. provides bit_length(), conjugate() etc. However these are not valid completions as 123.bit_length() is a syntax error.

However, the primary reason for this pull request is to stop having completion pop-ups in the middle of typing a floating point number. While working on this aspect I realised the suggested completions were not even valid.

A similar thing happens in the editor, but it is less clear to me how to resolve it there. I can see that org.python.pydev.editor.codecompletion.revisited.AbstractASTManager.getBuiltinsCompletions(ICompletionState) provides the incorrect completions, and by suppressing completion results with NodeUtils.getBuiltinType(act) returns "int" does seem to work, I had a lot less confidence that I was approaching it right in this case. 

Fabio, please let me know if I am on the right track or not. 

Thanks!
Jonah

