### PR TITLE
[#1007] Patched SimpleTerminalEmulator to handle \r & \r\n correctly for Win32.

### DIFF
--- a/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/FastStringBuffer.java
+++ b/plugins/org.python.pydev.shared_core/src/org/python/pydev/shared_core/string/FastStringBuffer.java
@@ -681,6 +681,24 @@ public final class FastStringBuffer implements CharSequence {
         return -1;
     }
 
+    public int lastIndexOf(char c) {
+        for (int i = this.count - 1; i > 0; i--) {
+            if (c == this.value[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    public int lastIndexOf(char c, int fromOffset) {
+        for (int i = fromOffset; i > 0; i--) {
+            if (c == this.value[i]) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
     public char firstChar() {
         return this.value[0];
     }


### PR DESCRIPTION
PR for Ticket [\#1007](https://www.brainwy.com/tracker/PyDev/1007).

Fixes issue with pipenv command line spinner filling up log.
Noticed this bug awhile ago since support for pipenv was added and wanted to do something about it, mostly cosmetic but slightly annoying to see the visual log bloated like that and wasn't sure if anybody else noticed it too.

Fixes this from happening with pipenv's spinner animations:
```
Creating a virtualenv for this project…
Pipfile: C:\Users\lshaw\Documents\Git\product-web\Pipfile
Using C:/Program Files/Python36/python.exe (3.6.8) to create virtualenv…

[    ] Creating virtual environment...
□
[=   ] Creating virtual environment...
□
[==  ] Creating virtual environment...
□
[=== ] Creating virtual environment...
□
[ ===] Creating virtual environment...
...etc...
```