### PR TITLE
Patch 1

### DIFF
--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/interpreter_managers/InterpreterInfo.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/interpreter_managers/InterpreterInfo.java
@@ -1717,7 +1717,7 @@ public class InterpreterInfo implements IInterpreterInfo {
                 if (manager != null) {
                     try {
                         value = manager.performStringSubstitution(value, false);
-                    } catch (Coreeception e) {
+                    } catch (CoreException e) {
                         // Unreachable as false passed to reportUndefinedVariables above
                     }
                 }

--- a/plugins/org.python.pydev.ast/src/org/python/pydev/ast/interpreter_managers/InterpreterInfo.java
+++ b/plugins/org.python.pydev.ast/src/org/python/pydev/ast/interpreter_managers/InterpreterInfo.java
@@ -14,6 +14,7 @@ package org.python.pydev.ast.interpreter_managers;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.io.StringReader;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -1716,7 +1717,7 @@ public class InterpreterInfo implements IInterpreterInfo {
                 if (manager != null) {
                     try {
                         value = manager.performStringSubstitution(value, false);
-                    } catch (CoreException e) {
+                    } catch (Coreeception e) {
                         // Unreachable as false passed to reportUndefinedVariables above
                     }
                 }
@@ -1970,7 +1971,7 @@ public class InterpreterInfo implements IInterpreterInfo {
             }
         } else {
             File target1 = new File(pythonContainerDir, executable);
-            if (target1.exists()) {
+            if (target1.exists() && Files.isRegularFile(target1.toPath()) && Files.isExecutable(target1.toPath())) {
                 return target1;
             }
         }


### PR DESCRIPTION
Fix searchExecutable for non Windows systems and the situation where the executable resides below a folder with the same name.

I myself had the issue, that the conda executable to be searchead is located as pymaven/conda/bin/conda. In which situation currently the folder pymaven/conda is returned and then tried to be executed.

