### PR TITLE
Reorder commands for flake8 when binary chosen directly

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/flake8/Flake8Analysis.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/flake8/Flake8Analysis.java
@@ -130,7 +130,7 @@ import com.python.pydev.analysis.external.WriteToStreamHelper;
                 SimpleRunner simpleRunner = new SimpleRunner();
 
                 String flake8Executable = FileUtils.getFileAbsolutePath(flake8Location);
-                cmdList.add(flake8Executable);
+                cmdList.add(0, flake8Executable);
 
                 String[] args = cmdList.toArray(new String[0]);
 


### PR DESCRIPTION
When flake8 location is specified directly, the arguments are before the command rather than after so it does not run