### PR TITLE
Fix for #PyDev-542: Automatic import doesn't check for trailing comma

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -198,26 +198,20 @@ public class AddTokenAndImportStatement {
                 String strToAdd = ", " + realImportHandleInfo.getImportedStr().get(0);
 
                 String line = PySelection.getLine(document, endLine);
+                line = line.trim();
+                int len = line.length();
+                int commaAmount = verifyComma(line); // gets the amount of commas at end of import
+                len -= commaAmount; // update the line length aux to offset before all commas at the end of import
+
                 if (line.length() + strToAdd.length() > maxCols) {
                     if (line.indexOf('#') == -1) {
                         //no comments: just add it in the next line
-                        int len = line.length();
-                        if (line.trim().endsWith(")")) {
-                            len = line.indexOf(")");
+                        if (line.endsWith(")")) {
+
+                            len--; // define offset to before ")"
                             strToAdd = "," + delimiter + computedInfo.indentString
                                     + realImportHandleInfo.getImportedStr().get(0);
                         } else {
-
-                            boolean withComma = true;
-
-                            while (withComma == true) {
-                                if (line.endsWith(",")) {
-                                    line = line.substring(0, len - 1);
-                                    len--;
-                                } else {
-                                    withComma = false;
-                                }
-                            }
 
                             strToAdd = ",\\" + delimiter + computedInfo.indentString
                                     + realImportHandleInfo.getImportedStr().get(0);
@@ -225,7 +219,7 @@ public class AddTokenAndImportStatement {
 
                         int end = lineInformation.getOffset() + len;
                         computedInfo.importLen = strToAdd.length();
-                        computedInfo.replace(end, 0, strToAdd);
+                        computedInfo.replace(end, commaAmount, strToAdd); //replace with strToAdd all the commas at the end of import
                         return;
 
                     }
@@ -233,27 +227,14 @@ public class AddTokenAndImportStatement {
                 } else {
                     //regular addition (it won't pass the number of columns expected).
                     line = PySelection.getLineWithoutCommentsOrLiterals(line);
-                    line = line.trim();
-                    int len = line.length();
 
                     if (line.endsWith(")")) {
-                        len = line.indexOf(")");
-                    }
-
-                    boolean withComma = true;
-
-                    while (withComma == true) {
-                        if (line.endsWith(",")) {
-                            line = line.substring(0, len - 1);
-                            len--;
-                        } else {
-                            withComma = false;
-                        }
+                        len--; // define offset to before ")"
                     }
 
                     int end = lineInformation.getOffset() + len;
                     computedInfo.importLen = strToAdd.length();
-                    computedInfo.replace(end, 0, strToAdd);
+                    computedInfo.replace(end, commaAmount, strToAdd); //replace with strToAdd all the commas at the end of import
                     return;
                 }
             }
@@ -270,6 +251,47 @@ public class AddTokenAndImportStatement {
         } catch (BadLocationException x) {
             Log.log(x);
         }
+    }
+
+    // function to get the amount of commas at the end of import string
+    private int verifyComma(String line) {
+        // TODO Auto-generated method stub
+        boolean withComma = true;
+        int commaAmount = 0;
+        int len = line.length();
+
+        if (line.endsWith(")")) {
+
+            line = line.substring(0, len - 1);
+            line = line.trim();
+            len--;
+
+            while (withComma == true) {
+                if (line.endsWith(",")) {
+                    line = line.substring(0, len - 1);
+                    len--;
+                    commaAmount++;
+                } else {
+                    withComma = false;
+                    line = line.concat(")");
+                    len++;
+                }
+            }
+
+        } else {
+
+            while (withComma == true) {
+                if (line.endsWith(",")) {
+                    line = line.substring(0, len - 1);
+                    len--;
+                    commaAmount++;
+                } else {
+                    withComma = false;
+                }
+            }
+        }
+
+        return commaAmount;
     }
 
     private String delimiter;

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -264,7 +264,7 @@ public class AddTokenAndImportStatement {
 
             line = line.substring(0, len - 1);
             line = line.trim();
-            len--;
+            len = line.length();
 
             while (withComma == true) {
                 if (line.endsWith(",")) {

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -207,6 +207,18 @@ public class AddTokenAndImportStatement {
                             strToAdd = "," + delimiter + computedInfo.indentString
                                     + realImportHandleInfo.getImportedStr().get(0);
                         } else {
+
+                            boolean withComma = true;
+
+                            while (withComma == true) {
+                                if (line.endsWith(",")) {
+                                    line = line.substring(0, len - 1);
+                                    len--;
+                                } else {
+                                    withComma = false;
+                                }
+                            }
+
                             strToAdd = ",\\" + delimiter + computedInfo.indentString
                                     + realImportHandleInfo.getImportedStr().get(0);
                         }
@@ -221,9 +233,22 @@ public class AddTokenAndImportStatement {
                 } else {
                     //regular addition (it won't pass the number of columns expected).
                     line = PySelection.getLineWithoutCommentsOrLiterals(line);
+                    line = line.trim();
                     int len = line.length();
-                    if (line.trim().endsWith(")")) {
+
+                    if (line.endsWith(")")) {
                         len = line.indexOf(")");
+                    }
+
+                    boolean withComma = true;
+
+                    while (withComma == true) {
+                        if (line.endsWith(",")) {
+                            line = line.substring(0, len - 1);
+                            len--;
+                        } else {
+                            withComma = false;
+                        }
                     }
 
                     int end = lineInformation.getOffset() + len;

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -1,0 +1,235 @@
+package com.python.pydev.analysis.refactoring.quick_fixes;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.python.pydev.core.log.Log;
+
+import com.python.pydev.analysis.refactoring.quick_fixes.AddTokenAndImportStatement.ComputedInfo;
+
+import junit.framework.TestCase;
+
+public class AddTokenAndImportStatementTest extends TestCase {
+
+    public String checkImport(String test_document, String test_realImportRep, int test_maxCols) throws Exception {
+
+        Document document = new Document(test_document);
+
+        char trigger = '\n';
+        int offset = 0;
+        boolean addLocalImport = false;
+        boolean addLocalImportsOnTopOfMethod = false;
+        boolean groupImports = true;
+        int maxCols = test_maxCols;
+
+        AddTokenAndImportStatement stmt = new AddTokenAndImportStatement(document, trigger, offset, addLocalImport,
+                addLocalImportsOnTopOfMethod,
+                groupImports, maxCols);
+
+        String realImportRep = test_realImportRep;
+        int fReplacementOffset = document.getLineLength(0);
+        int fLen = 0;
+        String indentString = "";
+        String fReplacementString = "";
+        boolean appliedWithTrigger = false;
+        int importLen = 0;
+
+        ComputedInfo computedInfo = new ComputedInfo(realImportRep, fReplacementOffset, fLen, indentString,
+                fReplacementString, appliedWithTrigger, importLen, document);
+        stmt.createTextEdit(computedInfo);
+
+        for (ReplaceEdit edit : computedInfo.replaceEdit) {
+            try {
+                edit.apply(document);
+            } catch (Exception e) {
+                Log.log(e);
+            }
+        }
+
+        return document.get();
+
+    }
+
+    // normal test
+    public void test1() throws Exception {
+        String test_document = "from math import ceil";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import ceil, sqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comma
+    public void test2() throws Exception {
+        String test_document = "from math import ceil,";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import ceil, sqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comment
+    public void test3() throws Exception {
+        String test_document = "from math import ceil #foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import ceil #foofrom math import sqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis and comment
+    public void test4() throws Exception {
+        String test_document = "from math import (ceil) #foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import (ceil) #foofrom math import sqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis, comma and comment
+    public void test5() throws Exception {
+        String test_document = "from math import (ceil,) #foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import (ceil,) #foofrom math import sqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis
+    public void test6() throws Exception {
+        String test_document = "from math import (ceil)";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import (ceil, sqrt)";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis and comma
+    public void test7() throws Exception {
+        String test_document = "from math import (ceil,)";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 80);
+
+        String expected = "from math import (ceil, sqrt)";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with cols limit exceeded
+    public void test8() throws Exception {
+        String test_document = "from math import ceil";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import ceil,\\\nsqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comma and cols limit exceeded
+    public void test9() throws Exception {
+        String test_document = "from math import ceil,";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import ceil,\\\nsqrt";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis and cols limit exceeded
+    public void test10() throws Exception {
+        String test_document = "from math import (ceil)";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import (ceil,\nsqrt)";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with parenthesis, comma and cols limit exceeded
+    public void test11() throws Exception {
+        String test_document = "from math import (ceil,)";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import (ceil,\nsqrt)";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comments after cols limit exceeded 
+    public void test12() throws Exception {
+        String test_document = "from math import ceil\n#foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import ceil,\\\nsqrt\n#foo";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comments after comma and cols limit exceeded
+    public void test13() throws Exception {
+        String test_document = "from math import ceil,\n#foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import ceil,\\\nsqrt\n#foo";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comments after parenthesis and cols limit exceeded
+    public void test14() throws Exception {
+        String test_document = "from math import (ceil)\n#foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import (ceil,\nsqrt)\n#foo";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    // test with comments after parenthesis, comma and cols limit exceeded
+    public void test15() throws Exception {
+        String test_document = "from math import (ceil,)\n#foo";
+        String test_realImportRep = "from math import sqrt";
+        String doc = checkImport(test_document, test_realImportRep, 20);
+
+        String expected = "from math import (ceil,\nsqrt)\n#foo";
+        String actual = doc;
+        assertEquals(expected, actual);
+    }
+
+    public void testall() throws Exception {
+        test1();
+        test2();
+        test3();
+        test4();
+        test5();
+        test6();
+        test7();
+        test8();
+        test9();
+        test10();
+        test11();
+        test12();
+        test13();
+        test14();
+        test15();
+    }
+
+}


### PR DESCRIPTION
I made a function to check how many commas are in the import line, so I defined the position of the replacement cursor based on the function return.