### PR TITLE
Added instructions on venv creation

### DIFF
--- a/plugins/com.python.pydev.docs/homepage/manual_101_interpreter.contents.html
+++ b/plugins/com.python.pydev.docs/homepage/manual_101_interpreter.contents.html
@@ -50,6 +50,9 @@ and add those to the system installation. </p>
 button and select the Python executable in the virtual environment -- just take care to <strong>double check the folders</strong> which are selected
 when the virtual environment executable is used to make sure that you leave checked the <strong>/Lib</strong> folder from the base interpreter <strong>if</strong> the virtual environment
 inherits the <strong>PYTHONPATH</strong> from a base installation).</p> 
+	
+<p> <strong>venv</strong> is the recommended way of managing virtual environments starting from Python 3.5. By default, venv will only symlinks to Python interpreter, and this
+will cause the pip of the created virtual environments in Pydev showing all system installed site-packages. To get it displayed correctly, you will need to append "--copies" to the "python3 -m venv /path/to/venv"</p>
 
 
 <h1><a name="PyDevInterpreterConfiguration-Whatifitisnotcorrect%3F"></a>What if it is not correct?</h1>


### PR DESCRIPTION
Starting from Python 3.5, "venv" is recommended for managing Python virtual environments. 
The default options will only symlink to existing python interpreters, and this will cause pip in Pydev intervene system level site-packages, we need to create virtual environments by passing a "--copies" as "python3 -m venv /path/to/venv --copies" to make it working correctly.