### PR TITLE
[PyDev/840] Feature: provide test names in configs

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/actions/RunEditorAsCustomUnitTestAction.java
@@ -215,7 +215,7 @@ public class RunEditorAsCustomUnitTestAction extends AbstractRunEditorAction {
                         TreeItem[] items = tree.getItems();
                         list = new ArrayList<Object>();
                         //Now, if he didn't select anything, let's create tests with all that is currently filtered
-                        //in the interface 
+                        //in the interface
                         createListWithLeafs(items, list);
                         setResult(list);
                     }
@@ -309,7 +309,13 @@ public class RunEditorAsCustomUnitTestAction extends AbstractRunEditorAction {
                     ILaunchConfigurationWorkingCopy workingCopy = super.createDefaultLaunchConfigurationWithoutSaving(
                             resource);
                     if (arguments.length() > 0) {
+                        // first remember the arguments to be used internally and for matching
                         workingCopy.setAttribute(Constants.ATTR_UNITTEST_TESTS, arguments);
+                        // then rename it (copy + delete as the easiest way)
+                        String argsWithTests = workingCopy.getName() + " ( " + arguments + " ) ";
+                        ILaunchConfigurationWorkingCopy workingCopyArgs = workingCopy.copy(argsWithTests);
+                        workingCopy.delete();
+                        return workingCopyArgs;
                     }
                     return workingCopy;
                 }

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
@@ -24,17 +24,19 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Text;
 import org.python.pydev.core.log.Log;
+import org.python.pydev.debug.core.Constants;
 import org.python.pydev.plugin.preferences.PydevPrefs;
 import org.python.pydev.pyunit.preferences.PyUnitPrefsPage2;
-
 
 public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationTab {
 
     private Button buttonAskOverride;
     private Combo comboSelectRunner;
     private Text textRunnerParameters;
+    private Text testsToRun; // test names (class + optionally methods)
 
     @Override
     public void createControl(Composite parent) {
@@ -96,6 +98,11 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
             }
         });
 
+        Label testsToRunLabel = new Label(group, SWT.LEFT);
+        testsToRunLabel.setText("Tests to run");
+        testsToRun = new Text(group, SWT.BORDER);
+        testsToRun.setLayoutData(gd);
+        testsToRun.setFont(font);
     }
 
     @Override
@@ -147,6 +154,15 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
         } catch (CoreException e) {
             Log.log(e);
         }
+
+        // Test cases - arguments to test runner
+        try {
+            String testCases = configuration.getAttribute(Constants.ATTR_UNITTEST_TESTS, "");
+            testsToRun.setText(testCases);
+        } catch (CoreException e) {
+            Log.log(e);
+        }
+
         updateOverrideState();
     }
 
@@ -158,6 +174,7 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
         configuration.setAttribute(PyUnitPrefsPage2.LAUNCH_CONFIG_OVERRIDE_TEST_RUNNER, data);
         configuration.setAttribute(PyUnitPrefsPage2.LAUNCH_CONFIG_OVERRIDE_PYUNIT_RUN_PARAMS,
                 textRunnerParameters.getText());
+        configuration.setAttribute(Constants.ATTR_UNITTEST_TESTS, testsToRun.getText());
     }
 
     @Override

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
@@ -109,7 +109,7 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
         testsToRun.setLayoutData(gd);
         testsToRun.setFont(font);
         // read only property
-        testsToRun.setEnabled(false);
+        testsToRun.setEditable(false);
     }
 
     @Override

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
@@ -99,7 +99,7 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
         });
 
         GridLayout testsLayout = new GridLayout(2, false);
-        Group testsGroup = new Group(group, SWT.NONE);
+        Composite testsGroup = new Composite(group, SWT.NONE);
         testsGroup.setLayout(testsLayout);
         gd = new GridData(GridData.FILL_HORIZONTAL);
         testsGroup.setLayoutData(gd);

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/blocks/OverrideUnittestArgumentsBlock.java
@@ -98,11 +98,18 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
             }
         });
 
-        Label testsToRunLabel = new Label(group, SWT.LEFT);
-        testsToRunLabel.setText("Tests to run");
-        testsToRun = new Text(group, SWT.BORDER);
+        GridLayout testsLayout = new GridLayout(2, false);
+        Group testsGroup = new Group(group, SWT.NONE);
+        testsGroup.setLayout(testsLayout);
+        gd = new GridData(GridData.FILL_HORIZONTAL);
+        testsGroup.setLayoutData(gd);
+        Label testsToRunLabel = new Label(testsGroup, SWT.LEFT);
+        testsToRunLabel.setText("Tests to run: ");
+        testsToRun = new Text(testsGroup, SWT.LEFT | SWT.FILL | SWT.BORDER);
         testsToRun.setLayoutData(gd);
         testsToRun.setFont(font);
+        // read only property
+        testsToRun.setEnabled(false);
     }
 
     @Override
@@ -174,7 +181,6 @@ public class OverrideUnittestArgumentsBlock extends AbstractLaunchConfigurationT
         configuration.setAttribute(PyUnitPrefsPage2.LAUNCH_CONFIG_OVERRIDE_TEST_RUNNER, data);
         configuration.setAttribute(PyUnitPrefsPage2.LAUNCH_CONFIG_OVERRIDE_PYUNIT_RUN_PARAMS,
                 textRunnerParameters.getText());
-        configuration.setAttribute(Constants.ATTR_UNITTEST_TESTS, testsToRun.getText());
     }
 
     @Override

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
@@ -1028,6 +1028,15 @@ public class PythonRunnerConfig {
         String[] args;
         try {
             args = getCommandLine(false);
+            // append test names to command line to show
+            String testArgs = configuration.getAttribute(Constants.ATTR_UNITTEST_TESTS, "");
+            if (testArgs != "") {
+                // only in case any tests were selected
+                String[] argsWithTests = new String[args.length + 1];
+                System.arraycopy(args, 0, argsWithTests, 0, args.length);
+                argsWithTests[args.length] = testArgs;
+                args = argsWithTests;
+            }
             return SimpleRunner.getArgumentsAsStr(args);
         } catch (CoreException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Provide test names (classes and optionally methods) in (unit)test runner:
1. As part of the created launch configuration, to make them easier to
distinguish.
2. In Run Python unittest configurations:
2a. In Arguments tab
2b. In Interpreter tab