### PR TITLE
Resolve type hints on keyword-only parameters

### DIFF
--- a/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/NodeUtils.java
+++ b/plugins/org.python.pydev.parser/src/org/python/pydev/parser/visitors/NodeUtils.java
@@ -1511,28 +1511,65 @@ public final class NodeUtils {
             if (args == null) {
                 return null;
             }
-            exprType[] annotation = args.annotation;
-            if (annotation == null) {
-                return null;
+            // Positional parameters: args.args[i] is annotated by args.annotation[i].
+            exprType found = getAnnotationForParameter(actTok, args.args, args.annotation);
+            if (found != null) {
+                return found;
             }
-            exprType[] args2 = args.args;
-            if (args2 == null) {
-                return null;
+            // Keyword-only parameters (declared after a bare '*' or '*args'):
+            // args.kwonlyargs[i] is annotated by args.kwonlyargannotation[i].
+            found = getAnnotationForParameter(actTok, args.kwonlyargs, args.kwonlyargannotation);
+            if (found != null) {
+                return found;
             }
-            for (int i = 0; i < args2.length; i++) {
-                exprType argI = args2[i];
-                if (argI != null) {
-                    String rep = NodeUtils.getRepresentationString(argI);
-                    if (actTok.equals(rep)) {
-                        if (annotation.length > i) {
-                            exprType exprType = annotation[i];
-                            if (exprType != null) {
-                                return exprType;
-                            }
-                        }
+            // The '*args' and '**kwargs' parameters carry a single annotation slot each.
+            found = getAnnotationForVararg(actTok, args.vararg, args.varargannotation);
+            if (found != null) {
+                return found;
+            }
+            found = getAnnotationForVararg(actTok, args.kwarg, args.kwargannotation);
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the annotation for the parameter named <code>actTok</code> in a pair of parallel
+     * arrays (parameter names and their annotations), as used for positional and keyword-only
+     * parameters in {@link argumentsType}.
+     */
+    private static exprType getAnnotationForParameter(String actTok, exprType[] params,
+            exprType[] annotations) {
+        if (params == null || annotations == null) {
+            return null;
+        }
+        for (int i = 0; i < params.length; i++) {
+            exprType param = params[i];
+            if (param != null && actTok.equals(NodeUtils.getRepresentationString(param))) {
+                if (annotations.length > i) {
+                    exprType annotation = annotations[i];
+                    if (annotation != null) {
+                        return annotation;
                     }
                 }
             }
+        }
+        return null;
+    }
+
+    /**
+     * Finds the annotation for a '*args'/'**kwargs' parameter, which carries a single name and a
+     * single annotation slot in {@link argumentsType}.
+     */
+    private static exprType getAnnotationForVararg(String actTok, NameTokType param,
+            exprType annotation) {
+        if (param == null || annotation == null) {
+            return null;
+        }
+        if (actTok.equals(NodeUtils.getRepresentationString(param))) {
+            return annotation;
         }
         return null;
     }

--- a/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/NodeUtilsTest.java
+++ b/plugins/org.python.pydev.parser/tests/org/python/pydev/parser/visitors/NodeUtilsTest.java
@@ -9,6 +9,7 @@ package org.python.pydev.parser.visitors;
 import java.util.Iterator;
 import java.util.List;
 
+import org.python.pydev.core.IPythonNature;
 import org.python.pydev.parser.PyParserTestBase;
 import org.python.pydev.parser.jython.SimpleNode;
 import org.python.pydev.parser.jython.ast.Assign;
@@ -210,6 +211,37 @@ public class NodeUtilsTest extends PyParserTestBase {
         List<ASTEntry> classes = visitor.getClassesAndMethodsList();
         assertEquals(1, classes.size());
         assertEquals(endLine, classes.get(0).endLine);
+    }
+
+    private FunctionDef parseSingleFunctionDef(String src) {
+        setDefaultVersion(IPythonNature.GRAMMAR_PYTHON_VERSION_3_6);
+        Module module = (Module) parseLegalDocStr(src);
+        return (FunctionDef) module.body[0];
+    }
+
+    public void testGetTypeForPositionalParameter() throws Exception {
+        FunctionDef funcDef = parseSingleFunctionDef("def f(x: int):\n    return x\n");
+        assertEquals("int", NodeUtils.getTypeForParameterFromAST("x", funcDef).getActTok());
+    }
+
+    public void testGetTypeForKeywordOnlyParameter() throws Exception {
+        // Keyword-only parameters live in kwonlyargs/kwonlyargannotation, not args/annotation.
+        FunctionDef funcDef = parseSingleFunctionDef("def f(x, *, y: int):\n    return y\n");
+        assertEquals("int", NodeUtils.getTypeForParameterFromAST("y", funcDef).getActTok());
+    }
+
+    public void testGetTypeForKeywordOnlyParameterWithoutPositionalAnnotation() throws Exception {
+        // No positional parameter is annotated, so args.annotation is empty; the keyword-only
+        // annotation must still be found.
+        FunctionDef funcDef = parseSingleFunctionDef("def f(x, *, y: str):\n    return y\n");
+        assertEquals("str", NodeUtils.getTypeForParameterFromAST("y", funcDef).getActTok());
+        assertNull(NodeUtils.getTypeForParameterFromAST("x", funcDef));
+    }
+
+    public void testGetTypeForVarargAndKwargParameters() throws Exception {
+        FunctionDef funcDef = parseSingleFunctionDef("def f(*args: int, **kwargs: str):\n    pass\n");
+        assertEquals("int", NodeUtils.getTypeForParameterFromAST("args", funcDef).getActTok());
+        assertEquals("str", NodeUtils.getTypeForParameterFromAST("kwargs", funcDef).getActTok());
     }
 
     public void testFindStmtForNode() throws Exception {


### PR DESCRIPTION
## Summary

`NodeUtils.getTypeForParameterFromStaticTyping` resolves a parameter's type hint by scanning only the positional argument arrays (`args.args` and `args.annotation`). Keyword-only parameters (declared after a bare `*`) live in the sibling arrays `kwonlyargs` and `kwonlyargannotation`, which the method never inspects. As a result, a type hint on a keyword-only parameter is invisible to `getTypeForParameterFromAST`, which returns `null` even though the parser populates the keyword-only arrays correctly.

## Reproducer

```python
def f(x, *, y: int):
    return y
```

Parsing at any Py3 grammar yields `args.kwonlyargs.length == 1` and `args.kwonlyargannotation.length == 1`, so the annotation is present in the AST. But `getTypeForParameterFromAST("y", funcDef)` returns `null`. The same query for a positional parameter (`def f(x: int)`) returns the annotation as expected.

## Changes

- Factor the name-match-then-index lookup into a helper and apply it to the keyword-only arrays in addition to the positional ones.
- Also resolve the single annotation slots for `*args` and `**kwargs` (`varargannotation`/`kwargannotation`).
- Drop the previous early `return null` when `args.annotation` was null, so keyword-only hints are still found when no positional parameter is annotated.
- Add regression tests to `NodeUtilsTest` covering positional, keyword-only (with and without a positional annotation present), and vararg/kwarg annotations.

## Testing

Ran the updated `NodeUtilsTest`: all tests pass with the fix; the three new keyword-only/vararg tests fail against the pre-fix code (negative control confirms they exercise the bug).

Originally reported at https://github.com/ponder-lab/Pydev/issues/11

🤖 Generated with [Claude Code](https://claude.com/claude-code)
