### PR TITLE
control ScrollLock state for interactive console

### DIFF
--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
@@ -110,6 +110,11 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
      */
     private List<IConsoleLineTracker> consoleLineTrackers;
 
+    /**
+     * scrollLock state flag, controls revealEndOfDocument().
+     */
+    private boolean scrollLock = false;
+
     public IHandleScriptAutoEditStrategy getIndentStrategy() {
         return strategy;
     }
@@ -414,7 +419,9 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
                 Log.log(e);
             }
         }
-        revealEndOfDocument();
+        if (!this.scrollLock) {
+            revealEndOfDocument();
+        }
     }
 
     /**
@@ -1065,6 +1072,14 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
         } finally {
             stopDisconnected();
         }
+    }
+
+    /**
+     * control ScrollLock state.
+     * @param scrollLock state true or false.
+     */
+    public void setScrollLock(boolean state) {
+        this.scrollLock = state;
     }
 
 }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
@@ -978,4 +978,8 @@ public class ScriptConsoleViewer extends TextConsoleViewer implements IScriptCon
     public void discardCommandLine() {
         listener.discardCommandLine();
     }
+
+    public void setScrollLock(boolean scrollLock) {
+        listener.setScrollLock(scrollLock);
+    }
 }


### PR DESCRIPTION
Added a flag to control scroll lock state for interactive console.
default is false (normal auto scroll behaviour)
exposed an API in ScriptConsoleViewer to control the state.
[https://www.brainwy.com/tracker/PyDev/920](https://www.brainwy.com/tracker/PyDev/920)

also would like in the future to add an 'action' button in that console viewer to reflect and control scrollLock state  like in a default IOConsole.