### PR TITLE
Enable proper termination of ProcessServer

### DIFF
--- a/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServer.java
+++ b/plugins/com.python.pydev.debug/src/com/python/pydev/debug/model/ProcessServer.java
@@ -29,6 +29,7 @@ public class ProcessServer extends Process {
     private PipedInputStream errorStream;
     private OutputStream outputStream;
     private Object lock;
+    private boolean exited = false;
 
     public ProcessServer() {
         super();
@@ -73,6 +74,9 @@ public class ProcessServer extends Process {
 
     @Override
     public int exitValue() {
+        if (exited) {
+            return 0;
+        }
         throw new IllegalThreadStateException();
     }
 
@@ -111,6 +115,8 @@ public class ProcessServer extends Process {
         } catch (Exception e) {
             Log.log(e);
         }
+
+        exited = true;
     }
 
     /**


### PR DESCRIPTION
It's currently not possible to stop the Debug Server, because the underlying ProcessServer does not support proper termination.

The following code is used to shutdown the process:
https://github.com/eclipse-platform/eclipse.platform/blob/ebe8db5d9d1c7d231be261d9fd5207dfc94ca9a0/debug/org.eclipse.debug.core/core/org/eclipse/debug/core/model/RuntimeProcess.java#L243-L293

The call to `waitFor(...)` queries the exit value of the process, which always throws an `IllegalThreadStateException`, indicating that the process is still running, and thus leading to a timeout. I changed the implementation, such that `exitValue()` returns  zero, if the process has been terminated.

The easiest way to reproduce this is to start/stop the debug server via the Pydev menu. When stopping the server, the UI will freeze until the timeout occurs