### PR TITLE
Allow overriding of two more preferences via plugin_customizations.ini

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
@@ -212,12 +212,12 @@ public class AnalysisPreferences extends AbstractAnalysisPreferences {
 
     public static boolean TESTS_DO_AUTO_IMPORT = true;
 
-    public static boolean doAutoImport() {
+    public static boolean doAutoImport(IAdaptable projectAdaptable) {
         if (SharedCorePlugin.inTestMode()) {
             return TESTS_DO_AUTO_IMPORT;
         }
 
-        return PyAnalysisScopedPreferences.getBoolean(AnalysisPreferenceInitializer.DO_AUTO_IMPORT, null);
+        return PyAnalysisScopedPreferences.getBoolean(AnalysisPreferenceInitializer.DO_AUTO_IMPORT, projectAdaptable);
     }
 
     public static boolean TESTS_DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS = true;

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/AnalysisPreferences.java
@@ -217,32 +217,28 @@ public class AnalysisPreferences extends AbstractAnalysisPreferences {
             return TESTS_DO_AUTO_IMPORT;
         }
 
-        return PydevPrefs.getAnalysisEclipsePreferences().getBoolean(
-                AnalysisPreferenceInitializer.DO_AUTO_IMPORT,
-                AnalysisPreferenceInitializer.DEFAULT_DO_AUT_IMPORT);
+        return PyAnalysisScopedPreferences.getBoolean(AnalysisPreferenceInitializer.DO_AUTO_IMPORT, null);
     }
 
     public static boolean TESTS_DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS = true;
 
-    public static boolean doAutoImportOnOrganizeImports() {
+    public static boolean doAutoImportOnOrganizeImports(IAdaptable projectAdaptable) {
         if (SharedCorePlugin.inTestMode()) {
             return TESTS_DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS;
         }
-        return PydevPrefs.getAnalysisEclipsePreferences().getBoolean(
-                AnalysisPreferenceInitializer.DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS,
-                AnalysisPreferenceInitializer.DEFAULT_DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS);
+        return PyAnalysisScopedPreferences.getBoolean(AnalysisPreferenceInitializer.DO_AUTO_IMPORT_ON_ORGANIZE_IMPORTS,
+                projectAdaptable);
     }
 
     public static boolean TESTS_DO_IGNORE_IMPORT_STARTING_WITH_UNDER = false;
 
-    public static boolean doIgnoreImportsStartingWithUnder() {
+    public static boolean doIgnoreImportsStartingWithUnder(IAdaptable projectAdaptable) {
         if (SharedCorePlugin.inTestMode()) {
             return TESTS_DO_IGNORE_IMPORT_STARTING_WITH_UNDER;
         }
 
-        return PydevPrefs.getAnalysisEclipsePreferences().getBoolean(
-                AnalysisPreferenceInitializer.DO_IGNORE_IMPORTS_STARTING_WITH_UNDER,
-                AnalysisPreferenceInitializer.DEFAULT_DO_IGNORE_FIELDS_WITH_UNDER);
+        return PyAnalysisScopedPreferences.getBoolean(
+                AnalysisPreferenceInitializer.DO_IGNORE_IMPORTS_STARTING_WITH_UNDER, projectAdaptable);
     }
 
     /**

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/UndefinedVariableQuickFixCreator.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/refactoring/quick_fixes/UndefinedVariableQuickFixCreator.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.text.BadLocationException;
 import org.python.pydev.ast.codecompletion.ProposalsComparator.CompareContext;
 import org.python.pydev.core.ICodeCompletionASTManager;
@@ -26,8 +27,9 @@ import com.python.pydev.analysis.additionalinfo.AbstractAdditionalTokensInfo;
 import com.python.pydev.analysis.additionalinfo.AdditionalProjectInterpreterInfo;
 
 public class UndefinedVariableQuickFixCreator {
-    
-    public static void createImportQuickProposalsFromMarkerSelectedText(PySelection ps, int offset,
+
+    public static void createImportQuickProposalsFromMarkerSelectedText(IAdaptable projectAdaptable, PySelection ps,
+            int offset,
             IPythonNature initialNature,
             List<ICompletionProposalHandle> props, ICodeCompletionASTManager astManager, int start, int end,
             boolean forceReparseOnApply)
@@ -38,7 +40,8 @@ public class UndefinedVariableQuickFixCreator {
 
         IModulesManager projectModulesManager = astManager.getModulesManager();
         IModulesManager[] managersInvolved = projectModulesManager.getManagersInvolved(true);
-        boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder();
+        boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences
+                .doIgnoreImportsStartingWithUnder(projectAdaptable);
 
         // Use a single buffer to create all the strings
         FastStringBuffer buffer = new FastStringBuffer();

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
@@ -142,7 +142,7 @@ public class CtxParticipant
         FastStringBuffer realImportRep = new FastStringBuffer();
         FastStringBuffer displayString = new FastStringBuffer();
         FastStringBuffer tempBuf = new FastStringBuffer();
-        boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder();
+        boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder(null);
         CompareContext compareContext = new CompareContext(nature);
         for (IInfo info : tokensStartingWith) {
             //there always must be a declaringModuleName
@@ -218,7 +218,7 @@ public class CtxParticipant
             FastStringBuffer displayString = new FastStringBuffer();
             FastStringBuffer tempBuf = new FastStringBuffer();
 
-            boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder();
+            boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder(null);
 
             for (IInfo info : tokensStartingWith) {
                 //there always must be a declaringModuleName

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/ctxinsensitive/CtxParticipant.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.python.pydev.ast.codecompletion.CompletionRequest;
 import org.python.pydev.ast.codecompletion.IPyDevCompletionParticipant;
 import org.python.pydev.ast.codecompletion.IPyDevCompletionParticipant2;
@@ -91,7 +92,7 @@ public class CtxParticipant
         String qual = tokenAndQual.qualifier;
         if (qual.length() >= PyCodeCompletionPreferences.getCharsForContextInsensitiveGlobalTokensCompletion()
                 && naturesUsed != null && naturesUsed.size() > 0) { //at least n characters required...
-            boolean addAutoImport = AnalysisPreferences.doAutoImport();
+            boolean addAutoImport = AnalysisPreferences.doAutoImport(null);
             int qlen = qual.length();
             boolean useSubstringMatchInCodeCompletion = PyCodeCompletionPreferences
                     .getUseSubstringMatchInCodeCompletion();
@@ -218,7 +219,9 @@ public class CtxParticipant
             FastStringBuffer displayString = new FastStringBuffer();
             FastStringBuffer tempBuf = new FastStringBuffer();
 
-            boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences.doIgnoreImportsStartingWithUnder(null);
+            IAdaptable projectAdaptable = request.getNature() != null ? request.getNature().getProject() : null;
+            boolean doIgnoreImportsStartingWithUnder = AnalysisPreferences
+                    .doIgnoreImportsStartingWithUnder(projectAdaptable);
 
             for (IInfo info : tokensStartingWith) {
                 //there always must be a declaringModuleName
@@ -290,7 +293,8 @@ public class CtxParticipant
     @Override
     public TokensOrProposalsList getGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
-        return new TokensOrProposalsList(getThem(request, state, AnalysisPreferences.doAutoImport()));
+        IAdaptable projectAdaptable = request.getNature() != null ? request.getNature().getProject() : null;
+        return new TokensOrProposalsList(getThem(request, state, AnalysisPreferences.doAutoImport(projectAdaptable)));
     }
 
     @Override

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/codecompletion/participant/ImportsCompletionParticipant.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.python.pydev.ast.codecompletion.CompletionRequest;
 import org.python.pydev.ast.codecompletion.IPyDevCompletionParticipant;
 import org.python.pydev.ast.codecompletion.IPyDevCompletionParticipant2;
@@ -69,7 +70,7 @@ public class ImportsCompletionParticipant implements IPyDevCompletionParticipant
                 && naturesUsed != null && naturesUsed.size() > 0) { //at least n characters required...
 
             int qlen = qual.length();
-            boolean addAutoImport = AnalysisPreferences.doAutoImport();
+            boolean addAutoImport = AnalysisPreferences.doAutoImport(null);
 
             for (IPythonNature nature : naturesUsed) {
                 fillCompletions(requestOffset, completions, qual, nature, qlen, addAutoImport, viewer);
@@ -266,7 +267,8 @@ public class ImportsCompletionParticipant implements IPyDevCompletionParticipant
     @Override
     public TokensOrProposalsList getGlobalCompletions(CompletionRequest request, ICompletionState state)
             throws MisconfigurationException {
-        return getThem(request, state, AnalysisPreferences.doAutoImport());
+        IAdaptable projectAdaptable = request.getNature() != null ? request.getNature().getProject() : null;
+        return getThem(request, state, AnalysisPreferences.doAutoImport(projectAdaptable));
     }
 
     @Override

--- a/plugins/org.python.pydev/src/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipant.java
+++ b/plugins/org.python.pydev/src/com/python/pydev/analysis/ctrl_1/UndefinedVariableFixParticipant.java
@@ -74,7 +74,8 @@ public class UndefinedVariableFixParticipant implements IAnalysisMarkersParticip
         }
         int start = markerAnnotation.position.offset;
         int end = start + markerAnnotation.position.length;
-        UndefinedVariableQuickFixCreator.createImportQuickProposalsFromMarkerSelectedText(ps, offset, initialNature,
+        UndefinedVariableQuickFixCreator.createImportQuickProposalsFromMarkerSelectedText(edit, ps, offset,
+                initialNature,
                 props, astManager, start, end, forceReparseOnApply);
     }
 

--- a/plugins/org.python.pydev/src/com/python/pydev/analysis/organizeimports/OrganizeImports.java
+++ b/plugins/org.python.pydev/src/com/python/pydev/analysis/organizeimports/OrganizeImports.java
@@ -70,7 +70,7 @@ public class OrganizeImports implements IOrganizeImports {
      */
     @Override
     public boolean beforePerformArrangeImports(final PySelection ps, final PyEdit edit, IFile f) {
-        if ((!AnalysisPreferences.doAutoImportOnOrganizeImports()) || edit == null) {
+        if ((!AnalysisPreferences.doAutoImportOnOrganizeImports(edit)) || edit == null) {
             return true;
         }
         didChange = false;
@@ -274,7 +274,7 @@ public class OrganizeImports implements IOrganizeImports {
      */
     @Override
     public void afterPerformArrangeImports(PySelection ps, PyEdit pyEdit) {
-        if (!AnalysisPreferences.doAutoImportOnOrganizeImports() || !didChange) {
+        if (!AnalysisPreferences.doAutoImportOnOrganizeImports(pyEdit) || !didChange) {
             return;
         }
         if (pyEdit != null) {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -37,6 +37,7 @@ import org.eclipse.ui.IPropertyListener;
 import org.python.pydev.core.docutils.PySelection;
 import org.python.pydev.core.log.Log;
 import org.python.pydev.core.performanceeval.OptimizationRelatedConstants;
+import org.python.pydev.core.preferences.PyScopedPreferences;
 import org.python.pydev.core.preferences.PydevPrefs;
 import org.python.pydev.editor.PyEdit;
 import org.python.pydev.parser.jython.ISpecialStr;
@@ -292,6 +293,13 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
     private static final Pattern regionStartPattern = Pattern.compile("(\\s)*#(\\s)*\\bregion\\b");
     private static final Pattern regionEndPattern = Pattern.compile("(\\s)*#(\\s)*\\bendregion\\b");
 
+    private static boolean getBooleanPreference(String key) {
+        IEclipsePreferences prefs = getPreferences();
+        IEclipsePreferences defaultPrefs = PydevPrefs.getDefaultEclipsePreferences();
+
+        return PyScopedPreferences.get().getBoolean(prefs, defaultPrefs, key, null);
+    }
+
     /**
      * To get the marks, we work a little with the ast and a little with the doc... the ast is good to give us all things but the comments,
      * and the doc will give us the comments.
@@ -306,80 +314,64 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
 
         CodeFoldingVisitor visitor = CodeFoldingVisitor.create(ast);
         //(re) insert annotations.
-        IEclipsePreferences prefs = getPreferences();
 
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_IMPORTS, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_IMPORTS)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IMPORTS)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IMPORTS,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_IMPORTS) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IMPORTS) : false,
                     Import.class,
                     ImportFrom.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF,
-                PyDevCodeFoldingPrefPage.DEFAULT_FOLD_FUNCTIONDEF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_CLASSDEF,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_CLASSDEF) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_CLASSDEF) : false,
                     ClassDef.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF,
-                PyDevCodeFoldingPrefPage.DEFAULT_FOLD_FUNCTIONDEF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FUNCTIONDEF,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_FUNCTIONDEF) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FUNCTIONDEF) : false,
                     FunctionDef.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_STRINGS, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_STRINGS)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_STRINGS)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_STRINGS,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_STRINGS) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_STRINGS) : false,
                     Str.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_WHILE, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_WHILE)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WHILE)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WHILE,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_WHILE) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WHILE) : false,
                     While.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_IF, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_IF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IF)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IF,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_IF) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IF) : false,
                     If.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_FOR, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_FOR)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FOR)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FOR,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_FOR) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FOR) : false,
                     For.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_WITH, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_WITH)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WITH)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WITH,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_WITH) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WITH) : false,
                     With.class);
         }
-        if (prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_TRY, PyDevCodeFoldingPrefPage.DEFAULT_FOLD_TRY)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_TRY)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_TRY,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_TRY) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_TRY) : false,
                     TryExcept.class, TryFinally.class);
         }
 
         //and at last, get the comments
-        final boolean foldComments = prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_COMMENTS,
-                PyDevCodeFoldingPrefPage.DEFAULT_FOLD_COMMENTS);
-        final boolean foldRegions = prefs.getBoolean(PyDevCodeFoldingPrefPage.FOLD_REGION,
-                PyDevCodeFoldingPrefPage.DEFAULT_FOLD_REGION);
+        final boolean foldComments = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_COMMENTS);
+        final boolean foldRegions = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_REGION);
         if (foldComments || foldRegions) {
             boolean collapseComments = foldInitial
-                    ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_COMMENTS,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_COMMENTS)
+                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_COMMENTS)
                     : false;
 
             boolean collapseRegions = foldInitial
-                    ? prefs.getBoolean(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_REGION,
-                            PyDevCodeFoldingPrefPage.DEFAULT_INITIALLY_FOLD_REGION)
+                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_REGION)
                     : false;
 
             DocIterator it = new DocIterator(true, new PySelection(doc, 0));
@@ -588,7 +580,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
         return foldingEntry;
     }
 
-    public static IEclipsePreferences getPreferences() {
+    private static IEclipsePreferences getPreferences() {
         if (testingPrefs == null) {
             return PydevPrefs.getEclipsePreferences();
         } else {

--- a/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/codefolding/CodeFoldingSetter.java
@@ -23,6 +23,7 @@ import java.util.Stack;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.jface.text.BadLocationException;
@@ -188,7 +189,7 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
                 if (doc != null) { //this can happen if we change the input of the editor very quickly.
                     boolean foldInitial = initialFolding;
                     initialFolding = false;
-                    List<FoldingEntry> marks = getMarks(doc, root2, foldInitial);
+                    List<FoldingEntry> marks = getMarks(doc, root2, foldInitial, editor);
                     Map<ProjectionAnnotation, Position> annotationsToAdd;
                     if (marks.size() > OptimizationRelatedConstants.MAXIMUM_NUMBER_OF_CODE_FOLDING_MARKS) {
                         annotationsToAdd = new HashMap<ProjectionAnnotation, Position>();
@@ -293,11 +294,11 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
     private static final Pattern regionStartPattern = Pattern.compile("(\\s)*#(\\s)*\\bregion\\b");
     private static final Pattern regionEndPattern = Pattern.compile("(\\s)*#(\\s)*\\bendregion\\b");
 
-    private static boolean getBooleanPreference(String key) {
+    private static boolean getBooleanPreference(String key, IAdaptable projectAdaptable) {
         IEclipsePreferences prefs = getPreferences();
         IEclipsePreferences defaultPrefs = PydevPrefs.getDefaultEclipsePreferences();
 
-        return PyScopedPreferences.get().getBoolean(prefs, defaultPrefs, key, null);
+        return PyScopedPreferences.get().getBoolean(prefs, defaultPrefs, key, projectAdaptable);
     }
 
     /**
@@ -308,70 +309,85 @@ public class CodeFoldingSetter implements IModelListener, IPropertyListener, IPy
      *
      * Also, there should be no overlap for any of the entries
      */
-    public static List<FoldingEntry> getMarks(IDocument doc, SimpleNode ast, boolean foldInitial) {
+    public static List<FoldingEntry> getMarks(IDocument doc, SimpleNode ast, boolean foldInitial,
+            IAdaptable projectAdaptable) {
 
         List<FoldingEntry> ret = new ArrayList<FoldingEntry>();
 
         CodeFoldingVisitor visitor = CodeFoldingVisitor.create(ast);
         //(re) insert annotations.
 
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IMPORTS)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IMPORTS, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IMPORTS) : false,
+                    foldInitial
+                            ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IMPORTS, projectAdaptable)
+                            : false,
                     Import.class,
                     ImportFrom.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_CLASSDEF, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_CLASSDEF) : false,
+                    foldInitial
+                            ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_CLASSDEF, projectAdaptable)
+                            : false,
                     ClassDef.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FUNCTIONDEF, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FUNCTIONDEF) : false,
+                    foldInitial
+                            ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FUNCTIONDEF,
+                                    projectAdaptable)
+                            : false,
                     FunctionDef.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_STRINGS)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_STRINGS, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_STRINGS) : false,
+                    foldInitial
+                            ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_STRINGS, projectAdaptable)
+                            : false,
                     Str.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WHILE)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WHILE, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WHILE) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WHILE, projectAdaptable)
+                            : false,
                     While.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IF)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_IF, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IF) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_IF, projectAdaptable)
+                            : false,
                     If.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FOR)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_FOR, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FOR) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_FOR, projectAdaptable)
+                            : false,
                     For.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WITH)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_WITH, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WITH) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_WITH, projectAdaptable)
+                            : false,
                     With.class);
         }
-        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_TRY)) {
+        if (getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_TRY, projectAdaptable)) {
             createFoldingEntries(ret, visitor,
-                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_TRY) : false,
+                    foldInitial ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_TRY, projectAdaptable)
+                            : false,
                     TryExcept.class, TryFinally.class);
         }
 
         //and at last, get the comments
-        final boolean foldComments = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_COMMENTS);
-        final boolean foldRegions = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_REGION);
+        final boolean foldComments = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_COMMENTS, projectAdaptable);
+        final boolean foldRegions = getBooleanPreference(PyDevCodeFoldingPrefPage.FOLD_REGION, projectAdaptable);
         if (foldComments || foldRegions) {
             boolean collapseComments = foldInitial
-                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_COMMENTS)
+                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_COMMENTS, projectAdaptable)
                     : false;
 
             boolean collapseRegions = foldInitial
-                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_REGION)
+                    ? getBooleanPreference(PyDevCodeFoldingPrefPage.INITIALLY_FOLD_REGION, projectAdaptable)
                     : false;
 
             DocIterator it = new DocIterator(true, new PySelection(doc, 0));

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/codefolding/CodeFoldingSetterTest.java
@@ -367,7 +367,7 @@ public class CodeFoldingSetterTest extends TestCase {
 
     private List<FoldingEntry> getMarks(Document doc, int grammarVersion) {
         ParseOutput r = PyParser.reparseDocument(new PyParser.ParserInfo(doc, grammarVersion, null));
-        List<FoldingEntry> marks = CodeFoldingSetter.getMarks(doc, (SimpleNode) r.ast, true);
+        List<FoldingEntry> marks = CodeFoldingSetter.getMarks(doc, (SimpleNode) r.ast, true, null);
         if (DEBUG) {
             for (FoldingEntry entry : marks) {
                 System.out.println(entry);


### PR DESCRIPTION
A product shipping PyDev plugins may want to override the default values
for certain preference settings. This can be done by specifying the
intended value inside a plugin_customizations.ini file that is loaded as
part of the product. The Eclipse eco-system will ensure that these values
land in the DefaultScope.INSTANCE preference instead of the values set
via the corresponding PreferenceInitializer classes.

In order to ensure those changed defaults are actually used one either has
to use an EclipsePreferenceStore instance that handles lookup through both
the instance and the default scope, explicitly use the
DefaultScope.INSTANCE for determining the default-value-argument or as
a third option use the IEclipsePreferenceService' API for accessing the
preference keys.

These two places used neither of those, leading to confusing behavior as
the preference pages themselves would reflect the default-values from the
plugin_customizations.ini file (since they use a PreferenceStore internally)
but the behavior when the code read the preferences would not reflect that.

I opted for the second option, i.e. accessing the default-scope explicitly
as that seemed to be the smallest change.