### PR TITLE
Omit hidden project files and CI files from org.python.pydev bundle

### DIFF
--- a/plugins/org.python.pydev/build.properties
+++ b/plugins/org.python.pydev/build.properties
@@ -150,4 +150,9 @@ bin.excludes = pysrc/__pycache__/,\
                pysrc/_pydev_bundle/pydev_monkey_qt.pyc,\
                pysrc/_pydev_bundle/pydev_umd.pyc,\
                pysrc/_pydev_bundle/pydev_override.pyc,\
-               pysrc/jython_test_deps/
+               pysrc/jython_test_deps/,\
+               pysrc/appveyor.yml,\
+               pysrc/.project,\
+               pysrc/.pydevproject,\
+               pysrc/.settings/,\
+               pysrc/.travis*


### PR DESCRIPTION
These files are only needed if you are developing Pydev or needed only by CI systems, they shouldn't be shipped in the binary distribution of Pydev itself.