### PR TITLE
Add option to disable CPython package manager buttons

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PackageTab.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/pythonpathconf/PackageTab.java
@@ -97,6 +97,9 @@ public class PackageTab {
             GridLayout layout = new GridLayout();
             layout.marginWidth = 0;
             boxPackage.setLayout(layout);
+            String packageManagersDisableProperty = System.getProperty("pydev.packagemanagers.disable", "false");
+            boolean packageManagersDisable = packageManagersDisableProperty.equalsIgnoreCase("true")
+                    || packageManagersDisableProperty.equalsIgnoreCase("1");
             btPip = AbstractInterpreterEditor.createBt(boxPackage, "Manage with pip",
                     new SelectionAdapter() {
                         @Override
@@ -134,6 +137,12 @@ public class PackageTab {
                                 update();
                             }
                         });
+            }
+
+            if (packageManagersDisable) {
+                btPip.setEnabled(false);
+                btPipenv.setEnabled(false);
+                btConda.setEnabled(false);
             }
             // Commented out for now (needs more time to properly integrate).
             // In this case we'd do wrappers and launch using them instead of launching Python itself -- see:


### PR DESCRIPTION
This would be useful whenever the user should not be allowed to (easily)
make changes to the conda or pip environments.

We work at a facility with a conda installation that is used by hundreds of users, with many using PyDev, and of which a substantial subset have sufficient privileges to modify the environment, even though that may be a bad idea...

This commit introduces support for a system property whose value will be checked to determine whether the package manager buttons in the CPython interpreter preferences screen should be enabled or disabled. The default will be to enable them.