### PR TITLE
Add problem markers for python files that declare invalid encodings

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
@@ -89,6 +89,9 @@ public class AnalysisPreferenceInitializer extends AbstractPreferenceInitializer
     public static final String SEVERITY_FSTRING_ERROR = "SEVERITY_FSTRING_ERROR";
     public static final int DEFAULT_SEVERITY_FSTRING_ERROR = IMarker.SEVERITY_ERROR;
 
+    public static final String SEVERITY_INVALID_ENCODING = "SEVERITY_INVALID_ENCODING";
+    public static final int DEFAULT_SEVERITY_INVALID_ENCODING = IMarker.SEVERITY_ERROR;
+
     @Override
     public void initializeDefaultPreferences() {
         Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_SCOPE);

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
@@ -75,6 +75,8 @@ public class AnalysisPreferences extends AbstractAnalysisPreferences {
                     AnalysisPreferenceInitializer.DEFAULT_SEVERITY_ARGUMENTS_MISMATCH },
             { IAnalysisPreferences.TYPE_FSTRING_SYNTAX_ERROR, AnalysisPreferenceInitializer.SEVERITY_FSTRING_ERROR,
                     AnalysisPreferenceInitializer.DEFAULT_SEVERITY_FSTRING_ERROR },
+            { IAnalysisPreferences.TYPE_INVALID_ENCODING, AnalysisPreferenceInitializer.SEVERITY_INVALID_ENCODING,
+                    AnalysisPreferenceInitializer.DEFAULT_SEVERITY_INVALID_ENCODING },
     };
 
     private HashMap<Integer, Integer> severityTypeMapCache;

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IAnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/IAnalysisPreferences.java
@@ -33,6 +33,7 @@ public interface IAnalysisPreferences {
     public static final int TYPE_PEP8 = IMiscConstants.TYPE_PEP8;
     public static final int TYPE_ARGUMENTS_MISATCH = IMiscConstants.TYPE_ARGUMENTS_MISATCH;
     public static final int TYPE_FSTRING_SYNTAX_ERROR = IMiscConstants.TYPE_FSTRING_SYNTAX_ERROR;
+    public static final int TYPE_INVALID_ENCODING = IMiscConstants.TYPE_INVALID_ENCODING;
 
     public static final String MSG_TO_IGNORE_TYPE_UNUSED_IMPORT = "@UnusedImport";
     public static final String MSG_TO_IGNORE_TYPE_UNUSED_WILD_IMPORT = "@UnusedWildImport";

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/OccurrencesAnalyzer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/OccurrencesAnalyzer.java
@@ -22,8 +22,11 @@ import org.python.pydev.core.IPythonNature;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.editor.codecompletion.revisited.modules.SourceModule;
 import org.python.pydev.parser.jython.SimpleNode;
+import org.python.pydev.shared_core.io.FileUtils;
+import org.python.pydev.shared_core.io.PyUnsupportedEncodingException;
 
 import com.python.pydev.analysis.messages.IMessage;
+import com.python.pydev.analysis.messages.Message;
 import com.python.pydev.analysis.tabnanny.TabNanny;
 import com.python.pydev.analysis.visitors.OccurrencesVisitor;
 
@@ -67,7 +70,14 @@ public class OccurrencesAnalyzer {
 
         List<IMessage> messages = new ArrayList<IMessage>();
         if (!monitor.isCanceled()) {
-            messages = visitor.getMessages();
+            messages.addAll(visitor.getMessages());
+            try {
+                FileUtils.getPythonFileEncoding(document.get(), module.getName());
+            } catch (PyUnsupportedEncodingException e) {
+                Message m = new Message(IAnalysisPreferences.TYPE_INVALID_ENCODING, e.getMessage(), e.getLine(),
+                        e.getLine(), e.getCharacter(), e.getCharacter() + e.getMessage().length(), prefs);
+                messages.add(m);
+            }
             try {
                 messages.addAll(TabNanny.analyzeDoc(document, prefs, module.getName(), indentPrefs, monitor));
             } catch (Exception e) {

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/AbstractMessage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/AbstractMessage.java
@@ -97,6 +97,7 @@ public abstract class AbstractMessage implements IMessage {
             messages.put(IAnalysisPreferences.TYPE_PEP8, "%s");
             messages.put(IAnalysisPreferences.TYPE_ARGUMENTS_MISATCH, "%s");
             messages.put(IAnalysisPreferences.TYPE_FSTRING_SYNTAX_ERROR, "SyntaxError: %s");
+            messages.put(IAnalysisPreferences.TYPE_INVALID_ENCODING, "Unsupported encoding: %s");
         }
         return messages.get(getType());
 

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/IMessage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/messages/IMessage.java
@@ -39,6 +39,7 @@ public interface IMessage {
      * @see com.python.pydev.analysis.IAnalysisPreferences#TYPE_INDENTATION_PROBLEM
      * @see com.python.pydev.analysis.IAnalysisPreferences#TYPE_PEP8
      * @see com.python.pydev.analysis.IAnalysisPreferences#TYPE_ARGUMENTS_MISATCH
+     * @see com.python.pydev.analysis.IAnalysisPreferences#TYPE_INVALID_ENCODING
      * 
      * @return this message type
      */

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AnalysisPreferencesPage.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ui/AnalysisPreferencesPage.java
@@ -127,6 +127,8 @@ public class AnalysisPreferencesPage extends ScopedFieldEditorPreferencePage imp
                 "Indentation problems and mixing of tabs/spaces", 4, values, p, true));
         addField(new RadioGroupFieldEditor(AnalysisPreferenceInitializer.SEVERITY_ASSIGNMENT_TO_BUILT_IN_SYMBOL,
                 "Redefinition of builtin symbols", 4, values, p, true));
+        addField(new RadioGroupFieldEditor(AnalysisPreferenceInitializer.SEVERITY_INVALID_ENCODING,
+                "Unsupported encoding", 4, values, p, true));
         //TODO: Add ARGUMENTS_MISMATCH again later on
         //addField(new RadioGroupFieldEditor(AnalysisPreferenceInitializer.SEVERITY_ARGUMENTS_MISMATCH, "Arguments mismatch", 4,values,p, true));
 

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/FileUtilsFileBuffer.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/FileUtilsFileBuffer.java
@@ -15,9 +15,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.Reader;
-import java.io.StringReader;
-import java.nio.charset.IllegalCharsetNameException;
 import java.util.zip.ZipFile;
 
 import org.eclipse.core.filebuffers.ITextFileBuffer;
@@ -152,7 +149,13 @@ public class FileUtilsFileBuffer {
         if (doc == null && loadIfNotInWorkspace) {
             FileInputStream stream = new FileInputStream(f);
             try {
-                String encoding = FileUtils.getPythonFileEncoding(f);
+                String encoding;
+                try {
+                    encoding = FileUtils.getPythonFileEncoding(f);
+                } catch (IOException e) {
+                    // The encoding specified in the file is unsupported
+                    encoding = null;
+                }
                 return FileUtils.getStreamContents(stream, encoding, null, returnType);
             } finally {
                 try {
@@ -208,13 +211,4 @@ public class FileUtilsFileBuffer {
     public static IDocument getDocFromResource(IResource resource) {
         return FileUtils.getDocFromResource(resource);
     }
-
-    /**
-     * The encoding declared in the document is returned (according to the PEP: http://www.python.org/doc/peps/pep-0263/)
-     */
-    public static String getPythonFileEncoding(IDocument doc, String fileLocation) throws IllegalCharsetNameException {
-        Reader inputStreamReader = new StringReader(doc.get());
-        return FileUtils.getPythonFileEncoding(inputStreamReader, fileLocation);
-    }
-
 }

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/IMiscConstants.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/IMiscConstants.java
@@ -45,4 +45,5 @@ public interface IMiscConstants {
     int TYPE_PEP8 = 15;
     int TYPE_ARGUMENTS_MISATCH = 16;
     int TYPE_FSTRING_SYNTAX_ERROR = 17;
+    int TYPE_INVALID_ENCODING = 18;
 }

--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/EncodingsTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/EncodingsTest.java
@@ -6,6 +6,7 @@
  */
 package org.python.pydev.core;
 
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
 import org.python.pydev.shared_core.io.FileUtils;
@@ -18,23 +19,21 @@ public class EncodingsTest extends TestCase {
         junit.textui.TestRunner.run(EncodingsTest.class);
     }
 
-    private boolean was_LOG_ENCODING_ERROR;
-
-    @Override
-    protected void setUp() throws Exception {
-        was_LOG_ENCODING_ERROR = FileUtils.LOG_ENCODING_ERROR;
-        FileUtils.LOG_ENCODING_ERROR = false;
-    }
-
-    @Override
-    protected void tearDown() throws Exception {
-        FileUtils.LOG_ENCODING_ERROR = was_LOG_ENCODING_ERROR;
-    }
-
     public void testRefEncoding() throws Exception {
         String validEncoding = FileUtils.getValidEncoding("latin-1", null);
         assertEquals("latin1", validEncoding);
-        assertNull(FileUtils.getValidEncoding("utf-8-*-", null));
+        try {
+            FileUtils.getValidEncoding("utf-8-", null);
+            fail("Did not throw error for invalid encoding");
+        } catch (UnsupportedEncodingException e) {
+            assertEquals("utf-8-", e.getMessage());
+        }
+        try {
+            FileUtils.getValidEncoding("utf-8-*-", null);
+            fail("Did not throw error for invalid encoding");
+        } catch (UnsupportedEncodingException e) {
+            assertEquals("utf-8-*-", e.getMessage());
+        }
 
         //supported
         assertTrue(Charset.isSupported("latin1"));

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/FileUtils.java
@@ -28,6 +28,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.io.Reader;
+import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.nio.charset.IllegalCharsetNameException;
@@ -64,7 +65,6 @@ import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
@@ -611,83 +611,121 @@ public class FileUtils {
     }
 
     /**
+     * Retrieves the contents of the given file using the default system encoding.
+     * 
      * @param file the file we want to read
-     * @return the contents of the file as a string
+     * @return the contents of the given file as a string
      */
     public static String getFileContents(File file) {
         return getFileContentsCustom(file, null, String.class);
     }
 
     /**
-     * To get file contents for a python file, the encoding is required!
+     * Retrieves the contents of the given python file. If present, the encoding declared at the top of the python file
+     * is used to read it. If no encoding is declared, or no encoding is declared, the default system encoding is used.
+     * 
+     * @param file the file we want to read
+     * @return the contents of the given file as a string
      */
     public static String getPyFileContents(File file) {
-        return getFileContentsCustom(file, getPythonFileEncoding(file), String.class);
+        String encoding;
+        try {
+            encoding = getPythonFileEncoding(file);
+        } catch (IOException e) {
+            encoding = null;
+        }
+        return getFileContentsCustom(file, encoding, String.class);
     }
 
     /**
-     * The encoding declared in the reader is returned (according to the PEP: http://www.python.org/doc/peps/pep-0263/)
-     * -- may return null
+     * Retrieves the encoding declared in the given python file, according to the PEP: https://www.python.org/dev/peps/pep-0263/
      *
-     * Will close the reader.
-     * @param fileLocation the file we want to get the encoding from (just passed for giving a better message
-     * if it fails -- may be null).
+     * @param file a file from which to get the encoding
+     * @return the encoding declared in the file, or null if no encoding was declared or could not be retrieved
+     * @throws PyUnsupportedEncodingException if the encoding declared in the file is invalid or not supported
      */
-    public static String getPythonFileEncoding(Reader inputStreamReader, String fileLocation)
-            throws IllegalCharsetNameException {
+    public static String getPythonFileEncoding(File file) throws PyUnsupportedEncodingException {
+        try (Reader inputStreamReader = new InputStreamReader(new BufferedInputStream(new FileInputStream(file)))) {
+            return getPythonFileEncoding(inputStreamReader, file.getAbsolutePath());
+        } catch (PyUnsupportedEncodingException e) {
+            throw e;
+        } catch (IOException e) {
+            Log.log(e);
+            return null;
+        }
+    }
+
+    /**
+     * Retrieves the encoding declared in the given python file, according to the PEP: https://www.python.org/dev/peps/pep-0263/
+     *
+     * @param str the contents of the file from which to get the encoding
+     * @param location the location of the file from which we want to get the encoding, may be null
+     * @return the encoding declared in the file, or null if no encoding was declared
+     * @throws PyUnsupportedEncodingException if the encoding declared in the file is invalid or not supported
+     */
+    public static String getPythonFileEncoding(String str, String location)
+            throws PyUnsupportedEncodingException {
+        Reader inputStreamReader = new StringReader(str);
+        return getPythonFileEncoding(inputStreamReader, location);
+    }
+
+    private static String getPythonFileEncoding(Reader inputStreamReader, String fileLocation)
+            throws PyUnsupportedEncodingException {
 
         String ret = null;
-        try {
-            List<String> lines = readLines(inputStreamReader, 2);
-            int readLines = lines.size();
-            String lEnc = null;
+        List<String> lines = readLines(inputStreamReader, 2);
+        int readLines = lines.size();
+        String lEnc = null;
+        int lineNum = -1;
+        int charNum = -1;
 
-            //pep defines that coding must be at 1st or second line: http://www.python.org/doc/peps/pep-0263/
-            String l1 = readLines > 0 ? lines.get(0) : null;
-            if (l1 != null) {
-                //Special case -- determined from the python docs:
-                //http://docs.python.org/reference/lexical_analysis.html#encoding-declarations
-                //We can return promptly in this case as utf-8 should be always valid.
-                if (l1.startsWith(BOM_UTF8)) {
-                    return "utf-8";
-                }
-
-                if (l1.indexOf("coding") != -1) {
-                    lEnc = l1;
-                }
+        //pep defines that coding must be at 1st or second line: https://www.python.org/dev/peps/pep-0263/
+        String l1 = readLines > 0 ? lines.get(0) : null;
+        if (l1 != null) {
+            //Special case -- determined from the python docs:
+            //http://docs.python.org/reference/lexical_analysis.html#encoding-declarations
+            //We can return promptly in this case as utf-8 should be always valid.
+            if (l1.startsWith(BOM_UTF8)) {
+                return "utf-8";
             }
 
-            if (lEnc == null) {
-                String l2 = readLines > 1 ? lines.get(1) : null;
-
-                //encoding must be specified in first or second line...
-                if (l2 != null && l2.indexOf("coding") != -1) {
-                    lEnc = l2;
-                } else {
-                    ret = null;
-                }
-            }
-
-            if (lEnc != null) {
-                lEnc = lEnc.trim();
-                if (lEnc.length() == 0) {
-                    ret = null;
-
-                } else if (lEnc.charAt(0) == '#') { //it must be a comment line
-
-                    Matcher matcher = ENCODING_PATTERN.matcher(lEnc);
-                    if (matcher.find()) {
-                        ret = matcher.group(1).trim();
-                    }
-                }
-            }
-        } finally {
-            try {
-                inputStreamReader.close();
-            } catch (IOException e1) {
+            if (l1.indexOf("coding") != -1) {
+                lEnc = l1;
+                lineNum = 1;
             }
         }
-        ret = getValidEncoding(ret, fileLocation);
+
+        if (lEnc == null) {
+            String l2 = readLines > 1 ? lines.get(1) : null;
+
+            //encoding must be specified in first or second line...
+            if (l2 != null && l2.indexOf("coding") != -1) {
+                lEnc = l2;
+                lineNum = 2;
+            } else {
+                ret = null;
+            }
+        }
+
+        if (lEnc != null) {
+            lEnc = lEnc.trim();
+            if (lEnc.length() == 0) {
+                ret = null;
+
+            } else if (lEnc.charAt(0) == '#') { //it must be a comment line
+
+                Matcher matcher = ENCODING_PATTERN.matcher(lEnc);
+                if (matcher.find()) {
+                    ret = matcher.group(1).trim();
+                    charNum = matcher.start(1) + 1;
+                }
+            }
+        }
+        try {
+            ret = getValidEncoding(ret, fileLocation);
+        } catch (UnsupportedEncodingException e) {
+            throw new PyUnsupportedEncodingException(e.getMessage(), lineNum, charNum);
+        }
         return ret;
     }
 
@@ -703,8 +741,9 @@ public class FileUtils {
 
     /**
      * @param fileLocation may be null
+     * @throws UnsupportedEncodingException
      */
-    /*package*/public static String getValidEncoding(String ret, String fileLocation) {
+    public static String getValidEncoding(String ret, String fileLocation) throws UnsupportedEncodingException {
         if (ret == null) {
             return ret;
         }
@@ -719,54 +758,26 @@ public class FileUtils {
         }
         try {
             if (!Charset.isSupported(ret)) {
-                if (LOG_ENCODING_ERROR) {
-                    if (fileLocation != null) {
-                        if ("uft-8".equals(ret) && fileLocation.endsWith("bad_coding.py")) {
-                            return null; //this is an expected error in the python library.
-                        }
-                        if ("string-escape".equals(ret) && fileLocation.endsWith("bad_coding3.py")) {
-                            return null; //this is an expected error in the python library.
-                        }
+                if (fileLocation != null) {
+                    if ("uft-8".equals(ret) && fileLocation.endsWith("bad_coding.py")) {
+                        return null; //this is an expected error in the python library.
                     }
-                    String msg = "The encoding found: >>" + ret + "<< on " + fileLocation + " is not a valid encoding.";
-                    Log.log(IStatus.ERROR, msg, new UnsupportedEncodingException(msg));
+                    if ("string-escape".equals(ret) && fileLocation.endsWith("bad_coding3.py")) {
+                        return null; //this is an expected error in the python library.
+                    }
                 }
-                return null; //ok, we've been unable to make it supported (better return null than an unsupported encoding).
+                throw new UnsupportedEncodingException(ret);
             }
             return ret;
         } catch (IllegalCharsetNameException ex) {
-            if (LOG_ENCODING_ERROR) {
-                String msg = "The encoding found: >>" + ret + "<< on " + fileLocation + " is not a valid encoding.";
-                Log.log(IStatus.ERROR, msg, ex);
-            }
+            throw new UnsupportedEncodingException(ret);
         }
-        return null;
     }
 
-    /**
-     * Useful to silent it on tests
-     */
-    public static boolean LOG_ENCODING_ERROR = true;
     /**
      * Regular expression for finding the encoding in a python file.
      */
     public static final Pattern ENCODING_PATTERN = Pattern.compile("coding[:=][\\s]*([-\\w.]+)");
-
-    /**
-     * The encoding declared in the file is returned (according to the PEP: http://www.python.org/doc/peps/pep-0263/)
-     */
-    public static String getPythonFileEncoding(File f) throws IllegalCharsetNameException {
-        try (FileInputStream fileInputStream = new FileInputStream(f)) {
-            Reader inputStreamReader = new InputStreamReader(new BufferedInputStream(fileInputStream));
-
-            //NOTE: the reader will be closed at 'getPythonFileEncoding'.
-            String pythonFileEncoding = getPythonFileEncoding(inputStreamReader, f.getAbsolutePath());
-            return pythonFileEncoding;
-        } catch (IOException e) {
-            Log.log(e);
-            return null;
-        }
-    }
 
     /**
      * Returns if the given file has a python shebang (i.e.: starts with #!... python)

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/PyUnsupportedEncodingException.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/io/PyUnsupportedEncodingException.java
@@ -1,0 +1,33 @@
+package org.python.pydev.shared_core.io;
+
+import java.io.UnsupportedEncodingException;
+
+public class PyUnsupportedEncodingException extends UnsupportedEncodingException {
+
+    private static final long serialVersionUID = 3821007258281155368L;
+
+    private int line;
+    private int character;
+
+    public PyUnsupportedEncodingException(String encoding, int line, int character) {
+        super(encoding);
+        this.setLine(line);
+        this.setCharacter(character);
+    }
+
+    public int getLine() {
+        return line;
+    }
+
+    public void setLine(int line) {
+        this.line = line;
+    }
+
+    public int getCharacter() {
+        return character;
+    }
+
+    public void setCharacter(int character) {
+        this.character = character;
+    }
+}

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyEdit.java
@@ -7,6 +7,7 @@
 package org.python.pydev.editor;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -83,7 +84,6 @@ import org.eclipse.ui.views.contentoutline.IContentOutlinePage;
 import org.osgi.framework.Version;
 import org.python.pydev.changed_lines.ChangedLinesComputer;
 import org.python.pydev.core.ExtensionHelper;
-import org.python.pydev.core.FileUtilsFileBuffer;
 import org.python.pydev.core.ICodeCompletionASTManager;
 import org.python.pydev.core.IDefinition;
 import org.python.pydev.core.IGrammarVersionProvider;
@@ -148,6 +148,7 @@ import org.python.pydev.plugin.preferences.PydevPrefs;
 import org.python.pydev.shared_core.callbacks.CallbackWithListeners;
 import org.python.pydev.shared_core.callbacks.ICallback;
 import org.python.pydev.shared_core.callbacks.ICallbackWithListeners;
+import org.python.pydev.shared_core.io.FileUtils;
 import org.python.pydev.shared_core.model.ErrorDescription;
 import org.python.pydev.shared_core.model.ISimpleNode;
 import org.python.pydev.shared_core.parsing.BaseParser.ParseOutput;
@@ -989,35 +990,39 @@ public class PyEdit extends PyEditProjection implements IPyEdit, IGrammarVersion
     private void fixEncoding(final IEditorInput input, IDocument document) {
         if (input instanceof FileEditorInput) {
             final IFile file = ((FileEditorInput) input).getAdapter(IFile.class);
+            String fileEncoding;
             try {
-                final String encoding = FileUtilsFileBuffer.getPythonFileEncoding(document, file.getFullPath()
-                        .toOSString());
-                if (encoding != null) {
-                    try {
-                        if (encoding.equals(file.getCharset()) == false) {
+                fileEncoding = FileUtils.getPythonFileEncoding(document.get(), file.getFullPath().toOSString());
+            } catch (UnsupportedEncodingException e) {
+                fileEncoding = null;
+            }
+            // If the file does not specify an encoding, or the encoding is not supported, we have nothing to do
+            if (fileEncoding == null) {
+                return;
+            }
+            // Proceed with the job if we know the encoding
+            final String encoding = fileEncoding;
+            try {
+                if (encoding.equals(file.getCharset()) == false) {
 
-                            new Job("Change encoding") {
+                    new Job("Change encoding") {
 
-                                @Override
-                                protected IStatus run(IProgressMonitor monitor) {
-                                    try {
-                                        file.setCharset(encoding, monitor);
-                                        ((TextFileDocumentProvider) getDocumentProvider()).setEncoding(input, encoding);
-                                        //refresh it...
-                                        file.refreshLocal(IResource.DEPTH_INFINITE, null);
-                                    } catch (CoreException e) {
-                                        Log.log(e);
-                                    }
-                                    return Status.OK_STATUS;
-                                }
-
-                            }.schedule();
+                        @Override
+                        protected IStatus run(IProgressMonitor monitor) {
+                            try {
+                                file.setCharset(encoding, monitor);
+                                ((TextFileDocumentProvider) getDocumentProvider()).setEncoding(input, encoding);
+                                //refresh it...
+                                file.refreshLocal(IResource.DEPTH_INFINITE, null);
+                            } catch (CoreException e) {
+                                Log.log(e);
+                            }
+                            return Status.OK_STATUS;
                         }
-                    } catch (CoreException e) {
-                        Log.log(e);
-                    }
+
+                    }.schedule();
                 }
-            } catch (Exception e) {
+            } catch (CoreException e) {
                 Log.log(e);
             }
         }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyFormatStd.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/actions/PyFormatStd.java
@@ -13,8 +13,7 @@ package org.python.pydev.editor.actions;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -466,9 +465,15 @@ public class PyFormatStd extends PyAction implements IFormatter {
                 defaultInterpreterInfo.getExecutableOrJar(), autopep8File.toString(),
                 lst.toArray(new String[0]));
 
-        Reader inputStreamReader = new StringReader(fileContents);
-        String pythonFileEncoding = FileUtils.getPythonFileEncoding(inputStreamReader, null);
-        if (pythonFileEncoding == null) {
+        // Try to find the file's encoding, but if none is given or the specified encoding is
+        // unsupported, then just default to utf-8
+        String pythonFileEncoding = null;
+        try {
+            pythonFileEncoding = FileUtils.getPythonFileEncoding(fileContents, null);
+            if (pythonFileEncoding == null) {
+                pythonFileEncoding = "utf-8";
+            }
+        } catch (UnsupportedEncodingException e) {
             pythonFileEncoding = "utf-8";
         }
         final String encodingUsed = pythonFileEncoding;

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelperTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/editor/codecompletion/revisited/PythonPathHelperTest.java
@@ -11,7 +11,6 @@
  */
 package org.python.pydev.editor.codecompletion.revisited;
 
-import java.io.CharArrayReader;
 import java.io.File;
 import java.util.Collection;
 import java.util.Map;
@@ -25,6 +24,7 @@ import org.python.pydev.core.TestDependent;
 import org.python.pydev.core.structure.CompletionRecursionException;
 import org.python.pydev.editor.codecompletion.revisited.modules.CompiledModule;
 import org.python.pydev.shared_core.io.FileUtils;
+import org.python.pydev.shared_core.io.PyUnsupportedEncodingException;
 
 /**
  * @author Fabio Zadrozny
@@ -322,78 +322,111 @@ public class PythonPathHelperTest extends CodeCompletionTestsBase {
     public void testGetEncoding2() {
         String s = "" + "#test.py\n" + "# handles encoding and decoding of xmlBlaster socket protocol \n" + "\n" + "\n"
                 + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals(null, encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals(null, encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding3() {
-        //silent it in the tests
-        FileUtils.LOG_ENCODING_ERROR = false;
         try {
-            String s = "" + "#coding: foo_1\n" + //not valid encoding... will show in log but will not throw error
+            String s = "" + "#coding: foo_1\n" + //not valid encoding...
                     "# handles encoding and decoding of xmlBlaster socket protocol \n" + "\n" + "\n" + "";
-            CharArrayReader reader = new CharArrayReader(s.toCharArray());
-            String encoding = FileUtils.getPythonFileEncoding(reader, null);
-            assertEquals(null, encoding);
-        } finally {
-            FileUtils.LOG_ENCODING_ERROR = true;
+            FileUtils.getPythonFileEncoding(s, null);
+            fail();
+        } catch (PyUnsupportedEncodingException e) {
+            assertEquals("foo_1", e.getMessage());
         }
     }
 
     public void testGetEncoding4() {
         String s = "" + "#coding: utf-8\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("utf-8", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("utf-8", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding5() {
         String s = "" + "#-*- coding: utf-8; -*-\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("utf-8", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("utf-8", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding6() {
         String s = "" + "#coding: utf-8;\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("utf-8", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("utf-8", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding7() {
         String s = "" + "#coding: utf8;\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("utf8", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("utf8", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding8() {
         String s = "" + "#coding: iso-latin-1-unix;\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("latin1", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("latin1", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding9() {
         String s = "" + "#coding: latin-1\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("latin1", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("latin1", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding10() {
         String s = "" + "#coding: latin1\n" + "\n" + "";
-        CharArrayReader reader = new CharArrayReader(s.toCharArray());
-        String encoding = FileUtils.getPythonFileEncoding(reader, null);
-        assertEquals("latin1", encoding);
+        String encoding;
+        try {
+            encoding = FileUtils.getPythonFileEncoding(s, null);
+            assertEquals("latin1", encoding);
+        } catch (PyUnsupportedEncodingException e) {
+            fail();
+        }
     }
 
     public void testGetEncoding() {
         String loc = TestDependent.TEST_PYSRC_LOC + "testenc/encutf8.py";
-        String encoding = FileUtils.getPythonFileEncoding(new File(loc));
-        assertEquals("UTF-8", encoding);
+        try {
+            String encoding = FileUtils.getPythonFileEncoding(new File(loc));
+            assertEquals("UTF-8", encoding);
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     public void testValidInitFile() throws Exception {


### PR DESCRIPTION
Refactors the getPythonFileEncoding methods so that we can tell the
difference between "no encoding was declared" and "the declared
encoding is invalid" so that we can use the information during code
analysis to create problem markers in the latter case.

Previously, when Pydev detected an unsupported encoding, it would
just dump a stacktrace into the log and silently continue without
informing the user. With this change, Pydev will inform the user
instead of polluting the log.

Signed-off-by: Mat Booth <mat.booth@redhat.com>