### PR TITLE
PyDev-860 / RAP-434 Ensure pydevconsole.py dies if parent eclipse does

### DIFF
--- a/plugins/org.python.pydev/pysrc/pydevconsole.py
+++ b/plugins/org.python.pydev/pysrc/pydevconsole.py
@@ -508,6 +508,17 @@ if __name__ == '__main__':
     port, client_port = sys.argv[1:3]
     from _pydev_bundle import pydev_localhost
 
+    # Automatically tear down the console if the parent Eclipse goes away
+    # https://www.brainwy.com/tracker/PyDev/860
+    import time
+    def exit_on_parent_death():
+        while True:
+            time.sleep(5)
+            # http://stackoverflow.com/questions/269494/how-can-i-cause-a-child-process-to-exit-when-the-parent-does
+            if os.getppid() == 1:
+                do_exit()
+    thread.start_new_thread(exit_on_parent_death, ())
+
     if int(port) == 0 and int(client_port) == 0:
         (h, p) = pydev_localhost.get_socket_name()
 


### PR DESCRIPTION
If Eclipse dies suddenly then the pydevconsole may persist. This change
ensure that the pydev console is killed if the parent process goes
away.