### PR TITLE
Fix logic error in editor preferences for subword navigation.

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevEditorPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevEditorPrefs.java
@@ -126,7 +126,7 @@ public class PydevEditorPrefs extends AbstractPydevPrefs {
                 String text = comboNavigation.getText();
                 String style = SubWordPreferences.WORD_NAVIGATION_STYLE_SUBWORD;
                 if (WORD_NAVIGATION_NATIVE_CAPTION.equals(text)) {
-                    style = SubWordPreferences.WORD_NAVIGATION_STYLE_SUBWORD;
+                    style = SubWordPreferences.WORD_NAVIGATION_STYLE_NATIVE;
                 }
                 fOverlayStore.setValue(SubWordPreferences.WORD_NAVIGATION_STYLE, style);
             }


### PR DESCRIPTION
There is a small bug in the new ["subword" navigation editor preference][1]:  It is impossible to switch back to the "Native" setting.

Disclaimer: I'm pretty sure this tiny PR will fix the issue, but I'm unable to test it myself.

**Edit:** To reproduce the bug, simply open Preferences > PyDev > Editor and select "Native" for the "Word navigation" setting.  Then close the Preferences window and re-open it.  The setting will say "Subword" again, because it never really changed.

[1]: http://pydev.blogspot.com/2017/09/pydev-60-pip-conda-isort-and-subword.html
![screen shot 2017-09-29 at 5 41 11 pm](https://user-images.githubusercontent.com/1655821/31037145-76d8c420-a53d-11e7-9da2-f568aab5ec82.png)
