### PR TITLE
handle also pyside2 in command line (as it is indeed internally handled correctly internally)

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_bundle/pydev_monkey_qt.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_bundle/pydev_monkey_qt.py
@@ -17,7 +17,7 @@ _patched_qt = False
 
 def patch_qt(qt_support_mode):
     '''
-    This method patches qt (PySide, PyQt4, PyQt5) so that we have hooks to set the tracing for QThread.
+    This method patches qt (PySide2, PySide, PyQt4, PyQt5) so that we have hooks to set the tracing for QThread.
     '''
     if not qt_support_mode:
         return

--- a/plugins/org.python.pydev.core/pysrc/_pydevd_bundle/pydevd_command_line_handling.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydevd_bundle/pydevd_command_line_handling.py
@@ -119,13 +119,13 @@ def process_command_line(argv):
             # The --qt-support is special because we want to keep backward compatibility:
             # Previously, just passing '--qt-support' meant that we should use the auto-discovery mode
             # whereas now, if --qt-support is passed, it should be passed as --qt-support=<mode>, where
-            # mode can be one of 'auto', 'none', 'pyqt5', 'pyqt4', 'pyside'.
+            # mode can be one of 'auto', 'none', 'pyqt5', 'pyqt4', 'pyside', 'pyside2'.
             if argv[i] == '--qt-support':
                 setup['qt-support'] = 'auto'
 
             elif argv[i].startswith('--qt-support='):
                 qt_support = argv[i][len('--qt-support='):]
-                valid_modes = ('none', 'auto', 'pyqt5', 'pyqt4', 'pyside')
+                valid_modes = ('none', 'auto', 'pyqt5', 'pyqt4', 'pyside', 'pyside2')
                 if qt_support not in valid_modes:
                     raise ValueError("qt-support mode invalid: " + qt_support)
                 if qt_support == 'none':

--- a/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
+++ b/plugins/org.python.pydev.debug/src/org/python/pydev/debug/ui/launching/PythonRunnerConfig.java
@@ -979,6 +979,7 @@ public class PythonRunnerConfig {
                     case "pyqt5":
                     case "pyqt4":
                     case "pyside":
+                    case "pyside2":
                         cmdArgs.add("--qt-support=" + qtThreadsDebugMode);
                         break;
                 }

--- a/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyDevEditorPreferences.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/plugin/preferences/PyDevEditorPreferences.java
@@ -131,6 +131,7 @@ public class PyDevEditorPreferences {
             { "PyQt5", "pyqt5" },
             { "PyQt4", "pyqt4" },
             { "PySide", "pyside" },
+            { "PySide2", "pyside2" },
     };
 
     public static final String MAKE_LAUNCHES_WITH_M_FLAG = "MAKE_LAUNCHES_WITH_M_FLAG";


### PR DESCRIPTION
I believe pyside2 basic debugging support was already there, but would be triggered just if using "auto" and this can be problematic when having multiple Python Qt bindings installed. Also the comments and error messages may mislead the user into thinking it is not really supported.
This PR just explicitly adds also the handling for pyside2 option.