### PR TITLE
Issue 1107 pylint message

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysis.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysis.java
@@ -251,7 +251,7 @@ import com.python.pydev.analysis.external.WriteToStreamHelper;
     // \Z = end of the input
 
     private static Pattern PYLINT_MATCH_PATTERN = Pattern
-            .compile("\\A[CRWEFI]:\\s*(\\d+)\\s*,\\s*(\\d+)\\s*:\\s*\\((.*)\\)(.*)\\Z");
+            .compile("\\A[CRWEFI]:\\s*(\\d+)\\s*,\\s*(\\d+)\\s*:\\s*\\((.*?)\\)(.*)\\Z");
 
     private void addToMarkers(String tok, int priority, String id, int line, int column, String lineContents) {
         Map<String, Object> additionalInfo = new HashMap<>();

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
@@ -1,6 +1,5 @@
 package com.python.pydev.analysis.pylint;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.resources.IMarker;
@@ -12,12 +11,19 @@ import org.python.pydev.core.MisconfigurationException;
 import org.python.pydev.core.PythonNatureWithoutProjectException;
 import org.python.pydev.core.preferences.PydevPrefs;
 import org.python.pydev.shared_core.markers.PyMarkerUtils.MarkerInfo;
-import org.python.pydev.shared_core.structure.Tuple;
 
 import junit.framework.TestCase;
 
 public class PyLintAnalysisTest extends TestCase {
 
+    /**
+     * Verify markers are created with correct line number and text
+     *  when supplied simulated PyLint input and output.
+     * 
+     * @throws UnableToFindExecutableException
+     * @throws MisconfigurationException
+     * @throws PythonNatureWithoutProjectException
+     */
     public void testMarkersInfoOutput()
             throws UnableToFindExecutableException, MisconfigurationException, PythonNatureWithoutProjectException {
 
@@ -70,25 +76,26 @@ public class PyLintAnalysisTest extends TestCase {
 
         pyLintAnalysis.afterRunProcess(output, "No config file found, using default configuration\n", null);
 
-        List<Tuple<Integer, String>> markersMessageInfo = new ArrayList<Tuple<Integer, String>>();
-
-        for (MarkerInfo marker : pyLintAnalysis.markers) {
-            markersMessageInfo.add(new Tuple<Integer, String>(marker.lineStart,
-                    (String) marker.additionalInfo.get(PyLintVisitor.PYLINT_MESSAGE_ID)));
-
-            // checks if it is getting marker region right (single line matches)
+        List<MarkerInfo> markers = pyLintAnalysis.markers;
+        for (MarkerInfo marker : markers) {
             assertEquals(marker.lineStart, marker.lineEnd);
         }
 
-        assertEquals(new Tuple<Integer, String>(13, "bad-whitespace"), markersMessageInfo.get(0));
-        assertEquals(new Tuple<Integer, String>(21, "missing-final-newline"), markersMessageInfo.get(1));
-        assertEquals(new Tuple<Integer, String>(21, "superfluous-parens"), markersMessageInfo.get(2));
-        assertEquals(new Tuple<Integer, String>(0, "missing-docstring"), markersMessageInfo.get(3));
-        assertEquals(new Tuple<Integer, String>(2, "invalid-name"), markersMessageInfo.get(4));
-        assertEquals(new Tuple<Integer, String>(3, "invalid-name"), markersMessageInfo.get(5));
-        assertEquals(new Tuple<Integer, String>(4, "invalid-name"), markersMessageInfo.get(6));
-        assertEquals(new Tuple<Integer, String>(5, "invalid-name"), markersMessageInfo.get(7));
-        assertEquals(new Tuple<Integer, String>(6, "invalid-name"), markersMessageInfo.get(8));
+        assertMarkerEquals(22, "line-too-long", "Line too long (106/100)", markers.get(0));
+        assertMarkerEquals(22, "missing-final-newline", "Final newline missing", markers.get(1));
+        assertMarkerEquals(0, "missing-module-docstring", "Missing module docstring", markers.get(2));
+        assertMarkerEquals(2, "invalid-name", "Constant name \"shift\" doesn't conform to UPPER_CASE naming style",
+                markers.get(3));
+        assertMarkerEquals(6, "invalid-name", "Constant name \"encoded\" doesn't conform to UPPER_CASE naming style",
+                markers.get(4));
+        assertMarkerEquals(10, "invalid-name", "Constant name \"encoded\" doesn't conform to UPPER_CASE naming style",
+                markers.get(5));
+        assertEquals(6, markers.size());
     }
 
+    private void assertMarkerEquals(int line, String message_id, String message, MarkerInfo actualMarker) {
+        assertEquals(line, actualMarker.lineStart);
+        assertEquals(message_id, actualMarker.additionalInfo.get(PyLintVisitor.PYLINT_MESSAGE_ID));
+        assertEquals("PyLint: " + message, actualMarker.message);
+    }
 }

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
@@ -44,28 +44,25 @@ public class PyLintAnalysisTest extends TestCase {
                         "        else:\n" +
                         "            x = letters.index(letter) - shift\n" +
                         "            encoded = encoded + letters[x]\n" +
-                        "print(encoded)");
+                        "print(encoded)\n" +
+                        "print(\"This line is really long\")" +
+                        " # This comment is part of the long line, going over the 100 char limit");
 
         PyLintAnalysis pyLintAnalysis = new PyLintAnalysis(null, document, null, new NullProgressMonitor(),
                 null);
 
-        String output = "************* Module snippet\n" +
-                "C: 14, 0: (bad-whitespace) Exactly one space required around assignment\n" +
-                "            encoded=encoded + letters[x]\n" +
-                "\n" +
-                "                   ^\n" +
-                "C: 22, 0: (missing-final-newline) Final newline missing\n" +
-                "C: 22, 0: (superfluous-parens) Unnecessary parens after 'print' keyword\n" +
-                "C:  1, 0: (missing-docstring) Missing module docstring\n" +
-                "C:  3, 0: (invalid-name) Constant name \"shift\" doesn't conform to UPPER_CASE naming style\n" +
-                "C:  4, 0: (invalid-name) Constant name \"choice\" doesn't conform to UPPER_CASE naming style\n" +
-                "C:  5, 0: (invalid-name) Constant name \"word\" doesn't conform to UPPER_CASE naming style\n" +
-                "C:  6, 0: (invalid-name) Constant name \"letters\" doesn't conform to UPPER_CASE naming style\n" +
-                "C:  7, 0: (invalid-name) Constant name \"encoded\" doesn't conform to UPPER_CASE naming style\n" +
-                "\n" +
-                "------------------------------------------------------------------\n" +
-                "\n" +
-                "Your code has been rated at 5.26/10 (previous run: 5.26/10, +0.00)\n";
+        String output = "PyLint: The stdout of the command line is:\n"
+                + " ************* Module snippet\n"
+                + "C: 23, 0: (line-too-long) Line too long (106/100)\n"
+                + "C: 23, 0: (missing-final-newline) Final newline missing\n"
+                + "C:  1, 0: (missing-module-docstring) Missing module docstring\n"
+                + "C:  3, 0: (invalid-name) Constant name \"shift\" doesn't conform to UPPER_CASE naming style\n"
+                + "C:  7, 0: (invalid-name) Constant name \"encoded\" doesn't conform to UPPER_CASE naming style\n"
+                + "C: 11,12: (invalid-name) Constant name \"encoded\" doesn't conform to UPPER_CASE naming style\n"
+                + "\n"
+                + "------------------------------------------------------------------\n"
+                + "\n"
+                + "Your code has been rated at 7.00/10 (previous run: 5.26/10, +0.00)\n";
 
         PydevPrefs.getEclipsePreferences().putInt(PyLintPreferences.SEVERITY_WARNINGS, IMarker.SEVERITY_ERROR);
         PydevPrefs.getEclipsePreferences().putInt(PyLintPreferences.SEVERITY_CODING_STANDARD, IMarker.SEVERITY_ERROR);

--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/pylint/PyLintAnalysisTest.java
@@ -59,6 +59,12 @@ public class PyLintAnalysisTest extends TestCase {
 
         String output = "PyLint: The stdout of the command line is:\n"
                 + " ************* Module snippet\n"
+                + "C: 14,19: (bad-whitespace) Exactly one space required around assignment\n"
+                + "            encoded=encoded + letters[x]\n"
+                + "\n"
+                + "                   ^\n"
+                + "C: 17,25: (trailing-whitespace) Trailing whitespace\n"
+                + "W: 22, 0: (unnecessary-semicolon) Unnecessary semicolon\n"
                 + "C: 23, 0: (line-too-long) Line too long (106/100)\n"
                 + "C: 23, 0: (missing-final-newline) Final newline missing\n"
                 + "C:  1, 0: (missing-module-docstring) Missing module docstring\n"
@@ -68,7 +74,7 @@ public class PyLintAnalysisTest extends TestCase {
                 + "\n"
                 + "------------------------------------------------------------------\n"
                 + "\n"
-                + "Your code has been rated at 7.00/10 (previous run: 5.26/10, +0.00)\n";
+                + "Your code has been rated at 5.50/10 (previous run: 5.26/10, +0.00)\n";
 
         PydevPrefs.getEclipsePreferences().putInt(PyLintPreferences.SEVERITY_WARNINGS, IMarker.SEVERITY_ERROR);
         PydevPrefs.getEclipsePreferences().putInt(PyLintPreferences.SEVERITY_CODING_STANDARD, IMarker.SEVERITY_ERROR);
@@ -81,16 +87,19 @@ public class PyLintAnalysisTest extends TestCase {
             assertEquals(marker.lineStart, marker.lineEnd);
         }
 
-        assertMarkerEquals(22, "line-too-long", "Line too long (106/100)", markers.get(0));
-        assertMarkerEquals(22, "missing-final-newline", "Final newline missing", markers.get(1));
-        assertMarkerEquals(0, "missing-module-docstring", "Missing module docstring", markers.get(2));
+        assertMarkerEquals(13, "bad-whitespace", "Exactly one space required around assignment", markers.get(0));
+        assertMarkerEquals(16, "trailing-whitespace", "Trailing whitespace", markers.get(1));
+        assertMarkerEquals(21, "unnecessary-semicolon", "Unnecessary semicolon", markers.get(2));
+        assertMarkerEquals(22, "line-too-long", "Line too long (106/100)", markers.get(3));
+        assertMarkerEquals(22, "missing-final-newline", "Final newline missing", markers.get(4));
+        assertMarkerEquals(0, "missing-module-docstring", "Missing module docstring", markers.get(5));
         assertMarkerEquals(2, "invalid-name", "Constant name \"shift\" doesn't conform to UPPER_CASE naming style",
-                markers.get(3));
+                markers.get(6));
         assertMarkerEquals(6, "invalid-name", "Constant name \"encoded\" doesn't conform to UPPER_CASE naming style",
-                markers.get(4));
+                markers.get(7));
         assertMarkerEquals(10, "invalid-name", "Constant name \"encoded\" doesn't conform to UPPER_CASE naming style",
-                markers.get(5));
-        assertEquals(6, markers.size());
+                markers.get(8));
+        assertEquals(9, markers.size());
     }
 
     private void assertMarkerEquals(int line, String message_id, String message, MarkerInfo actualMarker) {


### PR DESCRIPTION
https://www.brainwy.com/tracker/PyDev/1107

When pylint message contains round brackets, it incorrectly parses output and shows in problems view as "PyLint:" intead of "PyLint: Line too long (106/100)"

#Hacktoberfest (please add label hacktoberfest-accepted to this PR)