### PR TITLE
Remove unnecessary hack

### DIFF
--- a/plugins/org.python.pydev/pysrc/interpreterInfo.py
+++ b/plugins/org.python.pydev/pysrc/interpreterInfo.py
@@ -260,5 +260,3 @@ if __name__ == '__main__':
         time.sleep(0.1)
     except:
         pass
-
-    raise RuntimeError('Ok, this is so that it shows the output (ugly hack for some platforms, so that it releases the output).')


### PR DESCRIPTION
Raising an exception to exit an application is a very bad style. I guess this is not needed any more. PyDev on Fedora 26 works fine without this line.

Since the original commit which introduced this hack has no message, I don't know for sure that this is not needed any more. On the other hand, there is no reason why it would be needed.