### PR TITLE
Fix ticket number in changelog

### DIFF
--- a/plugins/com.python.pydev.docs/homepage/final/history_pydev.html
+++ b/plugins/com.python.pydev.docs/homepage/final/history_pydev.html
@@ -1167,7 +1167,7 @@
 <ul class="simple">
 <li>The (fast) parser which detects the outline of a Python module now handles mixed indentation (and additional fixes which could result in log entries such as &quot;Did not expect to find item below node: Assign...&quot;).</li>
 <li>Support for unpacking generalizations (PEP 448) which could still result in a syntax error for the Python 3 grammar (#PyDev-701).</li>
-<li>Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-184, patch by Wesley Barroso Lopes)</li>
+<li>Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-622, patch by Wesley Barroso Lopes)</li>
 </ul>
 </blockquote>
 </li>

--- a/plugins/com.python.pydev.docs/homepage/history_pydev.contents.rst_html
+++ b/plugins/com.python.pydev.docs/homepage/history_pydev.contents.rst_html
@@ -894,7 +894,7 @@
 <ul class="simple">
 <li>The (fast) parser which detects the outline of a Python module now handles mixed indentation (and additional fixes which could result in log entries such as &quot;Did not expect to find item below node: Assign...&quot;).</li>
 <li>Support for unpacking generalizations (PEP 448) which could still result in a syntax error for the Python 3 grammar (#PyDev-701).</li>
-<li>Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-184, patch by Wesley Barroso Lopes)</li>
+<li>Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-622, patch by Wesley Barroso Lopes)</li>
 </ul>
 </blockquote>
 </li>

--- a/plugins/com.python.pydev.docs/homepage/history_pydev.rst
+++ b/plugins/com.python.pydev.docs/homepage/history_pydev.rst
@@ -621,7 +621,7 @@ Release 5.2.0 (2016-08-17)
 
     * The (fast) parser which detects the outline of a Python module now handles mixed indentation (and additional fixes which could result in log entries such as "Did not expect to find item below node: Assign...").
     * Support for unpacking generalizations (PEP 448) which could still result in a syntax error for the Python 3 grammar (#PyDev-701).
-    * Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-184, patch by Wesley Barroso Lopes)
+    * Fixed error in code analysis when the code is connected to an RTC source control (#PyDev-622, patch by Wesley Barroso Lopes)
 
 Release 5.1.2 (2016-06-23)
 ===========================


### PR DESCRIPTION
If I understand correctly, when we have ```#PyDev-xxx``` in the changelog, ```xxx``` refers to the ticket https://www.brainwy.com/tracker/PyDev.

PR #184 fix ticket https://www.brainwy.com/tracker/PyDev/622 and not tickt ```184```. I think you have put the PR number instead of the ticket number.