### PR TITLE
Fix for #PyDev-1055: Pydev does not recognize named unicode character escape in f-string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,4 +54,3 @@ plugins/org.python.pydev.core/pysrc/.settings
 **/v2_indexcache/**
 plugins/com.python.pydev.runalltests/fake_homedir*
 .cache
-plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,4 @@ plugins/org.python.pydev.core/pysrc/.settings
 **/v2_indexcache/**
 plugins/com.python.pydev.runalltests/fake_homedir*
 .cache
+plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/OccurrencesVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/visitors/OccurrencesVisitor.java
@@ -35,7 +35,7 @@ import org.python.pydev.parser.PyParser;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.FStringsAST;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.FStringsAST.FStringExpressionContent;
 import org.python.pydev.parser.grammar_fstrings.FStringsGrammar;
-import org.python.pydev.parser.jython.FastCharStream;
+import org.python.pydev.parser.grammar_fstrings.FStringsGrammarFactory;
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.jython.ast.Assert;
 import org.python.pydev.parser.jython.ast.Assign;
@@ -245,8 +245,7 @@ public final class OccurrencesVisitor extends AbstractScopeAnalyzerVisitor {
             FStringsAST ast = null;
             if (s.trim().length() > 0) {
                 try {
-                    FastCharStream in = new FastCharStream(s.toCharArray());
-                    FStringsGrammar fStringsGrammar = new FStringsGrammar(in);
+                    FStringsGrammar fStringsGrammar = FStringsGrammarFactory.createGrammar(s);
                     ast = fStringsGrammar.f_string();
                     //Note: we always try to generate a valid AST and get any errors in getParseErrors().
                     parseErrors = fStringsGrammar.getParseErrors();

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammar.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammar.java
@@ -673,18 +673,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
         while (true) {
           switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
           case TEXT:
-            label_13:
-            while (true) {
-              jj_consume_token(TEXT);
-              switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
-              case TEXT:
-                ;
-                break;
-              default:
-                jj_la1[21] = jj_gen;
-                break label_13;
-              }
-            }
+            jj_consume_token(TEXT);
             break;
           case EXCLAMATION:
             jj_consume_token(EXCLAMATION);
@@ -693,7 +682,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
             jj_consume_token(COLON);
             break;
           default:
-            jj_la1[22] = jj_gen;
+            jj_la1[21] = jj_gen;
             jj_consume_token(-1);
             throw new ParseException();
           }
@@ -704,7 +693,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
             ;
             break;
           default:
-            jj_la1[23] = jj_gen;
+            jj_la1[22] = jj_gen;
             break label_12;
           }
         }
@@ -714,7 +703,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
                          errorBackSlashInvalidInFStrings(t);
         break;
       default:
-        jj_la1[24] = jj_gen;
+        jj_la1[23] = jj_gen;
         jj_consume_token(-1);
         throw new ParseException();
       }
@@ -756,7 +745,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
     try {
                 start = getToken(1);
       jj_consume_token(QUOTE);
-      label_14:
+      label_13:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case LPAREN:
@@ -773,8 +762,8 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
           ;
           break;
         default:
-          jj_la1[25] = jj_gen;
-          break label_14;
+          jj_la1[24] = jj_gen;
+          break label_13;
         }
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case TEXT:
@@ -812,7 +801,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
                           errorBackSlashInvalidInFStrings(t);
           break;
         default:
-          jj_la1[26] = jj_gen;
+          jj_la1[25] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -844,7 +833,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
     try {
                 start = getToken(1);
       jj_consume_token(QUOTE2);
-      label_15:
+      label_14:
       while (true) {
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case LPAREN:
@@ -861,8 +850,8 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
           ;
           break;
         default:
-          jj_la1[27] = jj_gen;
-          break label_15;
+          jj_la1[26] = jj_gen;
+          break label_14;
         }
         switch ((jj_ntk==-1)?jj_ntk():jj_ntk) {
         case TEXT:
@@ -900,7 +889,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
                           errorBackSlashInvalidInFStrings(t);
           break;
         default:
-          jj_la1[28] = jj_gen;
+          jj_la1[27] = jj_gen;
           jj_consume_token(-1);
           throw new ParseException();
         }
@@ -931,13 +920,13 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
   public Token jj_nt;
   private int jj_ntk;
   private int jj_gen;
-  final private int[] jj_la1 = new int[29];
+  final private int[] jj_la1 = new int[28];
   static private int[] jj_la1_0;
   static {
       jj_la1_init_0();
    }
    private static void jj_la1_init_0() {
-      jj_la1_0 = new int[] {0x1ffe0,0x100,0x1ffe0,0x1e2a0,0x800,0x1000,0x10000,0x1e080,0x10000,0x1e2a0,0x1e080,0x10000,0x1e2a0,0x1e2a0,0x1faa0,0x1faa0,0x1faa0,0x2a0,0x1faa0,0x1faa0,0x1faa0,0x10000,0x11800,0x11800,0x1faa0,0x1dfe0,0x1dfe0,0x1bfe0,0x1bfe0,};
+      jj_la1_0 = new int[] {0x1ffe0,0x100,0x1ffe0,0x1e2a0,0x800,0x1000,0x10000,0x1e080,0x10000,0x1e2a0,0x1e080,0x10000,0x1e2a0,0x1e2a0,0x1faa0,0x1faa0,0x1faa0,0x2a0,0x1faa0,0x1faa0,0x1faa0,0x11800,0x11800,0x1faa0,0x1dfe0,0x1dfe0,0x1bfe0,0x1bfe0,};
    }
 
   /** Constructor with user supplied FastCharStream. */
@@ -946,7 +935,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 29; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 28; i++) jj_la1[i] = -1;
   }
 
   /** Reinitialise. */
@@ -958,7 +947,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
     token = new Token();
     jj_ntk = -1;
     jj_gen = 0;
-    for (int i = 0; i < 29; i++) jj_la1[i] = -1;
+    for (int i = 0; i < 28; i++) jj_la1[i] = -1;
   }
 
   /** Reinitialise. */
@@ -1017,7 +1006,7 @@ public final class FStringsGrammar extends AbstractFStringsGrammar/*@bgen(jjtree
       la1tokens[jj_kind] = true;
       jj_kind = -1;
     }
-    for (int i = 0; i < 29; i++) {
+    for (int i = 0; i < 28; i++) {
       if (jj_la1[i] == jj_gen) {
         for (int j = 0; j < 32; j++) {
           if ((jj_la1_0[i] & (1<<j)) != 0) {

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammarFactory.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammarFactory.java
@@ -6,17 +6,22 @@ public class FStringsGrammarFactory {
 
     public static FStringsGrammar createGrammar(String s) {
 
-        while (s.contains("\\N{")) {
-            int pos = s.indexOf("\\N{") + 3;
-            int posLength = s.substring(0, pos).length();
-            s = s.replace(s.charAt(pos), '_');
-            String s_ = s.substring(pos);
-            pos = s_.indexOf("}");
-
-            s = s.replace(s.charAt(pos + posLength), '_');
+        char[] c = s.toCharArray();
+        for (int i = 0, z = 0; i < c.length; i++) {
+            if (c[i] == '\\' && i + 2 < c.length && c[i + 1] == 'N' && c[i + 2] == '{') {
+                c[i + 2] = '_';
+                i += 2;
+                z = i + 1;
+                for (; z < c.length; z++) {
+                    if (c[z] == '}') {
+                        c[z] = '_';
+                        break;
+                    }
+                }
+            }
         }
 
-        FastCharStream in = new FastCharStream(s.toCharArray());
+        FastCharStream in = new FastCharStream(c);
         FStringsGrammar fStringsGrammar = new FStringsGrammar(in);
 
         return fStringsGrammar;

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammarFactory.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/FStringsGrammarFactory.java
@@ -1,0 +1,25 @@
+package org.python.pydev.parser.grammar_fstrings;
+
+import org.python.pydev.parser.jython.FastCharStream;
+
+public class FStringsGrammarFactory {
+
+    public static FStringsGrammar createGrammar(String s) {
+
+        while (s.contains("\\N{")) {
+            int pos = s.indexOf("\\N{") + 3;
+            int posLength = s.substring(0, pos).length();
+            s = s.replace(s.charAt(pos), '_');
+            String s_ = s.substring(pos);
+            pos = s_.indexOf("}");
+
+            s = s.replace(s.charAt(pos + posLength), '_');
+        }
+
+        FastCharStream in = new FastCharStream(s.toCharArray());
+        FStringsGrammar fStringsGrammar = new FStringsGrammar(in);
+
+        return fStringsGrammar;
+    }
+
+}

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
@@ -2,9 +2,10 @@
 	
 	
 
-	<property name="env" value="C:\Users\olccjr"/>
-    <property name="javaccHome" value="${env}/Documents/Javacc/javacc-5.0" />
-    <property name="python" value="${env}/miniconda3/envs/py27_tests_temp/python.exe" />
+	<property environment="env"/>
+	<property name="userProfile" value="${env.USERPROFILE}"/>
+    <property name="javaccHome" value="${userProfile}\Documents\Javacc\javacc-5.0" />
+    <property name="python" value="${userProfile}\miniconda3\envs\py27_tests_temp\python.exe" />
     <property name="basedir" value="." />
     <property name="parser.dir" value="${basedir}" />
 

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
@@ -1,7 +1,10 @@
 <project name="jython-parser" default="parser">
+	
+	
 
-    <property name="javaccHome" value="C:\Users\olccjr\Documents\Javacc\javacc-5.0" />
-    <property name="python" value="C:\Users\olccjr\miniconda3\envs\py27_tests_temp\python.exe" />
+	<property name="env" value="C:\Users\olccjr"/>
+    <property name="javaccHome" value="${env}/Documents/Javacc/javacc-5.0" />
+    <property name="python" value="${env}/miniconda3/envs/py27_tests_temp/python.exe" />
     <property name="basedir" value="." />
     <property name="parser.dir" value="${basedir}" />
 

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
@@ -3,9 +3,8 @@
 	
 
 	<property environment="env"/>
-	<property name="userProfile" value="${env.USERPROFILE}"/>
-    <property name="javaccHome" value="${userProfile}\Documents\Javacc\javacc-5.0" />
-    <property name="python" value="${userProfile}\miniconda3\envs\py27_tests_temp\python.exe" />
+    <property name="javaccHome" value="${env.GRAMMAR_JAVACC_DIR}"/>
+    <property name="python" value="${env.GRAMMAR_PYTHON_EXE}" />
     <property name="basedir" value="." />
     <property name="parser.dir" value="${basedir}" />
 

--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/grammar_fstrings/build.xml
@@ -1,7 +1,7 @@
 <project name="jython-parser" default="parser">
 
-    <property name="javaccHome" value="c:\bin\javacc-5.0" />
-    <property name="python" value="c:\bin\Miniconda\envs\py27_tests\python.exe" />
+    <property name="javaccHome" value="C:\Users\olccjr\Documents\Javacc\javacc-5.0" />
+    <property name="python" value="C:\Users\olccjr\miniconda3\envs\py27_tests_temp\python.exe" />
     <property name="basedir" value="." />
     <property name="parser.dir" value="${basedir}" />
 

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/FStringsParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/FStringsParserTest.java
@@ -10,7 +10,7 @@ import org.eclipse.jface.text.IDocument;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.FStringsAST;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.SimpleNode;
 import org.python.pydev.parser.grammar_fstrings.FStringsGrammar;
-import org.python.pydev.parser.jython.FastCharStream;
+import org.python.pydev.parser.grammar_fstrings.FStringsGrammarFactory;
 import org.python.pydev.parser.jython.ParseException;
 import org.python.pydev.shared_core.string.StringUtils;
 import org.python.pydev.shared_core.structure.Tuple;
@@ -21,8 +21,7 @@ import junit.framework.TestCase;
 public class FStringsParserTest extends TestCase {
 
     private Tuple<FStringsAST, List> check(String str) throws ParseException {
-        FastCharStream in = new FastCharStream(str.toCharArray());
-        FStringsGrammar fStringsGrammar = new FStringsGrammar(in);
+        FStringsGrammar fStringsGrammar = FStringsGrammarFactory.createGrammar(str);
         FStringsAST ast = fStringsGrammar.f_string();
         //Note: we always try to generate a valid AST and get any errors in getParseErrors().
         List<ParseException> parseErrors = fStringsGrammar.getParseErrors();
@@ -76,7 +75,24 @@ public class FStringsParserTest extends TestCase {
         }
     }
 
+    private Tuple<FStringsAST, List> checkStr(String str, Set<String> exprs)
+            throws ParseException, BadLocationException {
+        Tuple<FStringsAST, List> ret = checkNoError(str);
+        IDocument doc = new Document(str);
+        // ret.o1.dump(doc);
+        Set<String> found = new HashSet<>();
+        for (SimpleNode b : ret.o1.getBalancedExpressionsToBeEvaluatedInRegularGrammar()) {
+            String contents = b.getContentsFromString(doc);
+            found.add(contents);
+        }
+
+        assertEquals(exprs.toString(), found.toString());
+        return ret;
+    }
+
     public void testFStringParsing() throws ParseException, BadLocationException {
+        checkStr("\\N{foo}", ArrayUtils.asSet(""));
+
         checkExprs("{val:{width}.{precision}f}", ArrayUtils.asSet("val", "width", "precision"));
         checkExprs("{a:>{width}}", ArrayUtils.asSet("a", "width"));
         checkExprs("{a:>{{width}}}", ArrayUtils.asSet("a"));

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/FStringsParserTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/FStringsParserTest.java
@@ -75,23 +75,21 @@ public class FStringsParserTest extends TestCase {
         }
     }
 
-    private Tuple<FStringsAST, List> checkStr(String str, Set<String> exprs)
-            throws ParseException, BadLocationException {
-        Tuple<FStringsAST, List> ret = checkNoError(str);
-        IDocument doc = new Document(str);
-        // ret.o1.dump(doc);
-        Set<String> found = new HashSet<>();
-        for (SimpleNode b : ret.o1.getBalancedExpressionsToBeEvaluatedInRegularGrammar()) {
-            String contents = b.getContentsFromString(doc);
-            found.add(contents);
-        }
-
-        assertEquals(exprs.toString(), found.toString());
-        return ret;
-    }
-
     public void testFStringParsing() throws ParseException, BadLocationException {
-        checkStr("\\N{foo}", ArrayUtils.asSet(""));
+        checkExprs("\\N{foo}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{foo}}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{}}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{\\N{foo}}}", ArrayUtils.asSet());
+        checkExprs("\\N{", ArrayUtils.asSet());
+        checkExprs("\\N{foo} {foo}", ArrayUtils.asSet("foo"));
+        checkExprs("\\N{foo}{foo}", ArrayUtils.asSet("foo"));
+        checkExprs("\\N{foo}\\N{foo}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{foo}}\\N{foo}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{}} \\N{foo}", ArrayUtils.asSet());
+        checkExprs("\\N{\\N{\\N{foo}}} \\N{foo}", ArrayUtils.asSet());
+        checkExprs("\\N{foo", ArrayUtils.asSet());
+        checkExprs("\\N{foo} \\N{\\N{\\N{foo}}}", ArrayUtils.asSet());
+        checkExprs("\\N{foo} \\N{foo} {foo}", ArrayUtils.asSet("foo"));
 
         checkExprs("{val:{width}.{precision}f}", ArrayUtils.asSet("val", "width", "precision"));
         checkExprs("{a:>{width}}", ArrayUtils.asSet("a", "width"));

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyFStringScanner.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyFStringScanner.java
@@ -11,7 +11,7 @@ import org.python.pydev.core.docutils.SyntaxErrorException;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.FStringsAST;
 import org.python.pydev.parser.fastparser.grammar_fstrings_common.SimpleNode;
 import org.python.pydev.parser.grammar_fstrings.FStringsGrammar;
-import org.python.pydev.parser.jython.FastCharStream;
+import org.python.pydev.parser.grammar_fstrings.FStringsGrammarFactory;
 import org.python.pydev.shared_core.partitioner.IToken;
 import org.python.pydev.shared_core.partitioner.ITokenScanner;
 import org.python.pydev.shared_core.partitioner.SubRuleToken;
@@ -64,9 +64,7 @@ public class PyFStringScanner implements ITokenScanner {
         if (buf.length() < 0) {
             return;
         }
-
-        FastCharStream in = new FastCharStream(buf.toCharArray());
-        FStringsGrammar fStringsGrammar = new FStringsGrammar(in);
+        FStringsGrammar fStringsGrammar = FStringsGrammarFactory.createGrammar(buf);
         FStringsAST ast = null;
         try {
             ast = fStringsGrammar.f_string();


### PR DESCRIPTION
I created a new factory class to handle f-strings and check if it has a scape unicode character before code f-string variables definition.

I also ran JavaCC build.xml, so some code changes were automatic generated