### PR TITLE
Fix for #Pydev 1134: 'self' is being added on cases where it shouldn't be added

### DIFF
--- a/plugins/org.python.pydev/tests_completions/org/python/pydev/ast/codecompletion/PythonCompletionWithBuiltinsTest.java
+++ b/plugins/org.python.pydev/tests_completions/org/python/pydev/ast/codecompletion/PythonCompletionWithBuiltinsTest.java
@@ -679,4 +679,16 @@ public class PythonCompletionWithBuiltinsTest extends CodeCompletionTestsBase {
                 "Color.Black.";
         requestCompl(s, s.length(), -1, new String[] { "name", "value" });
     }
+
+    public void testMethodCompletion() throws Exception {
+        String s;
+        s = "" +
+                "def main():\n"
+                + "    import zipfile\n"
+                + "    z = zipfile.ZipFile('')\n"
+                + "    for name in z.namelist():\n"
+                + "        print(name)\n"
+                + "        with z.ope";
+        requestCompl(s, s.length(), -1, new String[] { "open(name, mode, pwd)" });
+    }
 }


### PR DESCRIPTION
The issue here is caused by the class tokens being assigned as unbound variables, so when those tokens reach `AbstractPyCodeCompletion.getArgs(String, int, Lookinfor)`, the "self" arg is not properly handled as it should be (as a instatiated class token).