### PR TITLE
Fix renaming of global variables in modules

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/wizards/rename/PyRenameGlobalProcess.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/wizards/rename/PyRenameGlobalProcess.java
@@ -39,7 +39,7 @@ public class PyRenameGlobalProcess extends AbstractRenameWorkspaceRefactorProces
             String initialName, SourceModule module) {
         SimpleNode searchStringsAt = module.getAst();
 
-        List<ASTEntry> ret = ScopeAnalysis.getLocalOccurrences(initialName, module.getAst());
+        List<ASTEntry> ret = ScopeAnalysis.getLocalOccurrences(initialName, module.getAst(), false);
         if (ret.size() > 0 && searchStringsAt != null) {
             //only add comments and strings if there's at least some other occurrence
             ret.addAll(ScopeAnalysis.getCommentOccurrences(request.initialName, searchStringsAt));
@@ -53,7 +53,7 @@ public class PyRenameGlobalProcess extends AbstractRenameWorkspaceRefactorProces
     protected void findReferencesToRenameOnLocalScope(RefactoringRequest request, RefactoringStatus status) {
         SimpleNode ast = request.getAST();
         //it was found in another module, but we want to keep things local
-        List<ASTEntry> ret = ScopeAnalysis.getLocalOccurrences(request.initialName, ast);
+        List<ASTEntry> ret = ScopeAnalysis.getLocalOccurrences(request.initialName, ast, false);
         if (ret.size() > 0) {
             //only add comments and strings if there's at least some other occurrence
             ret.addAll(ScopeAnalysis.getCommentOccurrences(request.initialName, ast));


### PR DESCRIPTION
There are currently two bugs when trying to rename globally defined variables
in modules:

1. renaming from inside the module where the variable is defined only
renames the variable in that module but not in any modules using the
variable
2. renaming the variable in a module where it's used but not defined ends
up not finding any occurrences for renaming in the corresponding dialog

A short sample setup can be found at the end of the message. This problem
occurs regardless of whether the modules are in the same or different
source folders.

This change enables the PyRenameGlobalProcess to also consider uses of
the variable in the form 'mymodule.var1' and thus find not only the
definition but also all uses of the variable by asking the ScopeAnalysis
to not only check the first part but all attribute parts when finding local
occurrences.

Example that fails to rename the variable properly:

mymodule1.py:
```python
var1 = "Hello World"
```

main.py:
```python
import mymodule1

print("%s!" % mymodule1.var1)
```