### PR TITLE
remove check for start_new in thread so jython works

### DIFF
--- a/plugins/org.python.pydev.core/pysrc/_pydev_imps/_pydev_saved_modules.py
+++ b/plugins/org.python.pydev.core/pysrc/_pydev_imps/_pydev_saved_modules.py
@@ -94,7 +94,7 @@ with VerifyShadowedImport('code') as verify_shadowed:
 
 if IS_PY2:
     with VerifyShadowedImport('thread') as verify_shadowed:
-        import thread;    verify_shadowed.check(thread, ['start_new_thread', 'start_new', 'allocate_lock'])
+        import thread;    verify_shadowed.check(thread, ['start_new_thread', 'allocate_lock'])
 
     with VerifyShadowedImport('Queue') as verify_shadowed:
         import Queue as _queue;    verify_shadowed.check(_queue, ['Queue', 'LifoQueue', 'Empty', 'Full', 'deque'])


### PR DESCRIPTION
Jython doesn't have start_new in the thread module since it is [obsolete](https://www.jython.org/jython-old-sites/archive/21/docs/differences.html) ("CPython's thread modules defines some aliases that Jython's doesn't. These aliases are considered obsolete and won't be supported by Jython."), so looking for it causes pydev to fail.  I ran into this when using Ghidra. You can see my comments the issue thread [here](https://github.com/NationalSecurityAgency/ghidra/issues/3378#issuecomment-931878167).

I don't know if this is the right fix or not, but I did not see start_new used in this codebase. I do see what looks like a monkey patch to add start_new [here](https://github.com/fabioz/Pydev/blob/cd7bb8c3df5cd3231c2bb4d4954e0314a920afb0/plugins/org.python.pydev.core/pysrc/_pydev_bundle/pydev_monkey.py#L1152).

I'll try to do whatever is needed.