### PR TITLE
Update Google App Engine Project Templates for GAE's update to Python 2.7

### DIFF
--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/ask_login/app.yaml
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/ask_login/app.yaml
@@ -1,8 +1,14 @@
+# Notice: This template has only been tested 
+# under Python27 + GAE standard environment
 application: ${app_id}
 version: 1
-runtime: python
+runtime: python27
+# threadsafe is required but can be either true or 
+# false. For some package, it should be true e.g. Flask
+threadsafe: true 
 api_version: 1
+
 
 handlers:
 - url: /.*
-  script: asklogin.py
+  script: asklogin.app

--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_webapp_world/app.yaml
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_webapp_world/app.yaml
@@ -1,8 +1,13 @@
+# Notice: This template has only been tested 
+# under Python27 + GAE standard environment
 application: ${app_id}
 version: 1
-runtime: python
+runtime: python27
+# threadsafe is required but can be either true or 
+# false. For some package, it should be true e.g. Flask
+threadsafe: true
 api_version: 1
 
 handlers:
 - url: /.*
-  script: helloworld.py
+  script: helloworld.app

--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_world/app.yaml
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_world/app.yaml
@@ -1,8 +1,13 @@
+# Notice: This template has only been tested 
+# under Python27 + GAE standard environment
 application: ${app_id}
 version: 1
-runtime: python
+runtime: python27
+# threadsafe is required but can be either true or 
+# false. For some package, it should be true e.g. Flask
+threadsafe: true
 api_version: 1
 
 handlers:
 - url: /.*
-  script: helloworld.py
+  script: helloworld.app


### PR DESCRIPTION
- update `.yam`l file for google app engine project templates. 
   - According to GAE Docs [Migrate to Python 2.7][1], update the `version:` element and add `threadsafe:` element
   - According to GAE Docs [Using WSGI][2], update the `script:` element
- update line break to `LF` for `.yaml` files

[1]: https://cloud.google.com/appengine/docs/standard/python/python25/migrate27#appyaml
[2]: https://cloud.google.com/appengine/docs/standard/python/python25/migrate27#wsgi