### PR TITLE
Always initialize preference defaults using the extension point

### DIFF
--- a/plugins/com.python.pydev.analysis/plugin.xml
+++ b/plugins/com.python.pydev.analysis/plugin.xml
@@ -12,7 +12,9 @@
 
 
    <extension point="org.eclipse.core.runtime.preferences">
+      <initializer class="com.python.pydev.analysis.pylint.PyLintPrefInitializer"/>
       <initializer class="com.python.pydev.analysis.AnalysisPreferenceInitializer"/>
+      <initializer class="com.python.pydev.analysis.mypy.MypyPrefInitializer"/>
    </extension>
 
 

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPlugin.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPlugin.java
@@ -34,8 +34,6 @@ import org.python.pydev.parser.jython.ast.exprType;
 import org.python.pydev.shared_core.structure.Location;
 
 import com.python.pydev.analysis.additionalinfo.ReferenceSearchesLucene;
-import com.python.pydev.analysis.mypy.MypyPrefInitializer;
-import com.python.pydev.analysis.pylint.PyLintPrefInitializer;
 
 /**
  * The main plugin class to be used in the desktop.
@@ -62,10 +60,6 @@ public class AnalysisPlugin extends Plugin {
     public void start(BundleContext context) throws Exception {
         super.start(context);
 
-        // As it starts things in the org.python.pydev node for backward-compatibility, we must
-        // initialize it now.
-        PyLintPrefInitializer.initializeDefaultPreferences();
-        MypyPrefInitializer.initializeDefaultPreferences();
         stateLocation = AnalysisPlugin.getDefault().getStateLocation();
 
         // Leaving code around to know when we get to the PyDev perspective in the active window (may be

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferenceInitializer.java
@@ -16,7 +16,7 @@ import org.osgi.service.prefs.Preferences;
 
 public class AnalysisPreferenceInitializer extends AbstractPreferenceInitializer {
 
-    public static final String DEFAULT_SCOPE = "com.python.pydev.analysis";
+    public static final String DEFAULT_QUALIFIER = "com.python.pydev.analysis";
 
     public static final String SEVERITY_UNUSED_PARAMETER = "SEVERITY_UNUSED_PARAMETER";
     public static final int DEFAULT_SEVERITY_UNUSED_PARAMETER = IMarker.SEVERITY_INFO;
@@ -103,7 +103,7 @@ public class AnalysisPreferenceInitializer extends AbstractPreferenceInitializer
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_QUALIFIER);
 
         for (int i = 0; i < AnalysisPreferences.completeSeverityMap.length; i++) {
             Object[] s = AnalysisPreferences.completeSeverityMap[i];

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/mypy/MypyPrefInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/mypy/MypyPrefInitializer.java
@@ -6,13 +6,15 @@
  */
 package com.python.pydev.analysis.mypy;
 
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.osgi.service.prefs.Preferences;
 import org.python.pydev.shared_core.SharedCorePlugin;
 
-public class MypyPrefInitializer {
+public class MypyPrefInitializer extends AbstractPreferenceInitializer {
 
-    public static void initializeDefaultPreferences() {
+    @Override
+    public void initializeDefaultPreferences() {
         Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         node.put(MypyPreferences.MYPY_FILE_LOCATION, "");

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/mypy/MypyPrefInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/mypy/MypyPrefInitializer.java
@@ -13,7 +13,7 @@ import org.python.pydev.shared_core.SharedCorePlugin;
 public class MypyPrefInitializer {
 
     public static void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         node.put(MypyPreferences.MYPY_FILE_LOCATION, "");
         node.putBoolean(MypyPreferences.USE_MYPY, MypyPreferences.DEFAULT_USE_MYPY);

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintPrefInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintPrefInitializer.java
@@ -16,7 +16,7 @@ import org.python.pydev.shared_core.SharedCorePlugin;
 public class PyLintPrefInitializer {
 
     public static void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         node.put(PyLintPreferences.PYLINT_FILE_LOCATION, "");
         node.putBoolean(PyLintPreferences.USE_PYLINT, PyLintPreferences.DEFAULT_USE_PYLINT);

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintPrefInitializer.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintPrefInitializer.java
@@ -9,13 +9,15 @@
  */
 package com.python.pydev.analysis.pylint;
 
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.osgi.service.prefs.Preferences;
 import org.python.pydev.shared_core.SharedCorePlugin;
 
-public class PyLintPrefInitializer {
+public class PyLintPrefInitializer extends AbstractPreferenceInitializer {
 
-    public static void initializeDefaultPreferences() {
+    @Override
+    public void initializeDefaultPreferences() {
         Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         node.put(PyLintPreferences.PYLINT_FILE_LOCATION, "");

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPlugin.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPlugin.java
@@ -31,7 +31,6 @@ public class DebugPlugin extends AbstractUIPlugin {
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
-        new DebugPluginPrefsInitializer().initializeDefaultPreferences();
     }
 
     /**

--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPluginPrefsInitializer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/DebugPluginPrefsInitializer.java
@@ -33,7 +33,7 @@ public class DebugPluginPrefsInitializer extends AbstractPreferenceInitializer {
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
         node.putInt(PYDEV_REMOTE_DEBUGGER_PORT, DEFAULT_REMOTE_DEBUGGER_PORT);
 
         node.putInt(DEBUG_SERVER_STARTUP, DEFAULT_DEBUG_SERVER_ALWAYS_ON);

--- a/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPreferencesInitializer.java
+++ b/plugins/com.python.pydev.refactoring/src/com/python/pydev/refactoring/RefactoringPreferencesInitializer.java
@@ -13,11 +13,11 @@ import org.osgi.service.prefs.Preferences;
 import com.python.pydev.refactoring.ui.MarkOccurrencesPreferencesPage;
 
 public class RefactoringPreferencesInitializer extends AbstractPreferenceInitializer {
-    public static final String DEFAULT_SCOPE = "com.python.pydev.analysis.refactoring";
+    public static final String DEFAULT_QUALIFIER = "com.python.pydev.analysis.refactoring";
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_QUALIFIER);
         node.putBoolean(MarkOccurrencesPreferencesPage.USE_MARK_OCCURRENCES,
                 MarkOccurrencesPreferencesPage.DEFAULT_USE_MARK_OCCURRENCES);
         node.putBoolean(MarkOccurrencesPreferencesPage.USE_MARK_OCCURRENCES_IN_STRINGS,

--- a/plugins/org.python.pydev.ast/plugin.xml
+++ b/plugins/org.python.pydev.ast/plugin.xml
@@ -35,5 +35,9 @@
          <run class="org.python.pydev.ast.builder.PyDevBuilder"/>
       </builder>
     </extension>
+    <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer class="org.python.pydev.ast.codecompletion.PyCodeCompletionInitializer"/>
+    </extension>
 
 </plugin>

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/AstPlugin.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/AstPlugin.java
@@ -11,7 +11,6 @@ import java.util.ResourceBundle;
 
 import org.eclipse.core.runtime.Plugin;
 import org.osgi.framework.BundleContext;
-import org.python.pydev.ast.codecompletion.PyCodeCompletionInitializer;
 
 /**
  * The main plugin class to be used in the desktop.
@@ -41,9 +40,6 @@ public class AstPlugin extends Plugin {
     @Override
     public void start(BundleContext context) throws Exception {
         super.start(context);
-        // Just called to initialize org.python.pydev.ast.codecompletion.PyCodeCompletionInitializer
-        // because we're actually initializing things in the "org.python.pydev" node.
-        new PyCodeCompletionInitializer().initializeDefaultPreferences();
     }
 
     /**

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/PyCodeCompletionInitializer.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/PyCodeCompletionInitializer.java
@@ -19,7 +19,7 @@ public class PyCodeCompletionInitializer extends AbstractPreferenceInitializer {
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         //use?
         node.putBoolean(PyCodeCompletionPreferences.USE_CODECOMPLETION,

--- a/plugins/org.python.pydev.core/build.properties
+++ b/plugins/org.python.pydev.core/build.properties
@@ -4,7 +4,8 @@ bin.includes = META-INF/,\
                core.jar,\
                LICENSE.txt,\
                pysrc/,\
-               helpers/
+               helpers/,\
+               plugin.xml
 jars.compile.order = core.jar
 bin.excludes = pysrc/__pycache__/,\
                pysrc/*$py.class,\

--- a/plugins/org.python.pydev.core/plugin.xml
+++ b/plugins/org.python.pydev.core/plugin.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.4"?>
+<plugin>
+    <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer class="org.python.pydev.core.preferences.PyDevCorePreferencesInitializer"/>
+    </extension>
+
+</plugin>

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/CorePlugin.java
@@ -24,7 +24,6 @@ import org.eclipse.core.runtime.Plugin;
 import org.eclipse.core.runtime.QualifiedName;
 import org.osgi.framework.BundleContext;
 import org.python.pydev.core.log.Log;
-import org.python.pydev.core.preferences.PyDevCorePreferencesInitializer;
 import org.python.pydev.shared_core.io.FileUtils;
 
 /**
@@ -54,10 +53,6 @@ public class CorePlugin extends Plugin {
      */
     public CorePlugin() {
         super();
-
-        // As it starts things in the org.python.pydev node for backward-compatibility, we must
-        // initialize it now.
-        PyDevCorePreferencesInitializer.initializeDefaultPreferences();
 
         plugin = this;
         try {

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyDevCorePreferencesInitializer.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyDevCorePreferencesInitializer.java
@@ -9,7 +9,7 @@ import org.python.pydev.shared_core.SharedCorePlugin;
 public class PyDevCorePreferencesInitializer {
 
     public static void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         //ironpython
         node.put(IInterpreterManager.IRONPYTHON_INTERNAL_SHELL_VM_ARGS,

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyDevCorePreferencesInitializer.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyDevCorePreferencesInitializer.java
@@ -1,14 +1,16 @@
 package org.python.pydev.core.preferences;
 
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.osgi.service.prefs.Preferences;
 import org.python.pydev.core.IInterpreterManager;
 import org.python.pydev.core.formatter.PyFormatterPreferences;
 import org.python.pydev.shared_core.SharedCorePlugin;
 
-public class PyDevCorePreferencesInitializer {
+public class PyDevCorePreferencesInitializer extends AbstractPreferenceInitializer {
 
-    public static void initializeDefaultPreferences() {
+    @Override
+    public void initializeDefaultPreferences() {
         Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         //ironpython

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyScopedPreferences.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/preferences/PyScopedPreferences.java
@@ -35,7 +35,7 @@ public class PyScopedPreferences {
     }
 
     public static IScopedPreferences get() {
-        return ScopedPreferences.get(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        return ScopedPreferences.get(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
     }
 
 }

--- a/plugins/org.python.pydev.debug/plugin.xml
+++ b/plugins/org.python.pydev.debug/plugin.xml
@@ -1430,6 +1430,10 @@
             priority="50">
       </pyTextHover>
    </extension>
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer class="org.python.pydev.debug.model.PyVariablesPreferences"/>
+   </extension>
 
 </plugin>
 

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPreferencesInitializer.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/core/PydevDebugPreferencesInitializer.java
@@ -9,7 +9,6 @@ package org.python.pydev.debug.core;
 import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.core.runtime.preferences.DefaultScope;
 import org.osgi.service.prefs.Preferences;
-import org.python.pydev.debug.model.PyVariablesPreferences;
 import org.python.pydev.debug.pyunit.PyUnitView;
 
 public class PydevDebugPreferencesInitializer extends AbstractPreferenceInitializer {
@@ -60,9 +59,6 @@ public class PydevDebugPreferencesInitializer extends AbstractPreferenceInitiali
 
         //Note: the preferences for the debug which appear in the preferences page are actually in
         //the PydevEditorPrefs (as we use the pydev preferences store there).
-
-        // Delegate to the variables preferences
-        PyVariablesPreferences.initializeDefaultPreferences();
     }
 
 }

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariablesPreferences.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/PyVariablesPreferences.java
@@ -11,12 +11,13 @@
 ******************************************************************************/
 package org.python.pydev.debug.model;
 
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.python.pydev.debug.core.PydevDebugPlugin;
 import org.python.pydev.shared_core.SharedCorePlugin;
 
-public class PyVariablesPreferences {
+public class PyVariablesPreferences extends AbstractPreferenceInitializer {
 
     public static final String DEBUG_UI_VARIABLES_SHOW_PRIVATE_REFERENCES = "DEBUG_UI_VARIABLES_SHOW_PRIVATE_REFERENCES";
     public static final boolean DEBUG_UI_VARIABLES_DEFAULT_SHOW_PRIVATE_REFERENCES = true;
@@ -93,7 +94,8 @@ public class PyVariablesPreferences {
         setHelper(PyVariablesPreferences.DEBUG_UI_VARIABLES_SHOW_FUNCTION_AND_MODULE_REFERENCES, value);
     }
 
-    public static void initializeDefaultPreferences() {
+    @Override
+    public void initializeDefaultPreferences() {
         setDefaultHelper(PyVariablesPreferences.DEBUG_UI_VARIABLES_SHOW_PRIVATE_REFERENCES,
                 PyVariablesPreferences.DEBUG_UI_VARIABLES_DEFAULT_SHOW_PRIVATE_REFERENCES);
         setDefaultHelper(PyVariablesPreferences.DEBUG_UI_VARIABLES_SHOW_CAPITALIZED_REFERENCES,

--- a/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptingExtensionInitializer.java
+++ b/plugins/org.python.pydev.jython/src/org/python/pydev/jython/ScriptingExtensionInitializer.java
@@ -12,11 +12,11 @@ import org.osgi.service.prefs.Preferences;
 import org.python.pydev.jython.ui.JyScriptingPreferencesPage;
 
 public class ScriptingExtensionInitializer extends AbstractPreferenceInitializer {
-    public static final String DEFAULT_SCOPE = "org.python.pydev.jython";
+    public static final String DEFAULT_QUALIFIER = "org.python.pydev.jython";
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(DEFAULT_QUALIFIER);
 
         node.putBoolean(JyScriptingPreferencesPage.SHOW_SCRIPTING_OUTPUT,
                 JyScriptingPreferencesPage.DEFAULT_SHOW_SCRIPTING_OUTPUT);

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/SharedCorePlugin.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/SharedCorePlugin.java
@@ -29,7 +29,7 @@ public class SharedCorePlugin extends Plugin {
 
     public static final String PYDEV_PLUGIN_ID = "org.python.pydev";
 
-    public static final String DEFAULT_PYDEV_PREFERENCES_SCOPE = "org.python.pydev";
+    public static final String DEFAULT_PYDEV_PREFERENCES_QUALIFIER = "org.python.pydev";
 
     //The shared instance.
     private static SharedCorePlugin plugin;

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PyTabPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PyTabPreferencesPage.java
@@ -42,6 +42,6 @@ public class PyTabPreferencesPage extends ScopedFieldEditorPreferencePage implem
                 "Assume tab spacing when files contain tabs?", p));
         addField(new BooleanFieldEditor(PyDevCoreEditorPreferences.TAB_STOP_IN_COMMENT, "Allow tab stops in comments?", p));
 
-        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
     }
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevTypingPreferencesPage.java
@@ -171,7 +171,7 @@ public class PydevTypingPreferencesPage extends ScopedFieldEditorPreferencePage 
         addField(new LabelFieldEditor("__UNUSED__", "Note: smart move line up/down change applied on editor restart.",
                 p));
 
-        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
 
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevSaveActionsPrefPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/saveactions/PydevSaveActionsPrefPage.java
@@ -228,7 +228,7 @@ public class PydevSaveActionsPrefPage extends ScopedFieldEditorPreferencePage im
         addField(new LabelFieldEditor("__dummy__",
                 "I.e.: __updated__=\"2010-01-01\" will be synched on save.", p));
 
-        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
 
     }
 

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeFormatterPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyCodeFormatterPage.java
@@ -225,7 +225,7 @@ public class PyCodeFormatterPage extends ScopedFieldEditorPreferencePage impleme
         GridData layoutData = new GridData(SWT.FILL, SWT.FILL, true, true, 2, 1);
         labelExample.setLayoutData(layoutData);
 
-        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
     }
 
     private void createTabs(Composite p) {

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
@@ -32,7 +32,7 @@ public class PydevPrefsInitializer extends AbstractPreferenceInitializer {
 
     @Override
     public void initializeDefaultPreferences() {
-        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE);
+        Preferences node = DefaultScope.INSTANCE.getNode(SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER);
 
         node.putInt(IWizardNewProjectNameAndLocationPage.PYDEV_NEW_PROJECT_CREATE_PREFERENCES,
                 IWizardNewProjectNameAndLocationPage.PYDEV_NEW_PROJECT_CREATE_PROJECT_AS_SRC_FOLDER);

--- a/plugins/org.python.pydev/src/org/python/pydev/pyunit/preferences/PyUnitPrefsPage2.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/pyunit/preferences/PyUnitPrefsPage2.java
@@ -302,7 +302,7 @@ public class PyUnitPrefsPage2 extends ScopedFieldEditorPreferencePage implements
         layoutTestRunnerOptions(stackLayout, getTestRunner(null), contentPanel);
 
         addField(
-                new ScopedPreferencesFieldEditor(parentAll, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+                new ScopedPreferencesFieldEditor(parentAll, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
     }
 
     private void add(String linkText, String flag, String tooltip, Composite p) {

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/importsconf/ImportsPreferencesPage.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/importsconf/ImportsPreferencesPage.java
@@ -156,7 +156,7 @@ public class ImportsPreferencesPage extends ScopedFieldEditorPreferencePage impl
                     }
                 }));
 
-        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_SCOPE, this));
+        addField(new ScopedPreferencesFieldEditor(p, SharedCorePlugin.DEFAULT_PYDEV_PREFERENCES_QUALIFIER, this));
     }
 
     private void updateEnablement(Composite p, String importEngine) {


### PR DESCRIPTION
This aims to solve [https://www.brainwy.com/tracker/PyDev/956](https://www.brainwy.com/tracker/PyDev/956).

The problem was that calling the `initializeDefaultPreferences()` methods manually (directly) caused the defaults loaded from `plugin_customization.ini` to be overridden. According to the documentation, this should never be done, and using the extension point is the (only) proper way.

Now, there were comments I deleted, saying something about backward compatibility. What exactly are those about? Are they still relevant today?

I also renamed two variables that had confusing names, just for consistency's sake.