### PR TITLE
repairs ModuleNotFoundError mysite.settings when rightClick 'Shell with Django environment'

### DIFF
--- a/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleConstants.java
+++ b/plugins/org.python.pydev.debug/src_console/org/python/pydev/debug/newconsole/PydevConsoleConstants.java
@@ -55,7 +55,7 @@ public final class PydevConsoleConstants {
     public static final String DEFAULT_INITIAL_INTERPRETER_CMDS = "import sys; print('%s %s' % (sys.executable or sys.platform, sys.version))\n";
 
     public static final String DJANGO_INTERPRETER_CMDS = "DJANGO_INTERPRETER_CMDS";
-    public static final String DEFAULT_DJANGO_INTERPRETER_CMDS = "import os; os.environ['DJANGO_SETTINGS_MODULE'] = '${DJANGO_SETTINGS_MODULE}'; import django\nif django.VERSION <= (1, 5):\n\tfrom django.core import management\n\timport ${DJANGO_SETTINGS_MODULE} as settings\n\tmanagement.setup_environ(settings)\nelse:\n\tfrom django.core.wsgi import get_wsgi_application\n\tapplication = get_wsgi_application()\n";
+    public static final String DEFAULT_DJANGO_INTERPRETER_CMDS = "import os; os.environ['DJANGO_SETTINGS_MODULE'] = '${DJANGO_SETTINGS_MODULE}'; import django\n\nfrom django.conf import settings; settings.configure() # https://stackoverflow.com/a/22515135\n\nif django.VERSION <= (1, 5):\n\tfrom django.core import management\n\timport ${DJANGO_SETTINGS_MODULE} as settings\n\tmanagement.setup_environ(settings)\nelse:\n\tfrom django.core.wsgi import get_wsgi_application\n\tapplication = get_wsgi_application()\n";
 
     public static final String INTERACTIVE_CONSOLE_MAXIMUM_CONNECTION_ATTEMPTS = "INTERACTIVE_CONSOLE_MAXIMUM_CONNECTION_ATTEMPTS";
     public static final int DEFAULT_INTERACTIVE_CONSOLE_MAXIMUM_CONNECTION_ATTEMPTS = 50;


### PR DESCRIPTION
This helped me to make the error below go away. The fix was suggested here:  https://stackoverflow.com/a/22515135

The error before was:

```
Traceback (most recent call last):

  File "<input>", line 7, in <module>
  File "[myPath]\_ENVS\mysite\lib\site-packages\django\core\wsgi.py", line 12, in get_wsgi_application
    django.setup(set_prefix=False)
  File "[myPath]\_ENVS\mysite\lib\site-packages\django\__init__.py", line 19, in setup
    configure_logging(settings.LOGGING_CONFIG, settings.LOGGING)
  File "[myPath]\_ENVS\mysite\lib\site-packages\django\conf\__init__.py", line 81, in __getattr__
    self._setup(name)
  File "[myPath]\_ENVS\mysite\lib\site-packages\django\conf\__init__.py", line 68, in _setup
    self._wrapped = Settings(settings_module)
  File "[myPath]\_ENVS\mysite\lib\site-packages\django\conf\__init__.py", line 166, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
	
  File "C:\Program Files\WindowsApps\PythonSoftwareFoundation.Python.3.10_3.10.3056.0_x64__qbz5n2kfra8p0\lib\importlib\__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
	
  File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1004, in _find_and_load_unlocked
  
ModuleNotFoundError: No module named 'mysite.settings'
```

When using the right click shortcut:

    Liclipse ... mysite ... rightMouseClick  ... Django ... Shell with Django environment

Versions   LiClipse	11.1.0.202405280850	and:

    django-admin --version
    5.1.2



Thanks! Keep up the good work!

