### PR TITLE
Fix errors when compile make_replace.py

### DIFF
--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/make_replace.py
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammarcommon/make_replace.py
@@ -1,7 +1,7 @@
 from string import Template
 import os
 import sys
-grammar_common_dir = os.path.split(__file__)[0]
+grammar_common_dir = os.path.split(os.path.abspath(__file__))[0]
 parent_dir = os.path.split(grammar_common_dir)[0]
 
 


### PR DESCRIPTION
File doesnot compile as grammar_common_dir path is not written correct (4th line of the code). With small fix I've added it works