### PR TITLE
Fix for #Pydev 1075: Go to definition issue

### DIFF
--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/AssignAnalysis.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/AssignAnalysis.java
@@ -76,7 +76,7 @@ public class AssignAnalysis {
                 SourceModule sourceModule = (SourceModule) module;
 
                 try {
-                    defs = sourceModule.findDefinition(state, state.getLine() + 1, state.getCol() + 1,
+                    defs = sourceModule.findDefinition(state, state.getLine(), state.getCol(),
                             state.getNature());
                     if (defs.length > 0) {
                         for (int i = 0; i < defs.length; i++) {

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/AssignAnalysis.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/AssignAnalysis.java
@@ -76,7 +76,7 @@ public class AssignAnalysis {
                 SourceModule sourceModule = (SourceModule) module;
 
                 try {
-                    defs = sourceModule.findDefinition(state, state.getLine(), state.getCol(),
+                    defs = sourceModule.findDefinition(state, state.getLine() + 1, state.getCol() + 1,
                             state.getNature());
                     if (defs.length > 0) {
                         for (int i = 0; i < defs.length; i++) {

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionState.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionState.java
@@ -470,6 +470,15 @@ public final class CompletionState implements ICompletionState {
     }
 
     @Override
+    public ICompletionState getCopyWithActTok(String value, int line, int col) {
+        ICompletionState copy = getCopy();
+        copy.setLine(line);
+        copy.setCol(col);
+        copy.setActivationToken(value);
+        return copy;
+    }
+
+    @Override
     public String getQualifier() {
         return this.qualifier;
     }

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionState.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionState.java
@@ -469,6 +469,10 @@ public final class CompletionState implements ICompletionState {
         return copy;
     }
 
+    /**
+     * @param line starting at 0
+     * @param col starting at 0
+     */
     @Override
     public ICompletionState getCopyWithActTok(String value, int line, int col) {
         ICompletionState copy = getCopy();

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionStateWrapper.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionStateWrapper.java
@@ -169,6 +169,10 @@ public final class CompletionStateWrapper implements ICompletionState {
         return wrapped.getCopyWithActTok(value);
     }
 
+    /**
+     * @param line starting at 0
+     * @param col starting at 0
+     */
     @Override
     public ICompletionState getCopyWithActTok(String value, int line, int col) {
         return wrapped.getCopyWithActTok(value, line, col);

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionStateWrapper.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/CompletionStateWrapper.java
@@ -170,6 +170,11 @@ public final class CompletionStateWrapper implements ICompletionState {
     }
 
     @Override
+    public ICompletionState getCopyWithActTok(String value, int line, int col) {
+        return wrapped.getCopyWithActTok(value, line, col);
+    }
+
+    @Override
     public boolean getIsInCalltip() {
         return wrapped.getIsInCalltip();
     }

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/modules/SourceModule.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/modules/SourceModule.java
@@ -1089,7 +1089,7 @@ public class SourceModule extends AbstractModule implements ISourceModule {
         }
 
         //mod == this if we are now checking the globals (or maybe not)...heheheh
-        ICompletionState copy = state.getCopyWithActTok(tok, line, col);
+        ICompletionState copy = state.getCopyWithActTok(tok, line - 1, col - 1);
         // further on this we will get the first part of the same tok, so token line and column will be the same
         try {
             state.checkFindDefinitionMemory(mod, tok);

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/modules/SourceModule.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/codecompletion/revisited/modules/SourceModule.java
@@ -1089,8 +1089,8 @@ public class SourceModule extends AbstractModule implements ISourceModule {
         }
 
         //mod == this if we are now checking the globals (or maybe not)...heheheh
-        ICompletionState copy = state.getCopy();
-        copy.setActivationToken(tok);
+        ICompletionState copy = state.getCopyWithActTok(tok, line, col);
+        // further on this we will get the first part of the same tok, so token line and column will be the same
         try {
             state.checkFindDefinitionMemory(mod, tok);
             findDefinitionsFromModAndTok(nature, toRet, visitor.moduleImported, mod, copy);
@@ -1111,7 +1111,8 @@ public class SourceModule extends AbstractModule implements ISourceModule {
         String tok = state.getActivationToken();
         if (tok != null) {
             if (tok.length() > 0) {
-                Definition d = mod.findGlobalTokDef(state.getCopyWithActTok(tok), nature);
+                Definition d = mod.findGlobalTokDef(state.getCopyWithActTok(tok, state.getLine(), state.getCol()),
+                        nature);
                 if (d != null) {
                     toRet.add(d);
 
@@ -1200,7 +1201,8 @@ public class SourceModule extends AbstractModule implements ISourceModule {
         // }
         if (tokens == null || tokens.empty()) {
             if (nature != null) {
-                tokens = nature.getAstManager().getCompletionsForModule(this, state.getCopyWithActTok(firstPart), true);
+                tokens = nature.getAstManager().getCompletionsForModule(this,
+                        state.getCopyWithActTok(firstPart, state.getLine(), state.getCol()), true);
             } else {
                 tokens = getGlobalTokens();
             }

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
@@ -119,6 +119,8 @@ public interface ICompletionState extends ICompletionCache {
 
     ICompletionState getCopyWithActTok(String value);
 
+    ICompletionState getCopyWithActTok(String value, int line, int col);
+
     String getQualifier();
 
     LookingFor getLookingFor();

--- a/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
+++ b/plugins/org.python.pydev.core/src/org/python/pydev/core/ICompletionState.java
@@ -119,6 +119,10 @@ public interface ICompletionState extends ICompletionCache {
 
     ICompletionState getCopyWithActTok(String value);
 
+    /**
+     * @param line starting at 0
+     * @param col starting at 0
+     */
     ICompletionState getCopyWithActTok(String value, int line, int col);
 
     String getQualifier();

--- a/plugins/org.python.pydev/tests/pysrc/findActualDefinition/bar.py
+++ b/plugins/org.python.pydev/tests/pysrc/findActualDefinition/bar.py
@@ -1,0 +1,7 @@
+class Endpoint(object):
+    def notify(self):
+        pass
+
+class Bar(object):
+    def __init__(self):
+        self._endpoint = Endpoint()

--- a/plugins/org.python.pydev/tests/pysrc/findActualDefinition/foo.py
+++ b/plugins/org.python.pydev/tests/pysrc/findActualDefinition/foo.py
@@ -1,0 +1,5 @@
+from bar import Bar
+
+class Foo(Bar):
+    def foo(self):
+        self._endpoint.notify()

--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/ast/codecompletion/revisited/FindActualDefinitionTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/ast/codecompletion/revisited/FindActualDefinitionTest.java
@@ -6,15 +6,16 @@
  */
 package org.python.pydev.ast.codecompletion.revisited;
 
+import java.io.File;
 import java.util.ArrayList;
 
 import org.eclipse.jface.text.Document;
-import org.python.pydev.ast.codecompletion.revisited.CompletionCache;
 import org.python.pydev.ast.codecompletion.revisited.modules.SourceModule;
 import org.python.pydev.ast.refactoring.PyRefactoringFindDefinition;
 import org.python.pydev.core.ICompletionCache;
 import org.python.pydev.core.IDefinition;
 import org.python.pydev.core.IModule;
+import org.python.pydev.core.TestDependent;
 
 /**
  * @author Fabio
@@ -127,6 +128,16 @@ public class FindActualDefinitionTest extends CodeCompletionTestsBase {
         ICompletionCache completionCache = new CompletionCache();
         ArrayList<IDefinition> selected = new ArrayList<IDefinition>();
         PyRefactoringFindDefinition.findActualDefinition(null, mod, "x.items", selected, 13, 23, nature,
+                completionCache);
+        assertEquals(1, selected.size());
+    }
+
+    public void testFindActualDefinitionImported() throws Exception {
+        File file = new File(TestDependent.TEST_PYSRC_TESTING_LOC + "findActualDefinition/foo.py");
+        IModule mod = SourceModule.createModule("findActualDefinition.foo", file, nature, false);
+        ICompletionCache completionCache = new CompletionCache();
+        ArrayList<IDefinition> selected = new ArrayList<IDefinition>();
+        PyRefactoringFindDefinition.findActualDefinition(null, mod, "self._endpoint.notify", selected, 5, 29, nature,
                 completionCache);
         assertEquals(1, selected.size());
     }


### PR DESCRIPTION
The problem was that the visitorScope was not being defined correctly. Even though it was the same token (with the last part trimmed), the visitorScope line and column parameters were being setted different