### PR TITLE
pass `--output-format` instead of `--format` to ruff

### DIFF
--- a/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ruff/RuffAnalysis.java
+++ b/plugins/com.python.pydev.analysis/src/com/python/pydev/analysis/ruff/RuffAnalysis.java
@@ -152,8 +152,8 @@ import com.python.pydev.analysis.external.WriteToStreamHelper;
         String userArgs = StringUtils.replaceNewLines(
                 RuffPreferences.getRuffArgs(resource), " ");
         List<String> userArgsAsList = new ArrayList<>(Arrays.asList(ProcessUtils.parseArguments(userArgs)));
-        if (!userArgsAsList.contains("--format=json")) {
-            userArgsAsList.add("--format=json");
+        if (!userArgsAsList.contains("--output-format=json")) {
+            userArgsAsList.add("--output-format=json");
         }
         // run ruff in project location
         IProject project = resource.getProject();
@@ -272,7 +272,7 @@ import com.python.pydev.analysis.external.WriteToStreamHelper;
             jsonValue = JsonValue.readFrom(output);
         } catch (Exception e) {
             Log.log(StringUtils.format(
-                    "Expected ruff output to be with json format. i.e.: --format=json.\nFile: %s\nOutput:\n%s",
+                    "Expected ruff output to be with json format. i.e.: --output-format=json.\nFile: %s\nOutput:\n%s",
                     resource.getFullPath(), output), e);
             return;
         }


### PR DESCRIPTION
since [version 0.0.291](https://github.com/astral-sh/ruff/releases/tag/v0.0.291) ruff executable has replaced `--format` with `--output-format`. And in ruff `0.1.0` the only supported parameter is the new one