### PR TITLE
Check if offset is valid before using it

### DIFF
--- a/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
+++ b/plugins/org.python.pydev/src/org/python/pydev/editor/PyInformationPresenter.java
@@ -202,11 +202,10 @@ public class PyInformationPresenter extends AbstractInformationPresenter {
 
                 @Override
                 public void mouseDown(MouseEvent e) {
-                    int offset;
-                    try {
-                        offset = styledText.getOffsetAtPoint(new Point(e.x, e.y));
-                    } catch (IllegalArgumentException e1) {
-                        return; //invalid location
+                    int offset = styledText.getOffsetAtPoint(new Point(e.x, e.y));
+                    if (offset == -1) {
+                        // invalid location
+                        return;
                     }
                     StyleRange r = styledText.getStyleRangeAtOffset(offset);
                     if (r instanceof PyStyleRange) {


### PR DESCRIPTION
The offset might be invalid when a user clicks on a location which is after the last character of a line.
The existing check no longer works, because `getOffsetAtPoint` only throws an `IllegalArgumentException` when the given Point is `null`.