### PR TITLE
Extend syntax highlighter to allow colorizing of variables and properties

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyCodeScanner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyCodeScanner.java
@@ -68,6 +68,8 @@ public class PyCodeScanner extends RuleBasedScanner {
     private IToken funcNameToken;
     private IToken parensToken;
     private IToken operatorsToken;
+    private IToken variableToken;
+    private IToken propertyToken;
 
     private String[] keywords;
 
@@ -217,6 +219,10 @@ public class PyCodeScanner extends RuleBasedScanner {
 
         operatorsToken = new Token(colorCache.getOperatorsTextAttribute());
 
+        variableToken = new Token(colorCache.getVariableTextAttribute());
+
+        propertyToken = new Token(colorCache.getPropertyTextAttribute());
+
         setDefaultReturnToken(defaultToken);
         List<IRule> rules = new ArrayList<IRule>();
 
@@ -240,8 +246,8 @@ public class PyCodeScanner extends RuleBasedScanner {
         // must be before PyWordRule (to match decorator before matmul as operator).
         rules.add(new PyDecoratorRule(decoratorToken));
 
-        PyWordRule wordRule = new PyWordRule(new GreatKeywordDetector(), defaultToken, classNameToken, funcNameToken,
-                parensToken, operatorsToken);
+        PyIdentifierRule wordRule = new PyIdentifierRule(new GreatKeywordDetector(), defaultToken, classNameToken,
+                funcNameToken, parensToken, operatorsToken, variableToken, propertyToken);
         for (String keyword : keywords) {
             IToken token = defaults.get(keyword);
             if (token == null) {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyIdentifierRule.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyIdentifierRule.java
@@ -1,0 +1,64 @@
+package org.python.pydev.editor;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.python.pydev.shared_core.partitioner.ICharacterScanner;
+import org.python.pydev.shared_core.partitioner.IToken;
+import org.python.pydev.shared_core.partitioner.IWordDetector;
+
+public class PyIdentifierRule extends PyWordRule {
+
+    private String lastTokenStr;
+    private Set<String> potentialVariables;
+
+    private IToken variableToken;
+    private IToken propertyToken;
+
+    public PyIdentifierRule(IWordDetector detector, IToken defaultToken, IToken classNameToken, IToken funcNameToken,
+            IToken parensToken, IToken operatorsToken, IToken variableToken, IToken propertyToken) {
+        super(detector, defaultToken, classNameToken, funcNameToken, parensToken, operatorsToken);
+
+        this.lastTokenStr = "";
+        this.potentialVariables = new HashSet<String>();
+
+        this.variableToken = variableToken;
+        this.propertyToken = propertyToken;
+    }
+
+    @Override
+    public IToken evaluate(ICharacterScanner scanner) {
+        int c = scanner.read();
+
+        switch (c) {
+            case '=':
+                if (lastTokenStr.length() > 0 && !lastTokenStr.equals(".")) {
+                    potentialVariables.add(lastTokenStr);
+                }
+                break;
+            case '.':
+                lastTokenStr = ".";
+                break;
+        }
+        scanner.unread();
+
+        IToken result = super.evaluate(scanner);
+        String currentTokenStr = fBuffer.toString();
+
+        if (result == this.fDefaultToken && !this.fDefaultToken.isUndefined()) {
+            if (lastTokenStr.equals(".") &&
+                    !(lastFound.equals("import") || lastFound.equals("from"))) {
+                result = propertyToken;
+            } else if (lastTokenStr.equals("import")) {
+                potentialVariables.add(currentTokenStr);
+            } else if (potentialVariables.contains(currentTokenStr)) {
+                result = variableToken;
+            }
+            lastTokenStr = currentTokenStr;
+        } else if (currentTokenStr.equals("import")) {
+            lastTokenStr = currentTokenStr;
+        }
+
+        return result;
+    }
+}

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyWordRule.java
@@ -45,7 +45,7 @@ public class PyWordRule implements IRule {
     /** The table of predefined words and token for this rule */
     protected Map<String, IToken> fWords = new HashMap<String, IToken>();
     /** Buffer used for pattern detection */
-    private FastStringBuffer fBuffer = new FastStringBuffer();
+    protected FastStringBuffer fBuffer = new FastStringBuffer();
 
     private IToken classNameToken;
 
@@ -110,7 +110,7 @@ public class PyWordRule implements IRule {
         fColumn = column;
     }
 
-    private String lastFound = "";
+    protected String lastFound = "";
 
     @Override
     public IToken evaluate(ICharacterScanner scanner) {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevEditorPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/preferences/PydevEditorPrefs.java
@@ -370,6 +370,8 @@ public class PydevEditorPrefs extends AbstractPydevPrefs {
         localStore.setValue(PyDevEditorPreferences.PARENS_COLOR, fOverlayStore.getString(PyDevEditorPreferences.PARENS_COLOR));
         localStore.setValue(PyDevEditorPreferences.OPERATORS_COLOR, fOverlayStore.getString(PyDevEditorPreferences.OPERATORS_COLOR));
         localStore.setValue(PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR, fOverlayStore.getString(PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR));
+        localStore.setValue(PyDevEditorPreferences.VARIABLE_COLOR, fOverlayStore.getString(PyDevEditorPreferences.VARIABLE_COLOR));
+        localStore.setValue(PyDevEditorPreferences.PROPERTY_COLOR, fOverlayStore.getString(PyDevEditorPreferences.PROPERTY_COLOR));
 
         localStore.setValue(PyDevEditorPreferences.KEYWORD_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.KEYWORD_STYLE));
         localStore.setValue(PyDevEditorPreferences.SELF_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.SELF_STYLE));
@@ -385,6 +387,8 @@ public class PydevEditorPrefs extends AbstractPydevPrefs {
         localStore.setValue(PyDevEditorPreferences.PARENS_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.PARENS_STYLE));
         localStore.setValue(PyDevEditorPreferences.OPERATORS_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.OPERATORS_STYLE));
         localStore.setValue(PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE));
+        localStore.setValue(PyDevEditorPreferences.VARIABLE_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.VARIABLE_STYLE));
+        localStore.setValue(PyDevEditorPreferences.PROPERTY_STYLE, fOverlayStore.getInt(PyDevEditorPreferences.PROPERTY_STYLE));
 
         this.updateLabelExample(PyFormatterPreferences.getFormatStd(null), localStore);
     }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/AbstractPydevPrefs.java
@@ -52,7 +52,9 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
             { "Docstring markup", PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR, null }, { "Comments", PyDevEditorPreferences.COMMENT_COLOR, null },
             { "Backquotes", PyDevEditorPreferences.BACKQUOTES_COLOR, null }, { "Class Name", PyDevEditorPreferences.CLASS_NAME_COLOR, null },
             { "Function Name", PyDevEditorPreferences.FUNC_NAME_COLOR, null }, { "(), [], {}", PyDevEditorPreferences.PARENS_COLOR, null },
-            { "Operators (+,-,*,...)", PyDevEditorPreferences.OPERATORS_COLOR, null }, };
+            { "Operators (+,-,*,...)", PyDevEditorPreferences.OPERATORS_COLOR, null },
+            { "Variable (approx.)", PyDevEditorPreferences.VARIABLE_COLOR, null },
+            { "Properties (approx.)", PyDevEditorPreferences.PROPERTY_COLOR, null }, };
 
     protected final String[][] fAppearanceFontListModel = new String[][] { { "Code", PyDevEditorPreferences.CODE_STYLE, null },
             { "Decorators", PyDevEditorPreferences.DECORATOR_STYLE, null }, { "Numbers", PyDevEditorPreferences.NUMBER_STYLE, null },
@@ -61,7 +63,9 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
             { "Docstring markup", PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE, null }, { "Comments", PyDevEditorPreferences.COMMENT_STYLE, null },
             { "Backquotes", PyDevEditorPreferences.BACKQUOTES_STYLE, null }, { "Class Name", PyDevEditorPreferences.CLASS_NAME_STYLE, null },
             { "Function Name", PyDevEditorPreferences.FUNC_NAME_STYLE, null }, { "(), [], {}", PyDevEditorPreferences.PARENS_STYLE, null },
-            { "Operators (+,-,*,...)", PyDevEditorPreferences.OPERATORS_STYLE, null }, };
+            { "Operators (+,-,*,...)", PyDevEditorPreferences.OPERATORS_STYLE, null },
+            { "Variable (approx.)", PyDevEditorPreferences.VARIABLE_STYLE, null },
+            { "Properties (approx.)", PyDevEditorPreferences.PROPERTY_STYLE, null }, };
 
     protected OverlayPreferenceStore fOverlayStore;
 
@@ -164,6 +168,8 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PyDevEditorPreferences.PARENS_COLOR));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PyDevEditorPreferences.OPERATORS_COLOR));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PyDevEditorPreferences.VARIABLE_COLOR));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.STRING, PyDevEditorPreferences.PROPERTY_COLOR));
 
         //font style
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.CODE_STYLE));
@@ -180,6 +186,8 @@ public abstract class AbstractPydevPrefs extends PreferencePage implements IWork
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.PARENS_STYLE));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.OPERATORS_STYLE));
         overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.VARIABLE_STYLE));
+        overlayKeys.add(new OverlayPreferenceStore.OverlayKey(OverlayPreferenceStore.INT, PyDevEditorPreferences.PROPERTY_STYLE));
 
         OverlayPreferenceStore.OverlayKey[] keys = new OverlayPreferenceStore.OverlayKey[overlayKeys.size()];
         overlayKeys.toArray(keys);

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyDevEditorPreferences.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyDevEditorPreferences.java
@@ -97,6 +97,12 @@ public class PyDevEditorPreferences {
     public static final String DOCSTRING_MARKUP_COLOR = "DOCSTRING_MARKUP_COLOR";
     public static final RGB DEFAULT_DOCSTRING_MARKUP_COLOR = new RGB(0, 170, 0);
 
+    public static final String VARIABLE_COLOR = "VARIABLE_COLOR";
+    public static final RGB DEFAULT_VARIABLE_COLOR = new RGB(0, 0, 0);
+
+    public static final String PROPERTY_COLOR = "PROPERTY_COLOR";
+    public static final RGB DEFAULT_PROPERTY_COLOR = new RGB(0, 0, 0);
+
     //see initializeDefaultColors for selection defaults
     public static final String CONNECT_TIMEOUT = "CONNECT_TIMEOUT";
     public static final int DEFAULT_CONNECT_TIMEOUT = 20000;
@@ -181,5 +187,11 @@ public class PyDevEditorPreferences {
 
     public static final String DOCSTRING_MARKUP_STYLE = "DOCSTRING_MARKUP_STYLE";
     public static final int DEFAULT_DOCSTRING_MARKUP_STYLE = SWT.BOLD;
+
+    public static final String VARIABLE_STYLE = "VARIABLE_STYLE";
+    public static final int DEFAULT_VARIABLE_STYLE = SWT.NORMAL;
+
+    public static final String PROPERTY_STYLE = "PROPERTY_STYLE";
+    public static final int DEFAULT_PROPERTY_STYLE = SWT.NORMAL;
 
 }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PydevPrefsInitializer.java
@@ -97,6 +97,11 @@ public class PydevPrefsInitializer extends AbstractPreferenceInitializer {
                 StringConverter.asString(PyDevEditorPreferences.DEFAULT_OPERATORS_COLOR));
         node.put(PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR,
                 StringConverter.asString(PyDevEditorPreferences.DEFAULT_DOCSTRING_MARKUP_COLOR));
+        node.put(PyDevEditorPreferences.VARIABLE_COLOR,
+                StringConverter.asString(PyDevEditorPreferences.DEFAULT_VARIABLE_COLOR));
+        node.put(PyDevEditorPreferences.PROPERTY_COLOR,
+                StringConverter.asString(PyDevEditorPreferences.DEFAULT_PROPERTY_COLOR));
+
         //for selection colors see initializeDefaultColors()
 
         //font style
@@ -115,6 +120,8 @@ public class PydevPrefsInitializer extends AbstractPreferenceInitializer {
         node.putInt(PyDevEditorPreferences.OPERATORS_STYLE, PyDevEditorPreferences.DEFAULT_OPERATORS_STYLE);
         node.putInt(PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE,
                 PyDevEditorPreferences.DEFAULT_DOCSTRING_MARKUP_STYLE);
+        node.putInt(PyDevEditorPreferences.VARIABLE_STYLE, PyDevEditorPreferences.DEFAULT_VARIABLE_STYLE);
+        node.putInt(PyDevEditorPreferences.PROPERTY_STYLE, PyDevEditorPreferences.DEFAULT_PROPERTY_STYLE);
 
         //Debugger
         node.putInt(PyDevEditorPreferences.CONNECT_TIMEOUT, PyDevEditorPreferences.DEFAULT_CONNECT_TIMEOUT);

--- a/plugins/org.python.pydev/src/org/python/pydev/ui/ColorAndStyleCache.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/ui/ColorAndStyleCache.java
@@ -131,6 +131,20 @@ public class ColorAndStyleCache extends ColorCache {
                 PyDevEditorPreferences.DOCSTRING_MARKUP_COLOR), null,
                 preferences.getInt(PyDevEditorPreferences.DOCSTRING_MARKUP_STYLE));
     }
+
+    public TextAttribute getVariableTextAttribute() {
+
+        return new TextAttribute(getNamedColor(
+                PyDevEditorPreferences.VARIABLE_COLOR), null,
+                preferences.getInt(PyDevEditorPreferences.VARIABLE_STYLE));
+    }
+
+    public TextAttribute getPropertyTextAttribute() {
+
+        return new TextAttribute(getNamedColor(
+                PyDevEditorPreferences.PROPERTY_COLOR), null,
+                preferences.getInt(PyDevEditorPreferences.PROPERTY_STYLE));
+    }
     //[[[end]]]
 
 }


### PR DESCRIPTION
This adds new syntax highlighting options for variables and property
expression.

The options will end up in "Preferences -> PyDev -> Editor" and are
denoted as "Variable (approx.)" and "Properties (approx.)". They default
to black.

I chose to add the approximation remark because the python syntax
highlighting is only token based and does not use the AST, therefore the
highlighting can only be approximated. The highlighting seems to be
optimized for speed and is called in a blocking fashion on each text
change, it's also only called for the sections that are marked as changed.

The rule objects that are used for the highlighting are kept for as long as the
editor is open, which enables us to look at previous tokens and unchanged
sections.

So while this change has some limitations it already makes code with lots
of variables and properties a lot nicer to read.