### PR TITLE
Allow building against 2019-06

### DIFF
--- a/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
+++ b/plugins/org.python.pydev.core/tests/org/python/pydev/core/docutils/StringSubstitutionTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2013 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2019 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -33,7 +33,6 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourceAttributes;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IPluginDescriptor;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.QualifiedName;
@@ -552,6 +551,7 @@ public class StringSubstitutionTest extends TestCase {
                         throw new RuntimeException("Not implemented");
                     }
 
+                    @Override
                     public void clearCachedDynamicReferences() {
 
                     }
@@ -972,11 +972,6 @@ public class StringSubstitutionTest extends TestCase {
 
                     @Override
                     public IProjectNature getNature(String natureId) throws CoreException {
-                        throw new RuntimeException("Not implemented");
-                    }
-
-                    @Override
-                    public IPath getPluginWorkingLocation(IPluginDescriptor plugin) {
                         throw new RuntimeException("Not implemented");
                     }
 

--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/AbstractIProjectStub.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/AbstractIProjectStub.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2005-2012 by Appcelerator, Inc. All Rights Reserved.
+ * Copyright (c) 2005-2019 by Appcelerator, Inc. All Rights Reserved.
  * Licensed under the terms of the Eclipse Public License (EPL).
  * Please see the license.txt included with this distribution for details.
  * Any modifications to this file must keep this entire header intact.
@@ -18,7 +18,6 @@ import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.IPluginDescriptor;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.content.IContentTypeMatcher;
 
@@ -78,11 +77,6 @@ public class AbstractIProjectStub extends AbstractIContainerStub implements IPro
     @Override
     public IProjectNature getNature(String natureId) throws CoreException {
         return null;
-    }
-
-    @Override
-    public IPath getPluginWorkingLocation(IPluginDescriptor plugin) {
-        throw new RuntimeException("Not implemented");
     }
 
     @Override
@@ -193,6 +187,7 @@ public class AbstractIProjectStub extends AbstractIContainerStub implements IPro
         return IResource.PROJECT;
     }
 
+    @Override
     public void clearCachedDynamicReferences() {
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -124,11 +124,11 @@
 <project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <properties>
-    <tycho-version>1.1.0</tycho-version>
-    <tycho-extras-version>1.1.0</tycho-extras-version>
+    <tycho-version>1.4.0</tycho-version>
+    <tycho-extras-version>1.4.0</tycho-extras-version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <repository.id>eclipse-oxygen</repository.id>
-    <repository.url>http://download.eclipse.org/releases/oxygen/</repository.url>
+    <repository.id>eclipse-2019-06</repository.id>
+    <repository.url>http://download.eclipse.org/releases/2019-06/</repository.url>
   </properties>
   <prerequisites>
     <maven>3.0</maven>
@@ -220,19 +220,9 @@
               <arch>x86_64</arch>
             </environment>
             <environment>
-              <os>linux</os>
-              <ws>gtk</ws>
-              <arch>x86</arch>
-            </environment>
-            <environment>
               <os>win32</os>
               <ws>win32</ws>
               <arch>x86_64</arch>
-            </environment>
-            <environment>
-              <os>win32</os>
-              <ws>win32</ws>
-              <arch>x86</arch>
             </environment>
             <environment>
               <os>macosx</os>


### PR DESCRIPTION
This change fixes the fact that Pydev fails to compile against the newest Eclipse Platform release, 2019-06.

When you invoke maven like this:

```
mvn clean verify -Drepository.id=eclipse-2019-06 -Drepository.url=http://download.eclipse.org/releases/2019-06/
```

Then you see compile failures like this:

```
[ERROR] Failed to execute goal org.eclipse.tycho:tycho-compiler-plugin:1.1.0:compile (default-compile) on project org.python.pydev.shared_core: Compilation failure: Compilation failure: 
[ERROR] /home/mbooth/workspace-pydev/Pydev/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/AbstractIProjectStub.java:[21] 
[ERROR]         import org.eclipse.core.runtime.IPluginDescriptor;
[ERROR]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[ERROR] The import org.eclipse.core.runtime.IPluginDescriptor cannot be resolved
[ERROR] /home/mbooth/workspace-pydev/Pydev/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/resource_stubs/AbstractIProjectStub.java:[84] 
[ERROR]         public IPath getPluginWorkingLocation(IPluginDescriptor plugin) {
[ERROR]                                               ^^^^^^^^^^^^^^^^^
[ERROR] IPluginDescriptor cannot be resolved to a type
```

This is because after many years, the deprecated ```IPluginDescriptor``` interface and associated APIs have been finally been removed. See the upstream bug about this for more details: https://bugs.eclipse.org/bugs/show_bug.cgi?id=475944

After this change, Pydev compiles successfully against Eclipse 2019-06.

FWIW, I am carrying this patch in my downstream rebuilds for Fedora.