### PR TITLE
Fix translations for the interactive console view

### DIFF
--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.java
@@ -13,7 +13,7 @@ import org.eclipse.osgi.util.NLS;
 
 public class ScriptConsoleMessages extends NLS {
 
-    private static final String BUNDLE_NAME = "org.python.pydev.core.interactive_console.internal.ScriptConsoleMessages"; //$NON-NLS-1$
+    private static final String BUNDLE_NAME = ScriptConsoleMessages.class.getName();
 
     public static String SaveSessionAction;
 
@@ -30,6 +30,10 @@ public class ScriptConsoleMessages extends NLS {
     public static String InterruptConsoleAction;
 
     public static String InterruptConsoleTooltip;
+
+    public static String WordWrapConsoleAction;
+
+    public static String WordWrapConsoleTooltip;
 
     static {
         NLS.initializeMessages(BUNDLE_NAME, ScriptConsoleMessages.class);

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.properties
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.properties
@@ -6,3 +6,5 @@ LinkWithDebugAction = Link with Debug
 LinkWithDebugToolTip = Link with Debug Selection
 InterruptConsoleAction = Interrupt
 InterruptConsoleTooltip = Interrupt current console
+WordWrapConsoleAction = Word Wrap
+WordWrapConsoleTooltip = Toggles word-wrap in console

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsolePage.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsolePage.java
@@ -82,7 +82,8 @@ public class ScriptConsolePage extends TextConsolePage implements IScriptConsole
         // saveSessionAction = new SaveConsoleSessionAction((ScriptConsole) getConsole(),
         //        ScriptConsoleMessages.SaveSessionAction, ScriptConsoleMessages.SaveSessionTooltip);
 
-        wordWrapAction = new WordWrapAction((ScriptConsole) getConsole(), "Word Wrap", "Toggles word-wrap in console.");
+        wordWrapAction = new WordWrapAction((ScriptConsole) getConsole(),
+                ScriptConsoleMessages.WordWrapConsoleAction, ScriptConsoleMessages.WordWrapConsoleTooltip);
 
         closeConsoleAction = new CloseScriptConsoleAction((ScriptConsole) getConsole(),
                 ScriptConsoleMessages.TerminateConsoleAction, ScriptConsoleMessages.TerminateConsoleTooltip);


### PR DESCRIPTION
In the latest Pydev (6.3.2) we noticed that the translations for the interactive console actions were broken

See this screenshot for an illustration of the problem: https://ibin.co/3xKYxpoJHNMO.jpg

Signed-off-by: Mat Booth <mat.booth@redhat.com>

