### PR TITLE
bugfix completion for non-english language

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_bundle/_pydev_completer.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_bundle/_pydev_completer.py
@@ -192,6 +192,8 @@ def completions_to_xml(completions):
     msg = ["<xml>"]
 
     for comp in completions:
+        if IS_PY2:
+            comp = [(x.encode('utf-8') if x.__class__ == unicode else x) for x in comp]
         msg.append('<comp p0="')
         msg.append(valid_xml(quote(comp[0], '/>_= \t')))
         msg.append('" p1="')


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/22538408/62002388-a029fc80-b135-11e9-89c7-193d61d30b11.png)

For non-english language, urllib.quote cannot automatically transfer unicode characters to utf8 and thus will reach an error indicate that there is a key error for quote.

A simple way to resolve this is to transfer all unicode item to utf8.