### PR TITLE
Fix for #Pydev 1125: Undefined variable in return type annotations for classes "in construction" even when annotations are imported from __future__

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AbstractScopeAnalyzerVisitor.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/scopeanalysis/AbstractScopeAnalyzerVisitor.java
@@ -333,7 +333,7 @@ public abstract class AbstractScopeAnalyzerVisitor extends VisitorBase {
                 //found match in names to ignore...
 
                 if (finishClassScope && scope.getCurrScopeId() < single.scopeFound.getScopeId()
-                        && (foundScopeType == Scope.SCOPE_TYPE_CLASS ||
+                        && (!futureAnnotationsImported && foundScopeType == Scope.SCOPE_TYPE_CLASS ||
                                 (!futureAnnotationsImported && foundScopeType == Scope.SCOPE_TYPE_ANNOTATION))) {
                     it.remove();
                     onAddUndefinedMessage(tok, found);

--- a/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/OccurrencesAnalyzerPy38Test.java
+++ b/plugins/org.python.pydev/tests_analysis/com/python/pydev/analysis/OccurrencesAnalyzerPy38Test.java
@@ -99,4 +99,23 @@ public class OccurrencesAnalyzerPy38Test extends AnalysisTestsBase {
         checkNoError();
     }
 
+    public void testClassSelfReferenceWithFutureImported() throws Exception {
+        doc = new Document("from __future__ import annotations\n" +
+                "\n" +
+                "class A():\n" +
+                "\n" +
+                "    def b(self) -> A:\n" +
+                "        return self");
+        checkNoError();
+    }
+
+    public void testClassSelfReferenceWithoutFutureImported() throws Exception {
+        doc = new Document("" +
+                "class A():\n" +
+                "\n" +
+                "    def b(self) -> A:\n" +
+                "        return self");
+        checkError("Undefined variable: A");
+    }
+
 }


### PR DESCRIPTION
I ran all the tests and all seems to work fine ;)