### PR TITLE
[Bugfix #808] Tooltip for nested call

### DIFF
--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/docutils/PySelection.java
@@ -1100,10 +1100,20 @@ public final class PySelection extends TextSelectionUtils {
     public static int getBeforeParentesisCall(Object doc, int calltipOffset) {
         ParsingUtils parsingUtils = ParsingUtils.create(doc);
         char c = parsingUtils.charAt(calltipOffset);
+        int parensBefore = 0;
 
-        while (calltipOffset > 0 && c != '(') {
+        while (calltipOffset > 0) {
             calltipOffset--;
             c = parsingUtils.charAt(calltipOffset);
+            if (c == ')') {
+                parensBefore += 1;
+            } else if (c == '(') {
+                if (parensBefore <= 0) {
+                    break;
+                } else {
+                    parensBefore -= 1;
+                }
+            }
         }
         if (c == '(') {
             while (calltipOffset > 0 && Character.isWhitespace(c)) {
@@ -1471,7 +1481,7 @@ public final class PySelection extends TextSelectionUtils {
     /**
      * Return true if the completion is at the dot after a literal number.
      * Literal numbers have no valid completions as they can be the first part of floats.
-     * 
+     *
      * @param activationToken this comes from either the console's ActivationTokenAndQual
      *      or editor's CompletionRequest
      * @return true if this completion is for a number

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/PythonCompletionWithoutBuiltinsTest.java
@@ -3187,4 +3187,31 @@ public class PythonCompletionWithoutBuiltinsTest extends CodeCompletionTestsBase
         assertEquals("Bar(a, b)", prop.getDisplayString());
 
     }
+
+    public void testInsideMethodParams() throws Exception {
+        String s;
+        String original = "" +
+                "def foo(a, b):\n" +
+                "    pass\n" +
+                "def bar(c, d):\n" +
+                "    pass\n" +
+                "foo(bar(1, 2), ";
+
+        s = StringUtils.format(original, "");
+
+        ICompletionProposal[] proposals = requestCompl(s, s.length() - 1, -1, new String[] {});
+        assertEquals(1, proposals.length);
+        ICompletionProposal prop = proposals[0];
+        assertEquals("foo(a, b)", prop.getDisplayString());
+
+        IPyCalltipsContextInformation contextInformation = (IPyCalltipsContextInformation) prop.getContextInformation();
+        assertEquals("a, b", contextInformation.getContextDisplayString());
+        assertEquals("a, b", contextInformation.getInformationDisplayString());
+
+        Document doc = new Document(s);
+        prop.apply(doc);
+        String expected = StringUtils.format(original, "c, d");
+        assertEquals(expected, doc.get());
+    }
+
 }


### PR DESCRIPTION
Fix tooltip showing for nested method call.
Calculate number of parentheses to skip instead of looking for the first
one.