### PR TITLE
More robust creation of the coverage.xml

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/pydev_coverage.py
+++ b/plugins/org.python.pydev.core/pysrc/pydev_coverage.py
@@ -10,15 +10,15 @@ def is_valid_py_file(path):
     '''
     import os
 
-    isValid = False
+    is_valid = False
     if os.path.isfile(path) and not os.path.splitext(path)[1] == '.pyx':
         try:
             with open(path, 'r') as f:
                 compile(f.read(), path, 'exec')
-                isValid = True
+                is_valid = True
         except:
             pass
-    return isValid
+    return is_valid
 
 
 def execute():
@@ -41,10 +41,14 @@ def execute():
                 s = input()
             s = s.replace('\r', '')
             s = s.replace('\n', '')
-            all_files = s.split('|')
 
-            files = [v for v in all_files if is_valid_py_file(v)]
-            invalid_files = [v for v in all_files if v and v not in files]
+            files = []
+            invalid_files = []
+            for v in s.split('|'):
+                if is_valid_py_file(v):
+                    files.append(v)
+                else:
+                    invalid_files.append(v)
             if invalid_files:
                 sys.stderr.write('Invalid files not passed to coverage: %s'
                                  % ', '.join(invalid_files))

--- a/plugins/org.python.pydev.core/pysrc/pydev_coverage.py
+++ b/plugins/org.python.pydev.core/pysrc/pydev_coverage.py
@@ -2,6 +2,25 @@
 Entry point module to run code-coverage.
 '''
 
+
+def is_valid_py_file(path):
+    '''
+    Checks whether the file can be read by the coverage module. This is especially
+    needed for .pyx files and .py files with syntax errors.
+    '''
+    import os
+
+    isValid = False
+    if os.path.isfile(path) and not os.path.splitext(path)[1] == '.pyx':
+        try:
+            with open(path, 'r') as f:
+                compile(f.read(), path, 'exec')
+                isValid = True
+        except:
+            pass
+    return isValid
+
+
 def execute():
     import os
     import sys
@@ -22,15 +41,20 @@ def execute():
                 s = input()
             s = s.replace('\r', '')
             s = s.replace('\n', '')
-            files = s.split('|')
-            files = [v for v in files if len(v) > 0]
+            all_files = s.split('|')
 
-            #Note that in this case we'll already be in the working dir with the coverage files, so, the
-            #coverage file location is not passed.
+            files = [v for v in all_files if is_valid_py_file(v)]
+            invalid_files = [v for v in all_files if v and v not in files]
+            if invalid_files:
+                sys.stderr.write('Invalid files not passed to coverage: %s'
+                                 % ', '.join(invalid_files))
+
+            #Note that in this case we'll already be in the working dir with the coverage files, 
+            #so, the coverage file location is not passed.
 
         else:
-            #For all commands, the coverage file is configured in pydev, and passed as the first argument
-            #in the command line, so, let's make sure this gets to the coverage module.
+            #For all commands, the coverage file is configured in pydev, and passed as the first 
+            #argument in the command line, so, let's make sure this gets to the coverage module.
             os.environ['COVERAGE_FILE'] = sys.argv[1]
             del sys.argv[1]
 
@@ -38,18 +62,24 @@ def execute():
         import coverage #@UnresolvedImport
     except:
         sys.stderr.write('Error: coverage module could not be imported\n')
-        sys.stderr.write('Please make sure that the coverage module (http://nedbatchelder.com/code/coverage/)\n')
+        sys.stderr.write('Please make sure that the coverage module '
+                         '(http://nedbatchelder.com/code/coverage/)\n')
         sys.stderr.write('is properly installed in your interpreter: %s\n' % (sys.executable,))
 
         import traceback;traceback.print_exc()
         return
-    
-    version = tuple(map(int, coverage.__version__.split('.')[:2]))
-    if version < (4, 3):
-        sys.stderr.write('Error: minimum supported coverage version is 4.3.\nFound: %s\nLocation: %s' % ('.'.join(str(x) for x in version), coverage.__file__))
-        sys.exit(1)
 
-    #print(coverage.__version__) TODO: Check if the version is a version we support (should be at least 3.4) -- note that maybe the attr is not there.
+    if hasattr(coverage, '__version__'):
+        version = tuple(map(int, coverage.__version__.split('.')[:2]))
+        if version < (4, 3):
+            sys.stderr.write('Error: minimum supported coverage version is 4.3.'
+                             '\nFound: %s\nLocation: %s' 
+                             % ('.'.join(str(x) for x in version), coverage.__file__))
+            sys.exit(1)
+    else:
+        sys.stderr.write('Warning: Could not determine version of python module coverage.'
+                         '\nEnsure coverage version is >= 4.3')
+
     from coverage.cmdline import main #@UnresolvedImport
 
     if files is not None:


### PR DESCRIPTION
Hi!

It took me some time to work out, why my code coverage is not shown in eclipse.  I realized that an advanced .pyx file prevented the whole coverage.xml generation. This behaviour also applies to regular python files with syntax errors.

Another solution would be to limit the files handles by the Code Coverage view to .py files.

In addition I tried to fix the little TODO ;-)