### PR TITLE
Use editor based on content type rather than forcing it and fix some errors in watch expression

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyDebugModelPresentation.java
@@ -17,6 +17,7 @@ import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
+import org.eclipse.core.runtime.OperationCanceledException;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IValue;
 import org.eclipse.debug.core.model.IVariable;
@@ -27,9 +28,10 @@ import org.eclipse.debug.ui.IValueDetailListener;
 import org.eclipse.jface.viewers.ILabelProviderListener;
 import org.eclipse.swt.graphics.Image;
 import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.ide.IDE;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.debug.core.PydevDebugPlugin;
-import org.python.pydev.editor.PyEdit;
 import org.python.pydev.editorinput.EditorInputFactory;
 import org.python.pydev.shared_core.image.IImageCache;
 import org.python.pydev.shared_core.string.StringUtils;
@@ -301,11 +303,20 @@ public class PyDebugModelPresentation implements IDebugModelPresentation {
     }
 
     /**
-     * @see org.eclipse.debug.ui.ISourcePresentation#getEditorInput
+     * This was copied from {@link org.eclipse.jdt.internal.debug.ui.JDIModelPresentation.getEditorId(IEditorInput, Object)}.
+     * <p>
+     * Use {@link IDE#getEditorDescriptor(String)} rather than sending a static String; this'll open the editior
+     * attached to the file instead of always Python editor (which expect Python code).
+     * 
+     * @see <a href="http://git.eclipse.org/c/jdt/eclipse.jdt.debug.git/tree/org.eclipse.jdt.debug.ui/ui/org/eclipse/jdt/internal/debug/ui/JDIModelPresentation.java#n1216">JDIModelPresentation</a>
      */
     @Override
-    public String getEditorId(IEditorInput input, Object element) {
-        return PyEdit.EDITOR_ID;
+    public String getEditorId(final IEditorInput input, final Object element) {
+        try {
+            return IDE.getEditorDescriptor(input.getName(), true, false).getId();
+        } catch (@SuppressWarnings("unused") PartInitException | OperationCanceledException ignored) {
+            return null;
+        }
     }
 
     @Override

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariable.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariable.java
@@ -35,13 +35,14 @@ public class PyVariable extends PlatformObject implements IVariable, IValue, IVa
 
     protected String name;
     protected String type;
+    protected String qualifier;
     protected String value;
     protected AbstractDebugTarget target;
     protected boolean isModified;
     protected IVariableLocator locator;
 
     //Only create one instance of an empty array to be returned
-    private static final IVariable[] EMPTY_IVARIABLE_ARRAY = new IVariable[0];
+    static final IVariable[] EMPTY_IVARIABLE_ARRAY = new IVariable[0];
 
     public PyVariable(AbstractDebugTarget target, String name, String type, String value, IVariableLocator locator) {
         this.value = value;
@@ -264,4 +265,13 @@ public class PyVariable extends PlatformObject implements IVariable, IValue, IVa
     public boolean isErrorOnEval() {
         return isErrorOnEval;
     }
+
+    public String getQualifier() {
+        return qualifier;
+    }
+
+    public void setQualifier(String qualifier) {
+        this.qualifier = qualifier;
+    }
+
 }

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableCollection.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariableCollection.java
@@ -29,11 +29,6 @@ public class PyVariableCollection extends PyVariable
 
     private final ContainerOfVariables variableContainer = new ContainerOfVariables(this, false);
 
-    /**
-     * Defines whether object is variable or watchExpression
-     */
-    boolean isWatchExpression = false;
-
     public PyVariableCollection(AbstractDebugTarget target, String name, String type, String value,
             IVariableLocator locator) {
         super(target, name, type, value, locator);

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyWatchExpressionDelegate.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyWatchExpressionDelegate.java
@@ -15,8 +15,10 @@ import java.util.Arrays;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.debug.core.DebugException;
+import org.eclipse.debug.core.model.DebugElement;
 import org.eclipse.debug.core.model.IDebugElement;
 import org.eclipse.debug.core.model.IValue;
+import org.eclipse.debug.core.model.IVariable;
 import org.eclipse.debug.core.model.IWatchExpressionDelegate;
 import org.eclipse.debug.core.model.IWatchExpressionListener;
 import org.eclipse.debug.core.model.IWatchExpressionResult;
@@ -28,7 +30,8 @@ import org.python.pydev.debug.model.remote.ICommandResponseListener;
 public class PyWatchExpressionDelegate implements IWatchExpressionDelegate, IWatchExpressionResult,
         ICommandResponseListener {
 
-    protected PyVariable variables[] = new PyVariable[0];
+    private final Object sync = new Object();
+    protected IValue value = null;
     protected IDebugElement context;
     protected String expression;
     protected IWatchExpressionListener listener;
@@ -60,20 +63,15 @@ public class PyWatchExpressionDelegate implements IWatchExpressionDelegate, IWat
         }
     }
 
-    protected String errors[] = new String[0];
+    protected String[] errors = new String[0];
 
     /* (non-Javadoc)
      * @see org.eclipse.debug.core.model.IWatchExpressionResult#getValue()
      */
     @Override
     public IValue getValue() {
-        synchronized (variables) {
-            if (variables.length == 0) {
-                variables = new PyVariable[1];
-                variables[0] = new PyVariable((AbstractDebugTarget) context.getDebugTarget(), "Error", "pydev ERROR",
-                        "Could not resolve variable", null);
-            }
-            return variables[0];
+        synchronized (sync) {
+            return value;
         }
     }
 
@@ -109,9 +107,9 @@ public class PyWatchExpressionDelegate implements IWatchExpressionDelegate, IWat
         return null;
     }
 
-    public void addError(String error_string) {
+    public void addError(String message) {
         errors = Arrays.copyOf(errors, errors.length + 1);
-        errors[errors.length - 1] = error_string;
+        errors[errors.length - 1] = message;
     }
 
     /* (non-Javadoc)
@@ -121,24 +119,83 @@ public class PyWatchExpressionDelegate implements IWatchExpressionDelegate, IWat
     public void commandComplete(AbstractDebuggerCommand cmd) {
         try {
             String payload = ((EvaluateExpressionCommand) cmd).getResponse();
-            synchronized (variables) {
-                variables = XMLUtils.XMLToVariables((AbstractDebugTarget) context.getDebugTarget(),
-                        ((PyStackFrame) context).getExpressionLocator(), payload);
+            PyVariable[] variables = XMLUtils.XMLToVariables((AbstractDebugTarget) context.getDebugTarget(),
+                    ((PyStackFrame) context).getExpressionLocator(), payload);
+            IValue value = newValue(variables);
+            synchronized (sync) {
+                this.value = value;
             }
+
         } catch (CoreException e) {
-            synchronized (variables) {
-                variables = new PyVariable[1];
-                variables[0] = new PyVariable((PyDebugTarget) context.getDebugTarget(), "Error", "pydev ERROR",
-                        "Could not resolve variable", null);
-            }
+            addError("Evaluation of " + this.getExpressionText() + " failed: " + e.getMessage());
             PydevDebugPlugin.log(IStatus.ERROR, "Error fetching a variable", e);
-        }
-        synchronized (variables) {
-            if (variables[0] instanceof PyVariableCollection) {
-                ((PyVariableCollection) variables[0]).isWatchExpression = true;
-            }
         }
 
         listener.watchEvaluationFinished(this);
+    }
+
+    private IValue newValue(PyVariable[] variables) {
+        if (null == variables || variables.length == 0) {
+            addError("Evaluation of " + this.getExpressionText() + " failed: no variables.");
+            return null; // see #getValue(), implies evaluation failure.
+        }
+        if (variables.length == 1) {
+            return variables[0];
+        }
+        return new WatchExpressionValue(this.context, variables);
+    }
+
+    public static class WatchExpressionValue extends DebugElement implements IValue {
+        private final IVariable[] variables;
+
+        public WatchExpressionValue(IDebugElement context, IVariable[] variables) {
+            super(context.getDebugTarget());
+            this.variables = variables;
+        }
+
+        @Override
+        public String getModelIdentifier() {
+            return this.getDebugTarget().getModelIdentifier();
+        }
+
+        @Override
+        public String getReferenceTypeName() throws DebugException {
+            return null;
+        }
+
+        @Override
+        public String getValueString() throws DebugException {
+            boolean first = true;
+            StringBuilder sb = new StringBuilder().append("{");
+            for (IVariable variable : variables) {
+                if (first) {
+                    first = false;
+                } else {
+                    sb.append(", ");
+                }
+                IValue val = variable.getValue();
+                sb.append(variable.getName()).append(": ").append(val == null ? "<error>" : val.getValueString());
+            }
+            return sb.append("}").toString();
+        }
+
+        @Override
+        public boolean isAllocated() throws DebugException {
+            return false;
+        }
+
+        @Override
+        public IVariable[] getVariables() throws DebugException {
+            if (hasVariables()) {
+                return Arrays.copyOf(variables, variables.length);
+            }
+            return PyVariable.EMPTY_IVARIABLE_ARRAY;
+        }
+
+        @Override
+        public boolean hasVariables() throws DebugException {
+            return variables.length > 0;
+        }
+
     }
 }


### PR DESCRIPTION
This PR provides several stuff:

1. A fix on the editor opened by default when clicking on a breakpoint (see e678894); 
2. A fix to read the qualifier returned by the <var /> tag
3. A fix when the <xml /> is empty, leaving ArrayIndexOutOfBoundsException


