### PR TITLE
Update code tracking user input in console

### DIFF
--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTarget.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/model/AbstractDebugTarget.java
@@ -929,7 +929,7 @@ public abstract class AbstractDebugTarget extends AbstractDebugTargetWithTransmi
                                 if (p.getType().equals(IOConsolePartition.INPUT_PARTITION_TYPE)) {
                                     if (event.fText.length() <= 2) {
                                         //the user typed something
-                                        final String inputFound = p.getString();
+                                        final String inputFound = event.getDocument().get(p.getOffset(), p.getLength());
                                         for (IConsoleInputListener listener : participants) {
                                             listener.newLineReceived(inputFound, target);
                                         }


### PR DESCRIPTION
The code to track user input in process console relies on some non-public
classes/methods from which one is [removed](https://bugs.eclipse.org/bugs/show_bug.cgi?id=548356) in a future eclipse version. This
replace the removed method call with an equivalent workaround.

See also https://bugs.eclipse.org/bugs/show_bug.cgi?id=548356#c4 ff.