### PR TITLE
fix problem with Cygwin dlopen

### DIFF
--- a/plugins/org.python.pydev/pysrc/interpreterInfo.py
+++ b/plugins/org.python.pydev/pysrc/interpreterInfo.py
@@ -64,7 +64,8 @@ if sys.platform == "cygwin":
         path = fully_normalize_path(path)
         path = tobytes(path)
         CCP_POSIX_TO_WIN_A = 0
-        ctypes.cdll.cygwin1.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
+        cygwin1dll = ctypes.cdll.LoadLibrary( 'cygwin1.dll' )
+        cygwin1dll.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
 
         return retval.value
 


### PR DESCRIPTION
I recently ran into some problems reinstalling the Cygwin python interpreter into PyDev on an install where it was previously working.

Specifically, Eclipse wasn't able to use the Cygwin python interpreter with the Cygwin DLL version 2.5.2 and later to discover the various paths - interpreterInfo.py was failing:

[~] $ python /c/dev/eclipse-cpp-neon-1a-win32-x86_64/plugins/org.python.pydev_5.4.0.201611281236/pysrc/interpreterInfo.py
Traceback (most recent call last):
  File "/c/dev/eclipse-cpp-neon-1a-win32-x86_64/plugins/org.python.pydev_5.4.0.201611281236/pysrc/interpreterInfo.py", line 207, in <module>
    prefix = tounicode(native_path(sys.prefix))
  File "/c/dev/eclipse-cpp-neon-1a-win32-x86_64/plugins/org.python.pydev_5.4.0.201611281236/pysrc/interpreterInfo.py", line 71, in native_path
    ctypes.cdll.cygwin1.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
  File "/cygdrive/c/Cygwin/lib/python2.7/ctypes/__init__.py", line 435, in __getattr__
    dll = self._dlltype(name)
  File "/cygdrive/c/Cygwin/lib/python2.7/ctypes/__init__.py", line 365, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: No such file or directory

I tracked it down to the line: 

     ctypes.cdll.cygwin1.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)

After some digging, I found other projects where having issues as well - it was briefly discussed on the cygwin mailing list:

   https://cygwin.com/ml/cygwin/2016-06/msg00379.html

I didn't see any followup on this, and it doesn't look like they've reverted that change. 

In any case, the fix for PyDev is fairly easy - change the above line in interpreterInfo.py to:

     cygwin1dll = ctypes.cdll.LoadLibrary( 'cygwin1.dll' )
     cygwin1dll.cygwin_conv_path(CCP_POSIX_TO_WIN_A, path, retval, MAX_PATH)
