### PR TITLE
Fix hover links when different pydev_link pointers are used

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
@@ -59,6 +59,21 @@ public class PyInformationPresenter extends AbstractInformationPresenter {
         }
 
         public String tagReplaced;
+
+        @Override
+        public boolean similarTo(StyleRange style) {
+            if (!super.similarTo(style)) {
+                return false;
+            }
+            if (style instanceof PyStyleRange) {
+                String otherTagReplaced = ((PyStyleRange) style).tagReplaced;
+                if (tagReplaced == null) {
+                    return otherTagReplaced == null;
+                }
+                return tagReplaced.equals(otherTagReplaced);
+            }
+            return true;
+        }
     }
 
     private int fCounter;


### PR DESCRIPTION
When using the org.python.pydev.pydev_hover2 extension point it is possible to add new hover info. When the hover info contains a pydev_link (through ItemPointer.asPortableString()) those links are clickable in the hover popup and will open the corresponding pointer.

Currently this does not work correctly because PyStyleRange.similarTo(StyleRange) is not implemented which causes all PyStyleRanges to be "similar" even though they have different pointers.
The StyledTextRenderer optimizes its memory consumption and discards similar style ranges.
This causes all links to point to the first pydev_link.

This pull request fixes the behaviour by taking the link pointer into account when comparing PyStyleRange for similarity.

As this is my first pull request for PyDev, please let me know if you need a test for this or something else I'm missing.