### PR TITLE
Ignore zero-length files

### DIFF
--- a/plugins/org.python.pydev.core/META-INF/MANIFEST.MF
+++ b/plugins/org.python.pydev.core/META-INF/MANIFEST.MF
@@ -14,7 +14,8 @@ Require-Bundle: org.junit;bundle-version="4.0.0";resolution:=optional,
  org.eclipse.core.variables,
  org.eclipse.text,
  org.python.pydev.shared_core;bundle-version="[6.4.4,6.4.5)";visibility:=reexport,
- org.eclipse.ltk.core.refactoring
+ org.eclipse.ltk.core.refactoring,
+ org.eclipse.core.filesystem
 Bundle-ActivationPolicy: lazy
 Export-Package: org.python.copiedfromeclipsesrc,
  org.python.pydev.core,

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
@@ -14,6 +14,8 @@ import java.io.Reader;
 import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
+import org.eclipse.core.filesystem.EFS;
+import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -188,6 +190,12 @@ public class CorePlugin extends Plugin {
         try {
             editorID = file.getPersistentProperty(EDITOR_KEY);
             if (editorID == null) {
+                // Ignore zero-length files
+                IFileStore store = EFS.getStore(file.getLocationURI());
+                if (store != null && store.fetchInfo().getLength() <= 0) {
+                    return false;
+                }
+
                 InputStream contents = file.getContents(true);
                 Reader inputStreamReader = new InputStreamReader(new BufferedInputStream(contents));
                 if (FileUtils.hasPythonShebang(inputStreamReader)) {


### PR DESCRIPTION
On Linux, some special files such as named pipes may present as zero-length files. When PyDev attempts to read these with a blocking read, it blocks the UI thread indefinitely if the pipe contains no data. By simply checking if the file is zero-length before reading it PyDev can avoid this.