### PR TITLE
pydev_saved_modules: clone first-level module content

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_imps/_pydev_saved_modules.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_imps/_pydev_saved_modules.py
@@ -1,23 +1,49 @@
 import sys
 IS_PY2 = sys.version_info < (3,)
+del sys
 
-import threading
+import importlib
+if IS_PY2:
+  def _CloneModule(name):
+    import imp
+    proxy_module = imp.new_module(name)
+    real_module = importlib.import_module(name)
+    for attr in dir(real_module):
+      setattr(proxy_module, attr, getattr(real_module, attr))
+    return proxy_module
+else:
+  def _CloneModule(name):
+    import types
+    proxy_module = types.ModuleType(name)
+    real_module = importlib.import_module(name)
+    for attr in dir(real_module):
+      setattr(proxy_module, attr, getattr(real_module, attr))
+    return proxy_module
 
-import time
+# Capture a clone of modules so that if parts of them are mocked out by a
+# target, it does not impact the execution of pydev.
+# Usage:
+#  import x --> x = CloneModule("x")
+#  import x as y --> y = CloneModule("x")
 
-import socket
-
-import select
+threading = _CloneModule("threading")
+time = _CloneModule("time")
+socket = _CloneModule("socket")
+select = _CloneModule("select")
 
 if IS_PY2:
-    import thread
-    import Queue as _queue
-    import xmlrpclib
-    import SimpleXMLRPCServer as _pydev_SimpleXMLRPCServer
-    import BaseHTTPServer
+    thread = _CloneModule("thread")
+    _queue = _CloneModule("Queue")
+    xmlrpclib = _CloneModule("xmlrpclib")
+    _pydev_SimpleXMLRPCServer = _CloneModule("SimpleXMLRPCServer")
+    BaseHTTPServer = _CloneModule("BaseHTTPServer")
 else:
-    import _thread as thread
-    import queue as _queue
-    import xmlrpc.client as xmlrpclib
-    import xmlrpc.server as _pydev_SimpleXMLRPCServer
-    import http.server as BaseHTTPServer
+    thread = _CloneModule("_thread")
+    _queue = _CloneModule("queue")
+    xmlrpclib = _CloneModule("xmlrpc.client")
+    _pydev_SimpleXMLRPCServer = _CloneModule("xmlrpc.server")
+    BaseHTTPServer = _CloneModule("http.server")
+
+del _CloneModule
+del importlib
+del IS_PY2


### PR DESCRIPTION
Some functions provided by the modules exposed in pydev_saved_modules are used internally by pydev and can cause problems if a target mocks them out. For each module provided `_pydev_imps._pydev_saved_modules`, this patch naively creates an new module, then assigns all attributes from the module it's meant to be a clone of, then attaches that module to the expected name.

This was motivated by a mock of 'time.sleep' causing pydev to continually escalate memory usage (even when stopped at a breakpoint). The underlying cause seemed to be the [`time.sleep` in `_do_wait_suspend`](https://github.com/fabioz/Pydev/blob/master/plugins/org.python.pydev.core/pysrc/pydevd.py#L1640) - it was calling the mock, spinning pretty fast and creating a record per-call.