### PR TITLE
implement new scrollLock action for interactive console

### DIFF
--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleDocumentListener.java
@@ -110,6 +110,11 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
      */
     private List<IConsoleLineTracker> consoleLineTrackers;
 
+    /**
+     * scrollLock state flag, controls revealEndOfDocument().
+     */
+    private boolean scrollLock = false;
+
     public IHandleScriptAutoEditStrategy getIndentStrategy() {
         return strategy;
     }
@@ -414,7 +419,9 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
                 Log.log(e);
             }
         }
-        revealEndOfDocument();
+        if (!this.scrollLock) {
+            revealEndOfDocument();
+        }
     }
 
     /**
@@ -1065,6 +1072,21 @@ public class ScriptConsoleDocumentListener implements IDocumentListener {
         } finally {
             stopDisconnected();
         }
+    }
+
+    /**
+     * control ScrollLock state.
+     * @param scrollLock state true or false.
+     */
+    public void setScrollLock(boolean state) {
+        scrollLock = state;
+    }
+
+    /**
+     * @return ScrollLock state.
+     */
+    public boolean getScrollLock() {
+        return scrollLock;
     }
 
 }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.java
@@ -35,6 +35,10 @@ public class ScriptConsoleMessages extends NLS {
 
     public static String WordWrapConsoleTooltip;
 
+    public static String ScrollLockConsoleAction;
+
+    public static String ScrollLockConsoleTooltip;
+
     static {
         NLS.initializeMessages(BUNDLE_NAME, ScriptConsoleMessages.class);
     }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.properties
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleMessages.properties
@@ -8,3 +8,5 @@ InterruptConsoleAction = Interrupt
 InterruptConsoleTooltip = Interrupt current console
 WordWrapConsoleAction = Word Wrap
 WordWrapConsoleTooltip = Toggles word-wrap in console
+ScrollLockConsoleAction = Scroll Lock
+ScrollLockConsoleTooltip = Toggles scroll-lock in console

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsolePage.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsolePage.java
@@ -26,6 +26,7 @@ import org.eclipse.ui.console.actions.TextViewerAction;
 import org.python.pydev.shared_interactive_console.console.ui.ScriptConsole;
 import org.python.pydev.shared_interactive_console.console.ui.internal.actions.CloseScriptConsoleAction;
 import org.python.pydev.shared_interactive_console.console.ui.internal.actions.InterruptScriptConsoleAction;
+import org.python.pydev.shared_interactive_console.console.ui.internal.actions.ScrollLockAction;
 import org.python.pydev.shared_interactive_console.console.ui.internal.actions.WordWrapAction;
 
 public class ScriptConsolePage extends TextConsolePage implements IScriptConsoleContentHandler {
@@ -72,6 +73,8 @@ public class ScriptConsolePage extends TextConsolePage implements IScriptConsole
 
     private WordWrapAction wordWrapAction;
 
+    private ScrollLockAction scrollLockAction;
+
     @Override
     protected void createActions() {
         super.createActions();
@@ -81,6 +84,9 @@ public class ScriptConsolePage extends TextConsolePage implements IScriptConsole
 
         // saveSessionAction = new SaveConsoleSessionAction((ScriptConsole) getConsole(),
         //        ScriptConsoleMessages.SaveSessionAction, ScriptConsoleMessages.SaveSessionTooltip);
+
+        scrollLockAction = new ScrollLockAction((ScriptConsole) getConsole(),
+                ScriptConsoleMessages.ScrollLockConsoleAction, ScriptConsoleMessages.ScrollLockConsoleTooltip);
 
         wordWrapAction = new WordWrapAction((ScriptConsole) getConsole(),
                 ScriptConsoleMessages.WordWrapConsoleAction, ScriptConsoleMessages.WordWrapConsoleTooltip);
@@ -103,6 +109,8 @@ public class ScriptConsolePage extends TextConsolePage implements IScriptConsole
         // toolbarManager.appendToGroup(SCRIPT_GROUP, saveSessionAction);
 
         toolbarManager.appendToGroup(SCRIPT_GROUP, interruptConsoleAction);
+
+        toolbarManager.appendToGroup(SCRIPT_GROUP, scrollLockAction);
 
         toolbarManager.appendToGroup(SCRIPT_GROUP, wordWrapAction);
 

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/ScriptConsoleViewer.java
@@ -978,4 +978,12 @@ public class ScriptConsoleViewer extends TextConsoleViewer implements IScriptCon
     public void discardCommandLine() {
         listener.discardCommandLine();
     }
+
+    public void setScrollLock(boolean scrollLock) {
+        listener.setScrollLock(scrollLock);
+    }
+
+    public boolean getScrollLock() {
+        return listener.getScrollLock();
+    }
 }

--- a/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/ScrollLockAction.java
+++ b/plugins/org.python.pydev.shared_interactive_console/src/org/python/pydev/shared_interactive_console/console/ui/internal/actions/ScrollLockAction.java
@@ -1,0 +1,43 @@
+package org.python.pydev.shared_interactive_console.console.ui.internal.actions;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.eclipse.jface.action.Action;
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.python.pydev.shared_core.log.Log;
+import org.python.pydev.shared_interactive_console.console.ui.ScriptConsole;
+
+public class ScrollLockAction extends Action {
+
+    private ScriptConsole console;
+
+    public ScrollLockAction(ScriptConsole console, String text, String tooltip) {
+        this.console = console;
+        setText(text);
+        setToolTipText(tooltip);
+        update();
+    }
+
+    @Override
+    public void run() {
+        console.getViewer().setScrollLock(isChecked());
+        update();
+    }
+
+    private void update() {
+        setChecked(console.getViewer().getScrollLock());
+    }
+
+    @Override
+    public ImageDescriptor getImageDescriptor() {
+        try {
+            return ImageDescriptor
+                    .createFromURL(new URL("platform:/plugin/org.eclipse.ui.console/icons/full/elcl16/lock_co.png"));
+        } catch (MalformedURLException e) {
+            Log.log(e);
+            return null;
+        }
+    }
+
+}


### PR DESCRIPTION
i have implemented a 'Scroll Lock' action (button), for the interactive console, very similar in look and feel to the 'word wrap' action.
found it necessary  for continues printouts and loops..
[[https://www.brainwy.com/tracker/PyDev/920]](https://www.brainwy.com/tracker/PyDev/920)

Default behaviour will stay the same(normal scroll to end of text). click on the button will toggle scroll lock state.