### PR TITLE
Black pyi files

### DIFF
--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatBlackTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatBlackTest.java
@@ -1,0 +1,110 @@
+package org.python.pydev.editor.actions;
+
+import org.eclipse.jface.text.Document;
+import org.python.pydev.ast.formatter.PyFormatter;
+import org.python.pydev.core.docutils.SyntaxErrorException;
+import org.python.pydev.core.formatter.FormatStd;
+import org.python.pydev.core.formatter.FormatStd.FormatterEnum;
+import org.python.pydev.shared_core.resource_stubs.AbstractIFileStub;
+
+import junit.framework.TestCase;
+
+public class PyFormatBlackTest extends TestCase {
+    private final class MockIFile extends AbstractIFileStub {
+        private final String ext;
+
+        private MockIFile(String ext) {
+            this.ext = ext;
+        }
+
+        @Override
+        public String getFileExtension() {
+            return ext;
+        }
+    }
+
+    static final String SRC = "from typing import (\n"
+            + " Union, Dict\n"
+            + "  )\n"
+            + "def a()->None: \n"
+            + " ...\n"
+            + "def b(_:Union[Dict[str,str],str])->int: \n"
+            + " ...\n"
+            + "d = [1, 2, 3]";
+
+    private static boolean DEBUG = false;
+
+    public static void main(String[] args) {
+        try {
+            PyFormatBlackTest n = new PyFormatBlackTest();
+            junit.textui.TestRunner.run(PyFormatBlackTest.class);
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
+    }
+
+    private FormatStd black;
+
+    private void checkFormat(String ext, String expected) {
+        try {
+            Document doc = new Document(SRC);
+            PyFormatter.formatAll(doc, new MockPyEdit(new MockIFile(ext)), true, black, false, true);
+            String formattedStr = doc.get();
+
+            assertEquals(expected, formattedStr);
+        } catch (SyntaxErrorException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * @see junit.framework.TestCase#setUp()
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        black = new FormatStd();
+        black.formatterStyle = FormatterEnum.BLACK;
+        black.searchBlackInInterpreter = false;
+
+        //TODO: get black location from config?
+        black.blackExecutableLocation = System.getenv("LOCALAPPDATA")
+                + "\\Programs\\Python\\Python37\\Scripts\\black.exe";
+
+        System.out.println(black);
+    }
+
+    /**
+     * Check that py file is formatted using Black's standard format
+     * @throws Exception
+     */
+    public void testPyFormat() throws Exception {
+        checkFormat("py", "from typing import Union, Dict\n"
+                + "\n"
+                + "\n"
+                + "def a() -> None:\n"
+                + "    ...\n"
+                + "\n"
+                + "\n"
+                + "def b(_: Union[Dict[str, str], str]) -> int:\n"
+                + "    ...\n"
+                + "\n"
+                + "\n"
+                + "d = [1, 2, 3]\n");
+    }
+
+    /**
+     * Check that pyi (python stub) file is formatted using Black's more compact format
+     * @throws Exception
+     */
+    public void testPyiFormat() throws Exception {
+        checkFormat("py", "from typing import Union, Dict\n"
+                + "\n"
+                + "def a() -> None: ...\n"
+                + "def b(_: Union[Dict[str, str], str]) -> int: ...\n"
+                + "\n"
+                + "d = [1, 2, 3]\n");
+    }
+
+}

--- a/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatStdTest.java
+++ b/plugins/org.python.pydev/tests/org/python/pydev/editor/actions/PyFormatStdTest.java
@@ -1070,7 +1070,8 @@ public class PyFormatStdTest extends TestCase {
             formatStr = doc.get();
             assertEquals(expected, formatStr);
 
-            formatStr = PyFormatter.formatStrAutopep8OrPyDev(null, new Document(s2), std, "\r", false, true, null);
+            formatStr = PyFormatter.formatStrAutopep8OrPyDev(null, new Document(s2), null, std, "\r", false, true,
+                    null);
             if (expected2.endsWith("\r") && !formatStr.endsWith("\r")) {
                 expected2 = expected2.substring(0, expected2.length() - 1);
             }
@@ -1080,7 +1081,8 @@ public class PyFormatStdTest extends TestCase {
             String s3 = StringUtils.replaceAll(s, "\n", "\r\n");
             String expected3 = StringUtils.replaceAll(expected, "\n", "\r\n");
 
-            formatStr = PyFormatter.formatStrAutopep8OrPyDev(null, new Document(s3), std, "\r\n", false, true, null);
+            formatStr = PyFormatter.formatStrAutopep8OrPyDev(null, new Document(s3), null, std, "\r\n", false, true,
+                    null);
             if (expected3.endsWith("\r\n") && !formatStr.endsWith("\r\n")) {
                 expected3 = expected3.substring(0, expected3.length() - 2);
             }


### PR DESCRIPTION
Black usually formats pyi files (stubs) differently to how it formats py files. However, due to the way Pydev calls Black, it currently treats both file formats the same.

Update to pass the --pyi switch to Black when formatting a pyi file.

#Hacktoberfest