### PR TITLE
Ticket 694: Add code folding functionality via the #region and #endregion tags

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/FoldingEntry.java
@@ -38,6 +38,7 @@ public class FoldingEntry {
     public final static int TYPE_ELSE = 6;
     public final static int TYPE_EXCEPT = 7;
     public final static int TYPE_FINALLY = 8;
+    public final static int TYPE_REGION = 9;
     public int type;
     public int startLine;
     public int endLine;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/PyDevCodeFoldingPrefPage.java
@@ -126,6 +126,14 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
 
     public static final boolean DEFAULT_INITIALLY_FOLD_FOR = false;
 
+    public static final String FOLD_REGION = "FOLD_REGION";
+
+    public static final boolean DEFAULT_FOLD_REGION = false;
+
+    public static final String INITIALLY_FOLD_REGION = "INITIALLY_FOLD_REGION";
+
+    public static final boolean DEFAULT_INITIALLY_FOLD_REGION = false;
+
     /**
      * 
      */
@@ -225,6 +233,10 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
         Button slaveFoldFor = addCheckBox(top, "Fold For statements?", FOLD_FOR, 0);
         Button slaveInitialCollapseFoldFor = addCheckBox(top, "Initially Fold For statements?", INITIALLY_FOLD_FOR, 0);
         createDependency(new Button[] { master, slaveFoldFor }, slaveInitialCollapseFoldFor, USE_CODE_FOLDING, FOLD_FOR);
+
+        Button slaveFoldRegion = addCheckBox(top, "Fold #region?", FOLD_REGION, 0);
+        Button slaveInitialCollapseFoldRegion = addCheckBox(top, "Initially Fold For #region?", INITIALLY_FOLD_REGION, 0);
+        createDependency(new Button[] { master, slaveFoldRegion }, slaveInitialCollapseFoldRegion, USE_CODE_FOLDING, FOLD_REGION);
 
         //[[[end]]]
 
@@ -395,6 +407,9 @@ public class PyDevCodeFoldingPrefPage extends PreferencePage implements IWorkben
 
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, FOLD_FOR));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, INITIALLY_FOLD_FOR));
+
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, FOLD_REGION));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.BOOLEAN, INITIALLY_FOLD_REGION));
 
         //[[[end]]]
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/DocstringsPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/correctionassist/docstrings/DocstringsPrefPage.java
@@ -42,6 +42,8 @@ public class DocstringsPrefPage extends FieldEditorPreferencePage implements IWo
 
     public static final String DOCSTRINGSTYLE_EPYDOC = "@";
 
+    public static final String DOCSTRINGSTYLE_GOOGLE = "";
+
     public static final String DEFAULT_P_DOCSTIRNGSTYLE = DOCSTRINGSTYLE_SPHINX;
 
     public static final String TYPETAG_GENERATION_NEVER = "Never";
@@ -158,7 +160,8 @@ public class DocstringsPrefPage extends FieldEditorPreferencePage implements IWo
 
         RadioGroupFieldEditor docstringStyleEditor = new RadioGroupFieldEditor(P_DOCSTRINGSTYLE, "Docstring style", 1,
                 new String[][] { { "Sphinx (:tag name:)", DOCSTRINGSTYLE_SPHINX },
-                        { "EpyDoc (@tag name:)", DOCSTRINGSTYLE_EPYDOC } },
+                        { "EpyDoc (@tag name:)", DOCSTRINGSTYLE_EPYDOC },
+                        { "Google (name:)", DOCSTRINGSTYLE_GOOGLE } },
                 p2, true);
         addField(docstringStyleEditor);
 

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
@@ -144,6 +144,7 @@ public class CodeFoldingSetterTest extends TestCase {
         preferences.putBoolean(PyDevCodeFoldingPrefPage.FOLD_TRY, value);
         preferences.putBoolean(PyDevCodeFoldingPrefPage.FOLD_WHILE, value);
         preferences.putBoolean(PyDevCodeFoldingPrefPage.FOLD_WITH, value);
+        preferences.putBoolean(PyDevCodeFoldingPrefPage.FOLD_REGION, value);
     }
 
     private void setOptionTrue(String option) {
@@ -587,4 +588,46 @@ public class CodeFoldingSetterTest extends TestCase {
 
         assertTrue(it.hasNext() == false);
     }
+
+    public void testRegion() throws Exception {
+        setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_REGION);
+        setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_COMMENTS);
+        setOptionTrue(PyDevCodeFoldingPrefPage.FOLD_IMPORTS);
+        setOptionTrue(PyDevCodeFoldingPrefPage.USE_CODE_FOLDING);
+        Document doc = new Document("" +
+                "import foo\n" +
+                "import foo2 \n" +
+                "\n" +
+                "#comment1\n" +
+                "#comment2\n" +
+                "#comment3\n" +
+                "\n" +
+                "#region 01\n" +
+                "some text\n" +
+                "#endregion 01\n" +
+                "\n" +
+                "\n" +
+                "#region 02 nested top level\n" +
+                "txt \n" +
+                "\n" +
+                "#region 03 nested inside region 2\n" +
+                "\n" +
+                "txt 3\n" +
+                "#endregion03\n" +
+                "txt\n" +
+                "\n" +
+                "#endregion 02" +
+                "\n");
+
+        List<FoldingEntry> marks = getMarks(doc);
+        System.out.println(marks);
+        Iterator<FoldingEntry> it = marks.iterator();
+        assertEquals(new FoldingEntry(FoldingEntry.TYPE_IMPORT, 0, 2, null), it.next());
+        assertEquals(new FoldingEntry(FoldingEntry.TYPE_COMMENT, 3, 6, null), it.next());
+        assertEquals(new FoldingEntry(FoldingEntry.TYPE_REGION, 7, 10, null), it.next());
+        assertEquals(new FoldingEntry(FoldingEntry.TYPE_REGION, 12, 22, null), it.next());
+        assertEquals(new FoldingEntry(FoldingEntry.TYPE_REGION, 15, 19, null), it.next());
+        assertTrue(it.hasNext() == false);
+    }
+
 }

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
@@ -613,14 +613,14 @@ public class CodeFoldingSetterTest extends TestCase {
                 "#region 03 nested inside region 2\n" +
                 "\n" +
                 "txt 3\n" +
-                "#endregion03\n" +
+                "#endregion 03\n" +
                 "txt\n" +
                 "\n" +
                 "#endregion 02" +
                 "\n");
 
         List<FoldingEntry> marks = getMarks(doc);
-        System.out.println(marks);
+
         Iterator<FoldingEntry> it = marks.iterator();
         assertEquals(new FoldingEntry(FoldingEntry.TYPE_IMPORT, 0, 2, null), it.next());
         assertEquals(new FoldingEntry(FoldingEntry.TYPE_COMMENT, 3, 6, null), it.next());


### PR DESCRIPTION
Passed unit testing. UI tests looked good although it is worth noting that several cases confuse the code folding. I think that is OK. As long as properly formatted '# region ', '#region ', '# endregion ', '#endregion ' (not the trailing space) tags are used the code folding works. 