### PR TITLE
[1096] Mark Skiped Tests as Skip in Overview

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_runfiles/pydev_runfiles_unittest.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_runfiles/pydev_runfiles_unittest.py
@@ -85,9 +85,17 @@ class PydevTestResult(_PythonTextTestResult):
         error_contents = ''
         test_name = self.get_test_name(test)
 
-
         diff_time = '%.2f' % (end_time - self.start_time)
-        if not self._current_errors_stack and not self._current_failures_stack:
+
+        skipped = False
+        outcome = getattr(test, '_outcome', None)
+        if outcome is not None:
+            skipped = bool(getattr(outcome, 'skipped', None))
+
+        if skipped:
+            pydev_runfiles_xml_rpc.notifyTest(
+                'skip', captured_output, error_contents, test.__pydev_pyfile__, test_name, diff_time)            
+        elif not self._current_errors_stack and not self._current_failures_stack:
             pydev_runfiles_xml_rpc.notifyTest(
                 'ok', captured_output, error_contents, test.__pydev_pyfile__, test_name, diff_time)
         else:


### PR DESCRIPTION
Fixes: https://www.brainwy.com/tracker/PyDev/1096
When an SkipTest Exception is thrown, the RPC Server will get notified of this an mark the test as Skip.

As I am not that deep into the codebase I am not sure if this is the "right" approach.
It works for my case, but if there is a better way please guide me in the right direction to implement it.

Thanks a lot for this awesome project!