### PR TITLE
Fix for #PyDev-542: Automatic import doesn't check for trailing comma

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -196,8 +196,8 @@ public class AddTokenAndImportStatement {
                 String endLineWithoutComment = PySelection.getLineWithoutCommentsOrLiterals(endLine); // also get the string of last line, but without comments
 
                 // get the string of full import statement, from first line to the last
-                String fullImportStatement = document.get().substring(startLineOffset,
-                        endLineOffset + endLineWithoutComment.length());
+                String fullImportStatement = document.get(startLineOffset,
+                        endLineOffset + endLineWithoutComment.length() - startLineOffset);
 
                 int importsLen = groupInto.getImportedStr().size(); // just get how many group imports have in import declaration
                 String lastImportedStr = groupInto.getImportedStr().get(importsLen - 1); // get the string from the last import

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -140,14 +140,9 @@ public class AddTokenAndImportStatement {
                                     }
                                     if (realImportHandleInfo.getFromImportStrWithoutUnwantedChars().equals(
                                             importHandleInfo.getFromImportStrWithoutUnwantedChars())) {
-                                        List<String> commentsForImports = importHandleInfo.getCommentsForImports();
 
-                                        if (commentsForImports.size() > 0
-                                                && commentsForImports.get(commentsForImports.size() - 1)
-                                                        .length() != 0) {
-                                            groupInto = importHandleInfo;
-                                            break;
-                                        }
+                                        groupInto = importHandleInfo;
+                                        break;
                                     }
                                 }
                             }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -140,9 +140,14 @@ public class AddTokenAndImportStatement {
                                     }
                                     if (realImportHandleInfo.getFromImportStrWithoutUnwantedChars().equals(
                                             importHandleInfo.getFromImportStrWithoutUnwantedChars())) {
+                                        List<String> commentsForImports = importHandleInfo.getCommentsForImports();
 
-                                        groupInto = importHandleInfo;
-                                        break;
+                                        if (commentsForImports.size() > 0
+                                                && commentsForImports.get(commentsForImports.size() - 1)
+                                                        .length() != 0) {
+                                            groupInto = importHandleInfo;
+                                            break;
+                                        }
                                     }
                                 }
                             }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -206,10 +206,10 @@ public class AddTokenAndImportStatement {
                 if (importsLen > 1) {
                     String penultImportedStr = groupInto.getImportedStr().get(importsLen - 2); // if import declaration has more than 1 imports, get the penult import
                     int penultImportedStrOffset = fullImportStatement.indexOf(penultImportedStr) + startLineOffset;
-                    int penultLineNum = document.getLineOfOffset(penultImportedStrOffset); // get the number of penult import line
+                    int penultImportedStrLineNum = document.getLineOfOffset(penultImportedStrOffset); // get the line number of penult import
 
-                    // if the penult import line doesn't surpassed columns value of document, get the standard user setted
-                    if (PySelection.getLine(document, penultLineNum).length() <= 80) {
+                    // if the penult import line doesn't surpassed document columns value, get the setted standard import style by user
+                    if (PySelection.getLine(document, penultImportedStrLineNum).length() <= 80) {
                         groupImportStandard = getGroupImportStandard(lastImportedStr, penultImportedStr,
                                 fullImportStatement);
                     }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatement.java
@@ -190,6 +190,7 @@ public class AddTokenAndImportStatement {
             if (groupInto != null && realImportHandleInfo != null) {
                 //let's try to group it
                 int endLine = groupInto.getEndLine();
+                IRegion lineInformation = document.getLineInformation(endLine);
                 String line = PySelection.getLine(document, endLine);
                 String lineWithoutComment = PySelection.getLineWithoutCommentsOrLiterals(line); // get line without comments for future uses
 
@@ -200,7 +201,8 @@ public class AddTokenAndImportStatement {
                 int offsetDiff = getOffsetDiff(line, lineWithoutComment, lineContainComment); // get difference of characters from real end of import and end with all commas, spaces and tabs
 
                 String lastImportedStr = groupInto.getImportedStr().get(groupInto.getImportedStr().size() - 1); // get the string from the last import
-                int offset = getOffset(line, lineWithoutComment, lineContainComment, lastImportedStr); // get offset based on the end of last import
+                int offset = getOffset(line, lineWithoutComment, lineInformation.getOffset(), lineContainComment,
+                        lastImportedStr); // get offset based on the end of last import
 
                 String lastImportStrParenthesis = ""; // just get a string to add on every strToAdd definition, it will concat ')' if import string has "(xx)" style
                 // it is here because offsetDiff for standard remove all spaces and tabs after ')' if import string doesn't have comment
@@ -251,7 +253,8 @@ public class AddTokenAndImportStatement {
     }
 
     // get the offset based on the last string from import
-    private int getOffset(String line, String lineWithoutComment, boolean lineContainComment, String lastImportedStr) {
+    private int getOffset(String line, String lineWithoutComment, int endLineOffset, boolean lineContainComment,
+            String lastImportedStr) {
 
         int offset;
 
@@ -261,7 +264,7 @@ public class AddTokenAndImportStatement {
             offset = line.indexOf(lastImportedStr) + lastImportedStr.length();
         }
 
-        return offset;
+        return offset + endLineOffset;
     }
 
     // get offset difference from import end offset and offset to insert strToAdd

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -47,7 +47,7 @@ public class AddTokenAndImportStatementTest extends TestCase {
         assertEquals(expectedDoc, document.get());
     }
 
-    // test all case possibilities
+    // test all possibility cases
     public void testAllCases() throws Exception {
 
         // -- TESTS WITH STANDARD COLS VALUE -- //
@@ -459,6 +459,8 @@ public class AddTokenAndImportStatementTest extends TestCase {
         */
         // -- TESTS WITH COMMENTS INLINE -- //
 
+        // -- TESTS WITH AN IMPORT COMMENTED AND LINE BREAK -- //
+
         // normal situation
         checkImport("from math import ceil#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
 
@@ -519,10 +521,84 @@ public class AddTokenAndImportStatementTest extends TestCase {
 
         // -- END OF TESTS WITH COMMENTS INLINE -- //
 
+        // -- TESTS WITH AN IMPORT COMMENTED AND A LINE BREAK -- //
+
         // normal situation
         checkImport("#from math import ceil\nfrom math import sqrt", "from math import fmod",
                 "#from math import ceil\nfrom math import sqrt, fmod",
                 80);
+
+        // test with multiple spaces and tabs
+        checkImport("#from math import ceil  \nfrom math import sqrt   ", "from math import fmod",
+                "#from math import ceil  \nfrom math import sqrt, fmod",
+                80);
+
+        // test with comma
+        checkImport("#from math import ceil\nfrom math import sqrt,", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod",
+                80);
+
+        // test with commas
+        checkImport("#from math import ceil\nfrom math import sqrt,,,,", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod",
+                80);
+
+        // test with commas, spaces and tabs
+        checkImport("#from math import ceil\nfrom math import sqrt,,,    ", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod",
+                80);
+
+        // test with "(xxxx)"
+        checkImport("#from math import ceil\nfrom math import (sqrt)", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("#from math import ceil\nfrom math import (sqrt)  ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)" and multiple spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt    )", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt   )    ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)" and comma
+        checkImport("#from math import ceil\nfrom math import (sqrt,)", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("#from math import ceil\nfrom math import (sqrt,)    ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)" and commas
+        checkImport("#from math import ceil\nfrom math import (sqrt,,,)", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)", spaces after and commas
+        checkImport("#from math import ceil\nfrom math import (sqrt,,,)   ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt,,,   )", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)", spaces after, commas and spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt,,,   )       ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // -- END OF TESTS WITH AN IMPORT COMMENTED AND LINE BREAK -- //
 
     }
 }

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -226,215 +226,114 @@ public class AddTokenAndImportStatementTest extends TestCase {
 
         // -- END OF TESTS WITH COMMENTS INLINE -- //
 
-        // -- TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
-        /*
-        // normal situation with tabs and spaces before
-        checkImport("    from math import ceil", "from math import sqrt", "    from math import ceil, sqrt", 80);
-        
-        // test with multiple spaces and tabs
-        checkImport("    from math import ceil          ", "from math import sqrt",
-                "    from math import ceil, sqrt", 80);
-        
-        // test with comma
-        checkImport("    from math import ceil,", "from math import sqrt", "    from math import ceil, sqrt", 80);
-        
-        // test with commas
-        checkImport("    from math import ceil,,,,", "from math import sqrt", "    from math import ceil, sqrt", 80);
-        
-        // test with commas, spaces and tabs
-        checkImport("    from math import ceil,,,,           ", "from math import sqrt",
-                "    from math import ceil, sqrt", 80);
-        
+        // -- TESTS WITH COLS LIMIT EXCEDEED -- //
+
+        // normal situation
+        checkImport("from math import ceil", "from math import sqrt", "from math import ceil,\\\r\nsqrt", 20);
+
+        // test with multiple spaces and tabs -> style conserves
+        checkImport("from math import ceil      ", "from math import sqrt",
+                "from math import ceil,\\\r\nsqrt      ", 20);
+
         // test with "(xxxx)"
-        checkImport("    from math import (ceil)", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
-        
+        checkImport("from math import (ceil)", "from math import sqrt", "from math import (ceil,\r\nsqrt)", 20);
+
         // test with "(xxxx)" and spaces after
-        checkImport("    from math import (ceil)   ", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
-        
+        checkImport("from math import (ceil)   ", "from math import sqrt", "from math import (ceil,\r\nsqrt)   ", 20);
+
         //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("    from math import (ceil       )", "from math import sqrt", "    from math import (ceil, sqrt)",
-                80);
-        
+        checkImport("from math import (ceil       )", "from math import sqrt",
+                "from math import (ceil,\r\nsqrt       )",
+                20);
+
         //!! test with "(xxxx)", spaces after and multiple spaces and tabs
-        checkImport("from math import (ceil       )   ", "from math import sqrt", "    from math import (ceil, sqrt)",
-                80);
-        
+        checkImport("from math import (ceil       )   ", "from math import sqrt",
+                "from math import (ceil,\r\nsqrt       )   ", 20);
+
         // test with "(xxxx)" and comma
-        checkImport("    from math import (ceil,)", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
-        
+        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil,\r\nsqrt,)", 20);
+
         // test with "(xxxx)", spaces after and comma
-        checkImport("    from math import (ceil,)    ", "from math import sqrt", "    from math import (ceil, sqrt)",
-                80);
-        
-        // test with "(xxxx)" and commas
-        checkImport("    from math import (ceil,,,,)", "from math import sqrt", "    from math import (ceil, sqrt)",
-                80);
-        
-        // test with "(xxxx)", spaces after and commas
-        checkImport("    from math import (ceil,,,,)     ", "from math import sqrt",
-                "    from math import (ceil, sqrt)", 80);
-        
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("    from math import (ceil,,,,     )", "from math import sqrt",
-                "    from math import (ceil, sqrt)", 80);
-        
-        // test with "(xxxx)", spaces after, commas and spaces and tabs
-        checkImport("    from math import (ceil,,,,     )    ", "from math import sqrt",
-                "    from math import (ceil, sqrt)",
-                80);
-        
-        // -- END OF TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
-        
-        // -- TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
-        
+        checkImport("from math import (ceil,)    ", "from math import sqrt", "from math import (ceil,\r\nsqrt,)    ",
+                20);
+
+        // -- END OF TESTS WITH COLS LIMIT EXCEDEED -- //
+
+        // -- TESTS WITH MULTI-LINE DECLARATIONS -- //
+
         // normal situation
-        checkImport("     from math import ceil", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
-        
-        // test with multiple spaces or tabs
-        checkImport("     from math import ceil  ", "from math import sqrt",
-               "     from math import ceil,\\\nsqrt", 20);
-        
-        // test with comma
-        checkImport("     from math import ceil,", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
-        
-        // test with commas
-        checkImport("     from math import ceil,,,", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
-        
-        // test with commas, spaces and tabs
-        checkImport("     from math import ceil,,  ", "from math import sqrt", "     from math import ceil,\\\nsqrt",
-               20);
-        
+        checkImport("from math import ceil,\\\r\nsqrt", "from math import fmod",
+                "from math import ceil,\\\r\nsqrt,\\\r\nfmod", 80);
+
+        // test with multiple spaces and tabs -> style conserves
+        checkImport("from math import ceil,\\\r\nsqrt      ", "from math import fmod",
+                "from math import ceil,\\\r\nsqrt,\\\r\nfmod      ", 80);
+
         // test with "(xxxx)"
-        checkImport("     from math import (ceil)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and spaces and tabs after
-        checkImport("     from math import (ceil)    ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("     from math import (ceil  )", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        //!! test with "(xxxx)", spaces and tabs after with multiple spaces and tabs
-        checkImport("     from math import (ceil  )   ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and comma
-        checkImport("     from math import (ceil,)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and spaces and tabs after with comma
-        checkImport("     from math import (ceil,)    ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and commas
-        checkImport("     from math import (ceil,,,)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and spaces and tabs after with commas
-        checkImport("     from math import (ceil,,,)      ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("     from math import (ceil,,  )", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", spaces and tabs after and commas, spaces and tabs
-        checkImport("     from math import (ceil,,  )     ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
-        
-        // -- END OF TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
-        
-        // -- TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
-        /*
-        // normal situation
-        checkImport("    from math import ceil\n#foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n#foo", 20);
-        
-        // normal situation and spaces after
-        checkImport("    from math import ceil\n     #foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n     #foo",
-                20);
-        
-        // test with multiple spaces and tabs
-        checkImport("    from math import ceil          \n#foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n#foo", 20);
-        
-        // test with multiple spaces and tabs and spaces after
-        checkImport("    from math import ceil          \n     #foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n     #foo", 20);
-        
-        // test with comma
-        checkImport("    from math import ceil,\n#foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n#foo",
-                20);
-        
-        // test with comma and spaces after
-        checkImport("    from math import ceil,\n     #foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n     #foo",
-                20);
-        
-        // test with commas
-        checkImport("    from math import ceil,,,,\n#foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n#foo",
-                20);
-        
-        // test with commas and spaces after
-        checkImport("    from math import ceil,,,,\n     #foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n     #foo",
-                20);
-        
-        // test with commas, spaces and tabs
-        checkImport("    from math import ceil,,,,           \n#foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n#foo",
-                20);
-        
-        // test with commas, spaces and tabs and spaces after
-        checkImport("    from math import ceil,,,,           \n     #foo", "from math import sqrt",
-                "    from math import ceil,\\\nsqrt\n     #foo",
-                20);
-        
-        // test with "(xxxx)"
-        checkImport("    from math import (ceil)\n#foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo",
-                20);
-        
+        checkImport("from math import (ceil,\r\nsqrt)", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod)", 80);
+
         // test with "(xxxx)" and spaces after
-        checkImport("    from math import (ceil)\n     #foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n     #foo",
-                20);
-        
+        checkImport("from math import (ceil,\r\nsqrt)   ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod)   ", 80);
+
         //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("    from math import (ceil       )\n#foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo",
-                20);
-        
-        // test with "(xxxx)" and multiple spaces and tabs and spaces after
-        checkImport("    from math import (ceil       )\n     #foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n     #foo",
-                20);
-        
+        checkImport("from math import (ceil,\r\nsqrt       )", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod       )",
+                80);
+
+        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("from math import (ceil,\r\nsqrt       )   ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod       )   ", 80);
+
         // test with "(xxxx)" and comma
-        checkImport("    from math import (ceil,)\n#foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo",
+        checkImport("from math import (ceil,\r\nsqrt,)", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod,)", 80);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("from math import (ceil,\r\nsqrt,)    ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod,)    ",
+                80);
+
+        // -- END OF TESTS WITH MULTI-LINE DECLARATIONS -- //
+
+        // -- TESTS WITH MULTI-LINE DECLARATIONS AND COLS LIMIT EXCEDEED -- //
+
+        // normal situation
+        checkImport("from math import ceil,\\\r\nsqrt", "from math import fmod",
+                "from math import ceil,\\\r\nsqrt,\\\r\nfmod", 20);
+
+        // test with multiple spaces and tabs -> style conserves
+        checkImport("from math import ceil,\\\r\nsqrt      ", "from math import fmod",
+                "from math import ceil,\\\r\nsqrt,\\\r\nfmod      ", 20);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil,\r\nsqrt)", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod)", 20);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("from math import (ceil,\r\nsqrt)   ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod)   ", 20);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil,\r\nsqrt       )", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod       )",
                 20);
-        
-        // test with "(xxxx)" and comma and spaces after
-        checkImport("    from math import (ceil,)\n     #foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n     #foo",
+
+        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("from math import (ceil,\r\nsqrt       )   ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod       )   ", 20);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,\r\nsqrt,)", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod,)", 20);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("from math import (ceil,\r\nsqrt,)    ", "from math import fmod",
+                "from math import (ceil,\r\nsqrt,\r\nfmod,)    ",
                 20);
-        
-        // test with "(xxxx)" and commas
-        checkImport("    from math import (ceil,,,,)\n#foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo", 20);
-        
-        // test with "(xxxx)" and commas and spaces after
-        checkImport("    from math import (ceil,,,,)\n     #foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n     #foo", 20);
-        
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("    from math import (ceil,,,,     )\n#foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo",
-                20);
-        
-        // test with "(xxxx)", commas, spaces and tabs and spaces after
-        checkImport("    from math import (ceil,,,,     )\n     #foo", "from math import sqrt",
-                "    from math import (ceil,\nsqrt)\n#foo",
-                20);
-        
-        // -- END OF TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
-        */
+
+        // -- END OF TESTS WITH MULTI-LINE DECLARATIONS AND COLS LIMIT EXCEDEED -- //
 
     }
 }

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -1,0 +1,522 @@
+package com.python.pydev.analysis.refactoring.quick_fixes;
+
+import org.eclipse.jface.text.Document;
+import org.eclipse.text.edits.ReplaceEdit;
+import org.python.pydev.core.log.Log;
+
+import com.python.pydev.analysis.refactoring.quick_fixes.AddTokenAndImportStatement.ComputedInfo;
+
+import junit.framework.TestCase;
+
+public class AddTokenAndImportStatementTest extends TestCase {
+
+    public void checkImport(String baseDoc, String importToAdd, String expectedDoc, int maxCols) throws Exception {
+
+        Document document = new Document(baseDoc);
+
+        char trigger = '\n';
+        int offset = 0;
+        boolean addLocalImport = false;
+        boolean addLocalImportsOnTopOfMethod = false;
+        boolean groupImports = true;
+
+        AddTokenAndImportStatement stmt = new AddTokenAndImportStatement(document, trigger, offset, addLocalImport,
+                addLocalImportsOnTopOfMethod,
+                groupImports, maxCols);
+
+        String realImportRep = importToAdd;
+        int fReplacementOffset = document.getLineLength(0);
+        int fLen = 0;
+        String indentString = "";
+        String fReplacementString = "";
+        boolean appliedWithTrigger = false;
+        int importLen = 0;
+
+        ComputedInfo computedInfo = new ComputedInfo(realImportRep, fReplacementOffset, fLen, indentString,
+                fReplacementString, appliedWithTrigger, importLen, document);
+        stmt.createTextEdit(computedInfo);
+
+        for (ReplaceEdit edit : computedInfo.replaceEdit) {
+            try {
+                edit.apply(document);
+            } catch (Exception e) {
+                Log.log(e);
+            }
+        }
+
+        assertEquals(expectedDoc, document.get());
+    }
+
+    // test all case possibilities
+    public void testAllCases() throws Exception {
+
+        // -- TESTS WITH STANDARD COLS VALUE -- //
+
+        // normal situation
+        checkImport("from math import ceil", "from math import sqrt", "from math import ceil, sqrt", 80);
+
+        // test with multiple spaces and tabs
+        checkImport("from math import ceil          ", "from math import sqrt",
+                "from math import ceil, sqrt", 80);
+
+        // test with comma
+        checkImport("from math import ceil,", "from math import sqrt", "from math import ceil, sqrt", 80);
+
+        // test with commas
+        checkImport("from math import ceil,,,,", "from math import sqrt", "from math import ceil, sqrt", 80);
+
+        // test with commas, spaces and tabs
+        checkImport("from math import ceil,,,,           ", "from math import sqrt", "from math import ceil, sqrt", 80);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("from math import (ceil)   ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil       )", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("from math import (ceil       )   ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("from math import (ceil,)    ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)" and commas
+        checkImport("from math import (ceil,,,,)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)", spaces after and commas
+        checkImport("from math import (ceil,,,,)     ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("from math import (ceil,,,,     )", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+
+        // test with "(xxxx)", spaces after, commas and spaces and tabs
+        checkImport("from math import (ceil,,,,     )    ", "from math import sqrt", "from math import (ceil, sqrt)",
+                80);
+
+        // -- END OF TESTS WITH STANDARD COLS VALUE -- //
+
+        // -- TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
+        /*
+        // normal situation with tabs and spaces before
+        checkImport("    from math import ceil", "from math import sqrt", "    from math import ceil, sqrt", 80);
+        
+        // test with multiple spaces and tabs
+        checkImport("    from math import ceil          ", "from math import sqrt",
+                "    from math import ceil, sqrt", 80);
+        
+        // test with comma
+        checkImport("    from math import ceil,", "from math import sqrt", "    from math import ceil, sqrt", 80);
+        
+        // test with commas
+        checkImport("    from math import ceil,,,,", "from math import sqrt", "    from math import ceil, sqrt", 80);
+        
+        // test with commas, spaces and tabs
+        checkImport("    from math import ceil,,,,           ", "from math import sqrt",
+                "    from math import ceil, sqrt", 80);
+        
+        // test with "(xxxx)"
+        checkImport("    from math import (ceil)", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
+        
+        // test with "(xxxx)" and spaces after
+        checkImport("    from math import (ceil)   ", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
+        
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("    from math import (ceil       )", "from math import sqrt", "    from math import (ceil, sqrt)",
+                80);
+        
+        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("from math import (ceil       )   ", "from math import sqrt", "    from math import (ceil, sqrt)",
+                80);
+        
+        // test with "(xxxx)" and comma
+        checkImport("    from math import (ceil,)", "from math import sqrt", "    from math import (ceil, sqrt)", 80);
+        
+        // test with "(xxxx)", spaces after and comma
+        checkImport("    from math import (ceil,)    ", "from math import sqrt", "    from math import (ceil, sqrt)",
+                80);
+        
+        // test with "(xxxx)" and commas
+        checkImport("    from math import (ceil,,,,)", "from math import sqrt", "    from math import (ceil, sqrt)",
+                80);
+        
+        // test with "(xxxx)", spaces after and commas
+        checkImport("    from math import (ceil,,,,)     ", "from math import sqrt",
+                "    from math import (ceil, sqrt)", 80);
+        
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("    from math import (ceil,,,,     )", "from math import sqrt",
+                "    from math import (ceil, sqrt)", 80);
+        
+        // test with "(xxxx)", spaces after, commas and spaces and tabs
+        checkImport("    from math import (ceil,,,,     )    ", "from math import sqrt",
+                "    from math import (ceil, sqrt)",
+                80);
+        
+        // -- END OF TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
+        */
+        /*
+         * 
+         * // -- TESTS WITH COLS LIMIT EXCEDEED WITHOUT COMMENTS -- //
+        
+        // normal situation
+        checkImport("from math import ceil", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
+        
+        // test with multiple spaces or tabs
+        checkImport("from math import ceil  ", "from math import sqrt",
+                "from math import ceil,\\\nsqrt", 20);
+        
+        // test with comma
+        checkImport("from math import ceil,", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
+        
+        // test with commas
+        checkImport("from math import ceil,,,", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
+        
+        // test with commas, spaces and tabs
+        checkImport("from math import ceil,,  ", "from math import sqrt", "from math import ceil,\\\nsqrt",
+                20);
+        
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", spaces and tabs after
+        checkImport("from math import (ceil)     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil  )", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        //!! test with "(xxxx)", spaces and tabs after with multiple spaces and tabs
+        checkImport("from math import (ceil  )    ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", spaces and tabs after with comma
+        checkImport("from math import (ceil,)     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and commas
+        checkImport("from math import (ceil,,,)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", spaces and tabs after with commas
+        checkImport("from math import (ceil,,,)   ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("from math import (ceil,,  )", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", spaces and tabs after with commas, spaces and tabs
+        checkImport("from math import (ceil,,  )     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
+        
+         * // -- END OF TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE WITHOUT COMMENTS -- //
+         * 
+         *         // -- TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
+        
+        // normal situation
+        checkImport("     from math import ceil", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
+        
+        // test with multiple spaces or tabs
+        checkImport("     from math import ceil  ", "from math import sqrt",
+                "     from math import ceil,\\\nsqrt", 20);
+        
+        // test with comma
+        checkImport("     from math import ceil,", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
+        
+        // test with commas
+        checkImport("     from math import ceil,,,", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
+        
+        // test with commas, spaces and tabs
+        checkImport("     from math import ceil,,  ", "from math import sqrt", "     from math import ceil,\\\nsqrt",
+                20);
+        
+        // test with "(xxxx)"
+        checkImport("     from math import (ceil)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and spaces and tabs after
+        checkImport("     from math import (ceil)    ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("     from math import (ceil  )", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        //!! test with "(xxxx)", spaces and tabs after with multiple spaces and tabs
+        checkImport("     from math import (ceil  )   ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and comma
+        checkImport("     from math import (ceil,)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and spaces and tabs after with comma
+        checkImport("     from math import (ceil,)    ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and commas
+        checkImport("     from math import (ceil,,,)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)" and spaces and tabs after with commas
+        checkImport("     from math import (ceil,,,)      ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("     from math import (ceil,,  )", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // test with "(xxxx)", spaces and tabs after and commas, spaces and tabs
+        checkImport("     from math import (ceil,,  )     ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
+        
+        // -- END OF TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
+        */
+        // -- TESTS WITH COLS LIMIT EXCEDEED WITH COMMENTS NEXT LINE -- //
+
+        // normal situation
+        checkImport("from math import ceil\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo", 20);
+
+        // normal situation and spaces after
+        checkImport("from math import ceil\n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo",
+                20);
+
+        // test with multiple spaces and tabs
+        checkImport("from math import ceil          \n#foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n#foo", 20);
+
+        // test with multiple spaces and tabs and spaces after
+        checkImport("from math import ceil          \n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo", 20);
+
+        // test with comma
+        checkImport("from math import ceil,\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo",
+                20);
+
+        // test with comma and spaces after
+        checkImport("from math import ceil,\n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo",
+                20);
+
+        // test with commas
+        checkImport("from math import ceil,,,,\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo",
+                20);
+
+        // test with commas and spaces after
+        checkImport("from math import ceil,,,,\n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo",
+                20);
+
+        // test with commas, spaces and tabs
+        checkImport("from math import ceil,,,,           \n#foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n#foo",
+                20);
+
+        // test with commas, spaces and tabs and spaces after
+        checkImport("from math import ceil,,,,           \n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo",
+                20);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt)\n#foo",
+                20);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("from math import (ceil)\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo",
+                20);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil       )\n#foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n#foo",
+                20);
+
+        // test with "(xxxx)" and multiple spaces and tabs and spaces after
+        checkImport("from math import (ceil       )\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo",
+                20);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt)\n#foo",
+                20);
+
+        // test with "(xxxx)" and comma and spaces after
+        checkImport("from math import (ceil,)\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo",
+                20);
+
+        // test with "(xxxx)" and commas
+        checkImport("from math import (ceil,,,,)\n#foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n#foo", 20);
+
+        // test with "(xxxx)" and commas and spaces after
+        checkImport("from math import (ceil,,,,)\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo", 20);
+
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("from math import (ceil,,,,     )\n#foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n#foo",
+                20);
+
+        // test with "(xxxx)", commas, spaces and tabs and spaces after
+        checkImport("from math import (ceil,,,,     )\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo",
+                20);
+
+        // -- END OF TESTS WITH COLS EXCEDEED WITH COMMENTS NEXT LINE -- //
+
+        // -- TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
+        /*
+        // normal situation
+        checkImport("    from math import ceil\n#foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n#foo", 20);
+        
+        // normal situation and spaces after
+        checkImport("    from math import ceil\n     #foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n     #foo",
+                20);
+        
+        // test with multiple spaces and tabs
+        checkImport("    from math import ceil          \n#foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n#foo", 20);
+        
+        // test with multiple spaces and tabs and spaces after
+        checkImport("    from math import ceil          \n     #foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n     #foo", 20);
+        
+        // test with comma
+        checkImport("    from math import ceil,\n#foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n#foo",
+                20);
+        
+        // test with comma and spaces after
+        checkImport("    from math import ceil,\n     #foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n     #foo",
+                20);
+        
+        // test with commas
+        checkImport("    from math import ceil,,,,\n#foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n#foo",
+                20);
+        
+        // test with commas and spaces after
+        checkImport("    from math import ceil,,,,\n     #foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n     #foo",
+                20);
+        
+        // test with commas, spaces and tabs
+        checkImport("    from math import ceil,,,,           \n#foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n#foo",
+                20);
+        
+        // test with commas, spaces and tabs and spaces after
+        checkImport("    from math import ceil,,,,           \n     #foo", "from math import sqrt",
+                "    from math import ceil,\\\nsqrt\n     #foo",
+                20);
+        
+        // test with "(xxxx)"
+        checkImport("    from math import (ceil)\n#foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo",
+                20);
+        
+        // test with "(xxxx)" and spaces after
+        checkImport("    from math import (ceil)\n     #foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n     #foo",
+                20);
+        
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("    from math import (ceil       )\n#foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo",
+                20);
+        
+        // test with "(xxxx)" and multiple spaces and tabs and spaces after
+        checkImport("    from math import (ceil       )\n     #foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n     #foo",
+                20);
+        
+        // test with "(xxxx)" and comma
+        checkImport("    from math import (ceil,)\n#foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo",
+                20);
+        
+        // test with "(xxxx)" and comma and spaces after
+        checkImport("    from math import (ceil,)\n     #foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n     #foo",
+                20);
+        
+        // test with "(xxxx)" and commas
+        checkImport("    from math import (ceil,,,,)\n#foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo", 20);
+        
+        // test with "(xxxx)" and commas and spaces after
+        checkImport("    from math import (ceil,,,,)\n     #foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n     #foo", 20);
+        
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("    from math import (ceil,,,,     )\n#foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo",
+                20);
+        
+        // test with "(xxxx)", commas, spaces and tabs and spaces after
+        checkImport("    from math import (ceil,,,,     )\n     #foo", "from math import sqrt",
+                "    from math import (ceil,\nsqrt)\n#foo",
+                20);
+        
+        // -- END OF TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
+        */
+        // -- TESTS WITH COMMENTS INLINE -- //
+
+        // normal situation
+        checkImport("from math import ceil#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
+
+        // test with multiple spaces or tabs
+        checkImport("from math import ceil          #foo", "from math import sqrt",
+                "from math import ceil, sqrt          #foo", 80);
+
+        // test with comma
+        checkImport("from math import ceil,#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
+
+        // test with commas
+        checkImport("from math import ceil,,,,#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
+
+        // test with commas, spaces and tabs
+        checkImport("from math import ceil,,,,           #foo", "from math import sqrt",
+                "from math import ceil, sqrt           #foo", 80);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo", 80);
+
+        // test with "(xxxx)", spaces and tabs before comment and spaces and tabs before comment
+        checkImport("from math import (ceil)     #foo", "from math import sqrt",
+                "from math import (ceil, sqrt)     #foo",
+                80);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil       )#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo",
+                80);
+
+        //!! test with "(xxxx)", spaces and tabs before comment and multiple spaces and tabs
+        checkImport("from math import (ceil       )   #foo", "from math import sqrt",
+                "from math import (ceil, sqrt)   #foo",
+                80);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo", 80);
+
+        // test with "(xxxx)", spaces and tabs before comment and comma
+        checkImport("from math import (ceil,)   #foo", "from math import sqrt", "from math import (ceil, sqrt)   #foo",
+                80);
+
+        // test with "(xxxx)" and commas
+        checkImport("from math import (ceil,,,,)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo",
+                80);
+
+        // test with "(xxxx)", spaces and tabs before comment and commas
+        checkImport("from math import (ceil,,,,)   #foo", "from math import sqrt",
+                "from math import (ceil, sqrt)   #foo",
+                80);
+
+        // test with "(xxxx)", commas, spaces and tabs
+        checkImport("from math import (ceil,,,,     )#foo", "from math import sqrt",
+                "from math import (ceil, sqrt)#foo", 80);
+
+        // test with "(xxxx)", spaces and tabs before comment and commas, spaces and tabs
+        checkImport("from math import (ceil,,,,     )   #foo", "from math import sqrt",
+                "from math import (ceil, sqrt)   #foo", 80);
+
+        // -- END OF TESTS WITH COMMENTS INLINE -- //
+    }
+}

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -55,51 +55,176 @@ public class AddTokenAndImportStatementTest extends TestCase {
         // normal situation
         checkImport("from math import ceil", "from math import sqrt", "from math import ceil, sqrt", 80);
 
-        // test with multiple spaces and tabs
+        // test with multiple spaces and tabs -> style conserves
         checkImport("from math import ceil          ", "from math import sqrt",
-                "from math import ceil, sqrt", 80);
-
-        // test with comma
-        checkImport("from math import ceil,", "from math import sqrt", "from math import ceil, sqrt", 80);
-
-        // test with commas
-        checkImport("from math import ceil,,,,", "from math import sqrt", "from math import ceil, sqrt", 80);
-
-        // test with commas, spaces and tabs
-        checkImport("from math import ceil,,,,           ", "from math import sqrt", "from math import ceil, sqrt", 80);
+                "from math import ceil, sqrt          ", 80);
 
         // test with "(xxxx)"
         checkImport("from math import (ceil)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
 
         // test with "(xxxx)" and spaces after
-        checkImport("from math import (ceil)   ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
+        checkImport("from math import (ceil)   ", "from math import sqrt", "from math import (ceil, sqrt)   ", 80);
 
         //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("from math import (ceil       )", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
-        checkImport("from math import (ceil       )   ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)" and comma
-        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)", spaces after and comma
-        checkImport("from math import (ceil,)    ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)" and commas
-        checkImport("from math import (ceil,,,,)", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)", spaces after and commas
-        checkImport("from math import (ceil,,,,)     ", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("from math import (ceil,,,,     )", "from math import sqrt", "from math import (ceil, sqrt)", 80);
-
-        // test with "(xxxx)", spaces after, commas and spaces and tabs
-        checkImport("from math import (ceil,,,,     )    ", "from math import sqrt", "from math import (ceil, sqrt)",
+        checkImport("from math import (ceil       )", "from math import sqrt", "from math import (ceil, sqrt       )",
                 80);
 
+        //!! test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("from math import (ceil       )   ", "from math import sqrt",
+                "from math import (ceil, sqrt       )   ", 80);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil, sqrt,)", 80);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("from math import (ceil,)    ", "from math import sqrt", "from math import (ceil, sqrt,)    ", 80);
+
         // -- END OF TESTS WITH STANDARD COLS VALUE -- //
+
+        // -- TESTS WITH COLS LIMIT EXCEDEED WITH COMMENTS NEXT LINE -- //
+
+        // normal situation
+        checkImport("from math import ceil\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo", 20);
+
+        // normal situation and spaces after
+        checkImport("from math import ceil\n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt\n     #foo",
+                20);
+
+        // test with multiple spaces and tabs
+        checkImport("from math import ceil          \n#foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt          \n#foo", 20);
+
+        // test with multiple spaces and tabs and spaces after
+        checkImport("from math import ceil          \n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt          \n     #foo", 20);
+
+        // test with comma
+        checkImport("from math import ceil,\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt,\n#foo",
+                20);
+
+        // test with comma and spaces after
+        checkImport("from math import ceil,\n     #foo", "from math import sqrt",
+                "from math import ceil,\\\nsqrt,\n     #foo",
+                20);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt)\n#foo",
+                20);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("from math import (ceil)\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt)\n     #foo",
+                20);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil       )\n#foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt       )\n#foo",
+                20);
+
+        // test with "(xxxx)" and multiple spaces and tabs and spaces after
+        checkImport("from math import (ceil       )\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt       )\n     #foo",
+                20);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt,)\n#foo",
+                20);
+
+        // test with "(xxxx)" and comma and spaces after
+        checkImport("from math import (ceil,)\n     #foo", "from math import sqrt",
+                "from math import (ceil,\nsqrt,)\n     #foo",
+                20);
+
+        // -- END OF TESTS WITH COLS EXCEDEED WITH COMMENTS NEXT LINE -- //
+
+        // -- TESTS WITH AN IMPORT COMMENTED AND A LINE BREAK -- //
+
+        // normal situation
+        checkImport("#from math import ceil\nfrom math import sqrt", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod",
+                80);
+
+        // test with multiple spaces and tabs
+        checkImport("#from math import ceil  \nfrom math import sqrt   ", "from math import fmod",
+                "#from math import ceil  \nfrom math import sqrt, fmod   ",
+                80);
+
+        // test with comma
+        checkImport("#from math import ceil\nfrom math import sqrt,", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod,",
+                80);
+
+        // test with "(xxxx)"
+        checkImport("#from math import ceil\nfrom math import (sqrt)", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)",
+                80);
+
+        // test with "(xxxx)" and spaces after
+        checkImport("#from math import ceil\nfrom math import (sqrt)  ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod)  ",
+                80);
+
+        // test with "(xxxx)" and multiple spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt    )", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod    )",
+                80);
+
+        // test with "(xxxx)", spaces after and multiple spaces and tabs
+        checkImport("#from math import ceil\nfrom math import (sqrt   )    ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod   )    ",
+                80);
+
+        // test with "(xxxx)" and comma
+        checkImport("#from math import ceil\nfrom math import (sqrt,)", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod,)",
+                80);
+
+        // test with "(xxxx)", spaces after and comma
+        checkImport("#from math import ceil\nfrom math import (sqrt,)    ", "from math import fmod",
+                "#from math import ceil\nfrom math import (sqrt, fmod,)    ",
+                80);
+
+        // -- END OF TESTS WITH AN IMPORT COMMENTED AND LINE BREAK -- //
+
+        // -- TESTS WITH COMMENTS INLINE -- //
+
+        // normal situation
+        checkImport("from math import ceil#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
+
+        // test with multiple spaces or tabs
+        checkImport("from math import ceil          #foo", "from math import sqrt",
+                "from math import ceil, sqrt          #foo", 80);
+
+        // test with comma
+        checkImport("from math import ceil,#foo", "from math import sqrt", "from math import ceil, sqrt,#foo", 80);
+
+        // test with "(xxxx)"
+        checkImport("from math import (ceil)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo", 80);
+
+        // test with "(xxxx)", spaces and tabs before comment and spaces and tabs before comment
+        checkImport("from math import (ceil)     #foo", "from math import sqrt",
+                "from math import (ceil, sqrt)     #foo",
+                80);
+
+        //!! test with "(xxxx)" and multiple spaces and tabs
+        checkImport("from math import (ceil       )#foo", "from math import sqrt",
+                "from math import (ceil, sqrt       )#foo",
+                80);
+
+        //!! test with "(xxxx)", spaces and tabs before comment and multiple spaces and tabs
+        checkImport("from math import (ceil       )   #foo", "from math import sqrt",
+                "from math import (ceil, sqrt       )   #foo",
+                80);
+
+        // test with "(xxxx)" and comma
+        checkImport("from math import (ceil,)#foo", "from math import sqrt", "from math import (ceil, sqrt,)#foo", 80);
+
+        // test with "(xxxx)", spaces and tabs before comment and comma
+        checkImport("from math import (ceil,)   #foo", "from math import sqrt", "from math import (ceil, sqrt,)   #foo",
+                80);
+
+        // -- END OF TESTS WITH COMMENTS INLINE -- //
 
         // -- TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
         /*
@@ -159,68 +284,15 @@ public class AddTokenAndImportStatementTest extends TestCase {
                 80);
         
         // -- END OF TESTS WITH STANDARD COLS VALUE AND SPACES AND TABS BEFORE -- //
-        */
-        /*
-         * 
-         * // -- TESTS WITH COLS LIMIT EXCEDEED WITHOUT COMMENTS -- //
         
-        // normal situation
-        checkImport("from math import ceil", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
-        
-        // test with multiple spaces or tabs
-        checkImport("from math import ceil  ", "from math import sqrt",
-                "from math import ceil,\\\nsqrt", 20);
-        
-        // test with comma
-        checkImport("from math import ceil,", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
-        
-        // test with commas
-        checkImport("from math import ceil,,,", "from math import sqrt", "from math import ceil,\\\nsqrt", 20);
-        
-        // test with commas, spaces and tabs
-        checkImport("from math import ceil,,  ", "from math import sqrt", "from math import ceil,\\\nsqrt",
-                20);
-        
-        // test with "(xxxx)"
-        checkImport("from math import (ceil)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", spaces and tabs after
-        checkImport("from math import (ceil)     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("from math import (ceil  )", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        //!! test with "(xxxx)", spaces and tabs after with multiple spaces and tabs
-        checkImport("from math import (ceil  )    ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and comma
-        checkImport("from math import (ceil,)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", spaces and tabs after with comma
-        checkImport("from math import (ceil,)     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)" and commas
-        checkImport("from math import (ceil,,,)", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", spaces and tabs after with commas
-        checkImport("from math import (ceil,,,)   ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("from math import (ceil,,  )", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-        // test with "(xxxx)", spaces and tabs after with commas, spaces and tabs
-        checkImport("from math import (ceil,,  )     ", "from math import sqrt", "from math import (ceil,\nsqrt)", 20);
-        
-         * // -- END OF TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE WITHOUT COMMENTS -- //
-         * 
-         *         // -- TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
+        // -- TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
         
         // normal situation
         checkImport("     from math import ceil", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
         
         // test with multiple spaces or tabs
         checkImport("     from math import ceil  ", "from math import sqrt",
-                "     from math import ceil,\\\nsqrt", 20);
+               "     from math import ceil,\\\nsqrt", 20);
         
         // test with comma
         checkImport("     from math import ceil,", "from math import sqrt", "     from math import ceil,\\\nsqrt", 20);
@@ -230,7 +302,7 @@ public class AddTokenAndImportStatementTest extends TestCase {
         
         // test with commas, spaces and tabs
         checkImport("     from math import ceil,,  ", "from math import sqrt", "     from math import ceil,\\\nsqrt",
-                20);
+               20);
         
         // test with "(xxxx)"
         checkImport("     from math import (ceil)", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
@@ -263,101 +335,7 @@ public class AddTokenAndImportStatementTest extends TestCase {
         checkImport("     from math import (ceil,,  )     ", "from math import sqrt", "     from math import (ceil,\nsqrt)", 20);
         
         // -- END OF TESTS WITH COLS LIMIT EXCEDEED AND SPACES AND TABS BEFORE, WITHOUT COMMENTS -- //
-        */
-        // -- TESTS WITH COLS LIMIT EXCEDEED WITH COMMENTS NEXT LINE -- //
-
-        // normal situation
-        checkImport("from math import ceil\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo", 20);
-
-        // normal situation and spaces after
-        checkImport("from math import ceil\n     #foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n     #foo",
-                20);
-
-        // test with multiple spaces and tabs
-        checkImport("from math import ceil          \n#foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n#foo", 20);
-
-        // test with multiple spaces and tabs and spaces after
-        checkImport("from math import ceil          \n     #foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n     #foo", 20);
-
-        // test with comma
-        checkImport("from math import ceil,\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo",
-                20);
-
-        // test with comma and spaces after
-        checkImport("from math import ceil,\n     #foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n     #foo",
-                20);
-
-        // test with commas
-        checkImport("from math import ceil,,,,\n#foo", "from math import sqrt", "from math import ceil,\\\nsqrt\n#foo",
-                20);
-
-        // test with commas and spaces after
-        checkImport("from math import ceil,,,,\n     #foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n     #foo",
-                20);
-
-        // test with commas, spaces and tabs
-        checkImport("from math import ceil,,,,           \n#foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n#foo",
-                20);
-
-        // test with commas, spaces and tabs and spaces after
-        checkImport("from math import ceil,,,,           \n     #foo", "from math import sqrt",
-                "from math import ceil,\\\nsqrt\n     #foo",
-                20);
-
-        // test with "(xxxx)"
-        checkImport("from math import (ceil)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt)\n#foo",
-                20);
-
-        // test with "(xxxx)" and spaces after
-        checkImport("from math import (ceil)\n     #foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n     #foo",
-                20);
-
-        //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("from math import (ceil       )\n#foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n#foo",
-                20);
-
-        // test with "(xxxx)" and multiple spaces and tabs and spaces after
-        checkImport("from math import (ceil       )\n     #foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n     #foo",
-                20);
-
-        // test with "(xxxx)" and comma
-        checkImport("from math import (ceil,)\n#foo", "from math import sqrt", "from math import (ceil,\nsqrt)\n#foo",
-                20);
-
-        // test with "(xxxx)" and comma and spaces after
-        checkImport("from math import (ceil,)\n     #foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n     #foo",
-                20);
-
-        // test with "(xxxx)" and commas
-        checkImport("from math import (ceil,,,,)\n#foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n#foo", 20);
-
-        // test with "(xxxx)" and commas and spaces after
-        checkImport("from math import (ceil,,,,)\n     #foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n     #foo", 20);
-
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("from math import (ceil,,,,     )\n#foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n#foo",
-                20);
-
-        // test with "(xxxx)", commas, spaces and tabs and spaces after
-        checkImport("from math import (ceil,,,,     )\n     #foo", "from math import sqrt",
-                "from math import (ceil,\nsqrt)\n     #foo",
-                20);
-
-        // -- END OF TESTS WITH COLS EXCEDEED WITH COMMENTS NEXT LINE -- //
-
+        
         // -- TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
         /*
         // normal situation
@@ -457,148 +435,6 @@ public class AddTokenAndImportStatementTest extends TestCase {
         
         // -- END OF TESTS WITH COLS EXCEDEED, SPACES AND TABS BEFORE AND COMMENTS NEXT LINE -- //
         */
-        // -- TESTS WITH COMMENTS INLINE -- //
-
-        // -- TESTS WITH AN IMPORT COMMENTED AND LINE BREAK -- //
-
-        // normal situation
-        checkImport("from math import ceil#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
-
-        // test with multiple spaces or tabs
-        checkImport("from math import ceil          #foo", "from math import sqrt",
-                "from math import ceil, sqrt          #foo", 80);
-
-        // test with comma
-        checkImport("from math import ceil,#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
-
-        // test with commas
-        checkImport("from math import ceil,,,,#foo", "from math import sqrt", "from math import ceil, sqrt#foo", 80);
-
-        // test with commas, spaces and tabs
-        checkImport("from math import ceil,,,,           #foo", "from math import sqrt",
-                "from math import ceil, sqrt           #foo", 80);
-
-        // test with "(xxxx)"
-        checkImport("from math import (ceil)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo", 80);
-
-        // test with "(xxxx)", spaces and tabs before comment and spaces and tabs before comment
-        checkImport("from math import (ceil)     #foo", "from math import sqrt",
-                "from math import (ceil, sqrt)     #foo",
-                80);
-
-        //!! test with "(xxxx)" and multiple spaces and tabs
-        checkImport("from math import (ceil       )#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo",
-                80);
-
-        //!! test with "(xxxx)", spaces and tabs before comment and multiple spaces and tabs
-        checkImport("from math import (ceil       )   #foo", "from math import sqrt",
-                "from math import (ceil, sqrt)   #foo",
-                80);
-
-        // test with "(xxxx)" and comma
-        checkImport("from math import (ceil,)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo", 80);
-
-        // test with "(xxxx)", spaces and tabs before comment and comma
-        checkImport("from math import (ceil,)   #foo", "from math import sqrt", "from math import (ceil, sqrt)   #foo",
-                80);
-
-        // test with "(xxxx)" and commas
-        checkImport("from math import (ceil,,,,)#foo", "from math import sqrt", "from math import (ceil, sqrt)#foo",
-                80);
-
-        // test with "(xxxx)", spaces and tabs before comment and commas
-        checkImport("from math import (ceil,,,,)   #foo", "from math import sqrt",
-                "from math import (ceil, sqrt)   #foo",
-                80);
-
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("from math import (ceil,,,,     )#foo", "from math import sqrt",
-                "from math import (ceil, sqrt)#foo", 80);
-
-        // test with "(xxxx)", spaces and tabs before comment and commas, spaces and tabs
-        checkImport("from math import (ceil,,,,     )   #foo", "from math import sqrt",
-                "from math import (ceil, sqrt)   #foo", 80);
-
-        // -- END OF TESTS WITH COMMENTS INLINE -- //
-
-        // -- TESTS WITH AN IMPORT COMMENTED AND A LINE BREAK -- //
-
-        // normal situation
-        checkImport("#from math import ceil\nfrom math import sqrt", "from math import fmod",
-                "#from math import ceil\nfrom math import sqrt, fmod",
-                80);
-
-        // test with multiple spaces and tabs
-        checkImport("#from math import ceil  \nfrom math import sqrt   ", "from math import fmod",
-                "#from math import ceil  \nfrom math import sqrt, fmod",
-                80);
-
-        // test with comma
-        checkImport("#from math import ceil\nfrom math import sqrt,", "from math import fmod",
-                "#from math import ceil\nfrom math import sqrt, fmod",
-                80);
-
-        // test with commas
-        checkImport("#from math import ceil\nfrom math import sqrt,,,,", "from math import fmod",
-                "#from math import ceil\nfrom math import sqrt, fmod",
-                80);
-
-        // test with commas, spaces and tabs
-        checkImport("#from math import ceil\nfrom math import sqrt,,,    ", "from math import fmod",
-                "#from math import ceil\nfrom math import sqrt, fmod",
-                80);
-
-        // test with "(xxxx)"
-        checkImport("#from math import ceil\nfrom math import (sqrt)", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)" and spaces after
-        checkImport("#from math import ceil\nfrom math import (sqrt)  ", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)" and multiple spaces and tabs
-        checkImport("#from math import ceil\nfrom math import (sqrt    )", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)", spaces after and multiple spaces and tabs
-        checkImport("#from math import ceil\nfrom math import (sqrt   )    ", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)" and comma
-        checkImport("#from math import ceil\nfrom math import (sqrt,)", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)", spaces after and comma
-        checkImport("#from math import ceil\nfrom math import (sqrt,)    ", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)" and commas
-        checkImport("#from math import ceil\nfrom math import (sqrt,,,)", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)", spaces after and commas
-        checkImport("#from math import ceil\nfrom math import (sqrt,,,)   ", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)", commas, spaces and tabs
-        checkImport("#from math import ceil\nfrom math import (sqrt,,,   )", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // test with "(xxxx)", spaces after, commas and spaces and tabs
-        checkImport("#from math import ceil\nfrom math import (sqrt,,,   )       ", "from math import fmod",
-                "#from math import ceil\nfrom math import (sqrt, fmod)",
-                80);
-
-        // -- END OF TESTS WITH AN IMPORT COMMENTED AND LINE BREAK -- //
 
     }
 }

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/refactoring/quick_fixes/AddTokenAndImportStatementTest.java
@@ -518,5 +518,11 @@ public class AddTokenAndImportStatementTest extends TestCase {
                 "from math import (ceil, sqrt)   #foo", 80);
 
         // -- END OF TESTS WITH COMMENTS INLINE -- //
+
+        // normal situation
+        checkImport("#from math import ceil\nfrom math import sqrt", "from math import fmod",
+                "#from math import ceil\nfrom math import sqrt, fmod",
+                80);
+
     }
 }


### PR DESCRIPTION
Fixes:
- automatic group imports don't recognize imports strings with comments
- commas trailing
- automatic import gets import end offset wrong when import comment has ")" in it
- import string concats wrongly when it has spaces and tabs
- import string concats wrongly when it style is "(aaa,)" or "(aaa  )", or "(aaa,  )", or "(aaa)  " or others similar styles

Changes:
- added two new functions: getOffsetDiff and getOffset
- now all import strings have a standard style
- imports are RIGHT trimmed when it doesn't have comments in
- after implementing the fixes, all unused old variables were deleted

Observations:
- all changes are compatible to correctly agroup similar imports to an import string with spaces and tabs before (because it doesn't trim import string), but the project class which handle imports doesn't recognize that kinda of import string (with tabs and spaces before)
- so, all tests with tabs and spaces before import are hidden by comments in test class
- some tests with cols limit excedeed are also hidden in test class, even with it all working correctly on real situation, because assertEquals is returning failure even not identifying differences