### PR TITLE
Fix Google App Engine templates that don't work out-of-the-box.

### DIFF
--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/ask_login/asklogin.py
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/ask_login/asklogin.py
@@ -18,11 +18,11 @@ class MainPage(webapp.RequestHandler):
             self.redirect(users.create_login_url(self.request.uri))
 
 
-application = webapp.WSGIApplication([('/', MainPage)], debug=True)
+app = webapp.WSGIApplication([('/', MainPage)], debug=True)
 
 
 def main():
-    run_wsgi_app(application)
+    run_wsgi_app(app)
 
 
 if __name__ == "__main__":

--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_webapp_world/helloworld.py
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_webapp_world/helloworld.py
@@ -10,11 +10,11 @@ class MainPage(webapp.RequestHandler):
         self.response.out.write('Hello, webapp World!')
 
 
-application = webapp.WSGIApplication([('/', MainPage)], debug=True)
+app = webapp.WSGIApplication([('/', MainPage)], debug=True)
 
 
 def main():
-    run_wsgi_app(application)
+    run_wsgi_app(app)
 
 if __name__ == "__main__":
     main()

--- a/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_world/app.yaml
+++ b/plugins/org.python.pydev.customizations/templates/google_app_engine/hello_world/app.yaml
@@ -5,9 +5,9 @@ version: 1
 runtime: python27
 # threadsafe is required but can be either true or 
 # false. For some package, it should be true e.g. Flask
-threadsafe: true
+threadsafe: false
 api_version: 1
 
 handlers:
 - url: /.*
-  script: helloworld.app
+  script: helloworld.py


### PR DESCRIPTION
I downloaded the Google App Engine SDK: https://storage.googleapis.com/appengine-sdks/featured/google_appengine_1.9.56.zip

But none of the GAE templates supplied with Pydev work with it out-of-the-box. All three templates generate errors in the console when you try to visit the app in your browser at http://localhost:8080/

For each template, I see an error similar to this:

```
ERROR    2017-08-03 21:08:18,001 wsgi.py:263] 
Traceback (most recent call last):
  File "/home/mbooth/google_appengine/google/appengine/runtime/wsgi.py", line 240, in Handle
    handler = _config_handle.add_wsgi_middleware(self._LoadHandler())
  File "/home/mbooth/google_appengine/google/appengine/runtime/wsgi.py", line 302, in _LoadHandler
    raise err
ImportError: <module 'helloworld' from '/home/mbooth/runtime-Pydev/testweb/helloworld.py'> has no attribute app
INFO     2017-08-03 21:08:18,004 module.py:832] default: "GET / HTTP/1.1" 500 -
```

With this patch applied, the errors go away and the templates work as expected.